### PR TITLE
fix: PR #50 mobile follow-ups (gap doc, OpenAPI repair, server-side CTA gating)

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -2,8 +2,14 @@
 openapi: 3.1.0
 info:
   title: Hali API
-  version: 0.3.0
+  version: 0.4.0
   summary: Civic signal and official update API for the Hali MVP
+  description: |
+    Spec repaired against the C# backend source in `src/Hali.Api/Controllers/*`
+    and `src/Hali.Contracts/**/*Dto.cs`. JSON convention:
+      - Property names: camelCase (System.Text.Json `JsonNamingPolicy.CamelCase`)
+      - Enum values: snake_case_lower (`JsonStringEnumConverter` with
+        `JsonNamingPolicy.SnakeCaseLower`)
 servers:
   - url: http://localhost:8080
 tags:
@@ -29,16 +35,29 @@ paths:
           application/json:
             schema:
               type: object
-              required: [authMethod, destination]
+              required: [destination, authMethod]
               properties:
+                destination: { type: string }
                 authMethod:
                   type: string
-                  enum: [phone_otp, email_otp, magic_link]
-                  description: Accepts snake_case; backend normalises to PascalCase AuthMethod enum
-                destination: { type: string }
+                  enum: [phone_otp, email_otp, magic_link, google, apple]
+                  description: |
+                    Serialised from `Hali.Domain.Enums.AuthMethod` via
+                    snake_case_lower converter. Phase 1 only uses `phone_otp`.
       responses:
         '200':
           description: OTP sent
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message: { type: string, example: "OTP sent" }
+        '429':
+          description: OTP rate limited
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/auth/verify:
     post:
       tags: [Auth]
@@ -66,6 +85,9 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
         '400':
           description: Invalid or expired OTP
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/auth/refresh:
     post:
       tags: [Auth]
@@ -88,6 +110,9 @@ paths:
                 $ref: '#/components/schemas/TokenResponse'
         '401':
           description: Invalid or expired refresh token
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/auth/logout:
     post:
       tags: [Auth]
@@ -124,7 +149,16 @@ paths:
                 phoneNumber: { type: string }
       responses:
         '202': { description: OTP sent to phone }
-        '400': { description: Invalid, expired, or already-accepted invite }
+        '400':
+          description: Invalid, expired, or already-accepted invite
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: OTP rate limited
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Localities ──────────────────────────────────────────────────────
   /v1/localities/followed:
@@ -134,7 +168,23 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        '200': { description: OK }
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                required: [localityIds]
+                properties:
+                  localityIds:
+                    type: array
+                    items: { type: string, format: uuid }
+                    description: |
+                      Followed locality UUIDs only. The wire shape does NOT
+                      currently include locality names (ward_name, etc.). See
+                      docs/arch/pr50-followup-gaps.md for the planned extension.
+        '401':
+          description: Unauthenticated
     put:
       tags: [Localities]
       summary: Set followed wards (max 5)
@@ -153,19 +203,24 @@ paths:
                   items: { type: string, format: uuid }
                   maxItems: 5
       responses:
-        '200': { description: Updated }
-        '422': { description: max_followed_localities_exceeded }
+        '204': { description: Updated }
+        '422':
+          description: max_followed_localities_exceeded
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Signals ─────────────────────────────────────────────────────────
   /v1/signals/preview:
     post:
       tags: [Signals]
-      summary: NLP-first preview — extracts candidate structured civic signals
+      summary: NLP-first preview — extracts a structured civic signal candidate
       description: |
-        Returns candidates[] (structured extractions from free text) and
-        existingClusterCandidates[] (nearby clusters the signal could join).
-      security:
-        - bearerAuth: []
+        Returns a single structured extraction from free text, including the
+        canonical category/subcategory and a resolved location object. Anonymous
+        callers are rate-limited to 10 requests per IP per 10 minutes (Redis-
+        backed).
+      security: []
       requestBody:
         required: true
         content:
@@ -174,11 +229,31 @@ paths:
               $ref: '#/components/schemas/SignalPreviewRequest'
       responses:
         '200':
-          description: Preview result with candidate clusters to join
+          description: Preview result
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/SignalPreviewResponse'
+        '400':
+          description: free_text is required
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: NLP returned an unrecognised category
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: Rate limited (anonymous IP cap)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '502':
+          description: NLP extraction service unavailable
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/signals/submit:
     post:
       tags: [Signals]
@@ -192,21 +267,56 @@ paths:
             schema:
               $ref: '#/components/schemas/SignalSubmitRequest'
       responses:
-        '201':
+        '200':
           description: Submitted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SignalSubmitResponse'
+        '400':
+          description: idempotency_key or device_hash missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '409':
+          description: Signal already submitted with this idempotency key
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: Invalid category
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: Too many signals submitted
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Clusters ────────────────────────────────────────────────────────
   /v1/clusters/{id}:
     get:
       tags: [Clusters]
       summary: Get cluster detail with official updates side by side
+      security: []
       parameters:
         - in: path
           name: id
           required: true
           schema: { type: string, format: uuid }
       responses:
-        '200': { description: OK }
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClusterResponse'
+        '404':
+          description: Cluster not found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/clusters/{id}/participation:
     post:
       tags: [Participation]
@@ -225,7 +335,17 @@ paths:
             schema:
               $ref: '#/components/schemas/ParticipationRequest'
       responses:
-        '202': { description: Accepted }
+        '204': { description: Recorded }
+        '400':
+          description: device_hash or type missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: invalid_participation_type or device_not_found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/clusters/{id}/context:
     post:
       tags: [Participation]
@@ -242,16 +362,25 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                contextText: { type: string, maxLength: 150 }
+              $ref: '#/components/schemas/ContextRequest'
       responses:
-        '202': { description: Accepted }
-        '422': { description: context_requires_affected_participation or context_edit_window_expired }
+        '204': { description: Recorded }
+        '400':
+          description: device_hash or text missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: |
+            One of: device_not_found, context_requires_affected_participation,
+            context_edit_window_expired
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/clusters/{id}/restoration-response:
     post:
       tags: [Participation]
-      summary: Cast a restoration vote (yes/no/unsure)
+      summary: Cast a restoration vote (still_affected / restored / not_sure)
       security:
         - bearerAuth: []
       parameters:
@@ -264,14 +393,19 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              required: [type]
-              properties:
-                type:
-                  type: string
-                  enum: [restoration_yes, restoration_no, restoration_unsure]
+              $ref: '#/components/schemas/RestorationResponseRequest'
       responses:
-        '202': { description: Accepted }
+        '204': { description: Recorded }
+        '400':
+          description: device_hash missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: invalid_restoration_response or device_not_found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Official Posts ──────────────────────────────────────────────────
   /v1/official-posts:
@@ -287,8 +421,27 @@ paths:
             schema:
               $ref: '#/components/schemas/OfficialPostCreateRequest'
       responses:
-        '201': { description: Created }
-        '403': { description: Outside institution jurisdiction }
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OfficialPostResponse'
+        '400':
+          description: type, category, title, or body missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '403':
+          description: Outside institution jurisdiction (code=outside_jurisdiction)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: invalid_post_type, invalid_category, or institution_required
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Home Feed ───────────────────────────────────────────────────────
   /v1/home:
@@ -298,7 +451,7 @@ paths:
       description: |
         Returns four sections. Without `section` or `cursor`, returns first page of all sections.
         Section limits: active_now=20, official_updates=5, recurring_at_this_time=10, other_active_signals=10.
-        First page (unauthenticated or empty follows) is cached in Redis for 30 seconds.
+        First page (authenticated with non-empty follows) is cached in Redis for 30 seconds.
         Subsequent pages are fetched live (no cache).
       security: []
       parameters:
@@ -324,6 +477,9 @@ paths:
                 $ref: '#/components/schemas/HomeResponse'
         '400':
           description: Unknown section name
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Users ───────────────────────────────────────────────────────────
   /v1/users/me:
@@ -333,7 +489,14 @@ paths:
       security:
         - bearerAuth: []
       responses:
-        '200': { description: OK }
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserMeResponse'
+        '401': { description: Unauthenticated }
+        '404': { description: Account not found }
   /v1/users/me/notification-settings:
     put:
       tags: [Users]
@@ -345,13 +508,10 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                clusterActivated: { type: boolean }
-                restorationPrompt: { type: boolean }
-                clusterResolved: { type: boolean }
+              $ref: '#/components/schemas/NotificationSettings'
       responses:
-        '200': { description: Updated }
+        '204': { description: Updated }
+        '401': { description: Unauthenticated }
 
   # ── Devices ─────────────────────────────────────────────────────────
   /v1/devices/push-token:
@@ -366,12 +526,22 @@ paths:
           application/json:
             schema:
               type: object
-              required: [deviceFingerprintHash, expoPushToken]
+              required: [deviceHash, expoPushToken]
               properties:
-                deviceFingerprintHash: { type: string }
+                deviceHash: { type: string }
                 expoPushToken: { type: string }
       responses:
-        '200': { description: Updated }
+        '204': { description: Updated }
+        '400':
+          description: device_hash or expo_push_token missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '422':
+          description: device_not_found
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Admin ───────────────────────────────────────────────────────────
   /v1/admin/institutions:
@@ -386,13 +556,13 @@ paths:
           application/json:
             schema:
               type: object
-              required: [name]
+              required: [name, jurisdictionLocalityIds]
               properties:
                 name: { type: string }
                 jurisdictionLocalityIds:
                   type: array
                   items: { type: string, format: uuid }
-                contactEmail: { type: string, format: email }
+                contactEmail: { type: string, format: email, nullable: true }
       responses:
         '201':
           description: Institution created with invite link
@@ -400,10 +570,16 @@ paths:
             application/json:
               schema:
                 type: object
+                required: [institutionId, inviteLink, inviteExpiresAt]
                 properties:
                   institutionId: { type: string, format: uuid }
                   inviteLink: { type: string, format: uri }
                   inviteExpiresAt: { type: string, format: date-time }
+        '400':
+          description: name is required
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/admin/institutions/{id}/access:
     delete:
       tags: [Admin]
@@ -416,15 +592,13 @@ paths:
           required: true
           schema: { type: string, format: uuid }
       responses:
-        '200': { description: Access revoked }
-  /v1/admin/orphaned-signals:
-    get:
-      tags: [Admin]
-      summary: View unowned categories and orphaned civic clusters
-      security:
-        - bearerAuth: []
-      responses:
-        '200': { description: OK }
+        '200':
+          description: Access revoked
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Empty object on success.
 
 components:
   securitySchemes:
@@ -439,87 +613,224 @@ components:
           - institution_id (UUID, present only for institution accounts)
           - jti, iat (standard)
   schemas:
+    ErrorResponse:
+      type: object
+      description: |
+        Standard error envelope. Most endpoints return `{ error }`; some 422
+        responses additionally include a stable `code` for programmatic handling.
+      properties:
+        error: { type: string }
+        code: { type: string, nullable: true }
+
     TokenResponse:
       type: object
+      required: [accessToken, refreshToken, expiresIn]
       properties:
         accessToken: { type: string }
         refreshToken: { type: string }
         expiresIn: { type: integer, description: Access token TTL in seconds }
+
+    # ── Signals ──────────────────────────────────────────────────────
     SignalPreviewRequest:
       type: object
-      required: [text, sourceLanguage]
+      required: [freeText]
+      description: |
+        Mirrors `Hali.Contracts.Signals.SignalPreviewRequestDto`. Location
+        signals are passed as flat fields, not a nested object.
       properties:
-        text: { type: string, maxLength: 500 }
-        sourceLanguage: { type: string, example: en }
-        location:
-          type: object
-          properties:
-            latitude: { type: number }
-            longitude: { type: number }
-            userEnteredPlace: { type: string }
-    SignalCandidate:
+        freeText: { type: string, maxLength: 500 }
+        userLatitude: { type: number, nullable: true }
+        userLongitude: { type: number, nullable: true }
+        selectedWard: { type: string, nullable: true }
+        locale: { type: string, nullable: true, example: en }
+        knownCity: { type: string, nullable: true }
+        countryCode: { type: string, nullable: true, example: KE }
+    SignalLocation:
       type: object
+      description: |
+        Mirrors `Hali.Contracts.Signals.SignalLocationDto`. Resolved location
+        descriptors and a confidence score.
+      required: [locationConfidence, locationSource]
+      properties:
+        areaName: { type: string, nullable: true }
+        roadName: { type: string, nullable: true }
+        junctionName: { type: string, nullable: true }
+        landmarkName: { type: string, nullable: true }
+        facilityName: { type: string, nullable: true }
+        locationLabel: { type: string, nullable: true }
+        locationPrecisionType: { type: string, nullable: true }
+        locationConfidence: { type: number, minimum: 0, maximum: 1 }
+        locationSource: { type: string }
+    SignalPreviewResponse:
+      type: object
+      description: |
+        Single extraction result. Mirrors `SignalPreviewResponseDto`. The
+        previously-documented `candidates[]` and `existingClusterCandidates[]`
+        arrays do NOT exist in the backend.
+      required:
+        [category, subcategorySlug, conditionConfidence, location, shouldSuggestJoin]
       properties:
         category: { type: string }
         subcategorySlug: { type: string }
         conditionSlug: { type: string, nullable: true }
-        neutralSummary: { type: string }
-        locationLabel: { type: string }
-        locationConfidence: { type: number, minimum: 0, maximum: 1 }
-        temporalType: { type: string }
-    ExistingClusterCandidate:
-      type: object
-      properties:
-        clusterId: { type: string, format: uuid }
-        summary: { type: string }
-        locationLabel: { type: string }
-        rawConfirmationCount: { type: integer }
-    SignalPreviewResponse:
-      type: object
-      properties:
-        candidates:
-          type: array
-          items: { $ref: '#/components/schemas/SignalCandidate' }
-        existingClusterCandidates:
-          type: array
-          items: { $ref: '#/components/schemas/ExistingClusterCandidate' }
+        conditionConfidence: { type: number, minimum: 0, maximum: 1 }
+        location: { $ref: '#/components/schemas/SignalLocation' }
+        temporalType: { type: string, nullable: true }
+        neutralSummary: { type: string, nullable: true }
+        shouldSuggestJoin: { type: boolean }
     SignalSubmitRequest:
       type: object
-      required: [candidate, deviceFingerprint, idempotencyKey]
+      description: |
+        Mirrors `SignalSubmitRequestDto`. Flat shape — no nested `candidate`
+        wrapper. `joinClusterId` does NOT exist on the backend.
+      required:
+        [idempotencyKey, deviceHash, freeText, category, subcategorySlug,
+         conditionConfidence, locationConfidence, locationSource]
       properties:
-        candidate: { $ref: '#/components/schemas/SignalCandidate' }
-        joinClusterId: { type: string, format: uuid, nullable: true }
-        deviceFingerprint: { type: string }
         idempotencyKey: { type: string }
+        deviceHash: { type: string }
+        freeText: { type: string }
+        category: { type: string }
+        subcategorySlug: { type: string }
+        conditionSlug: { type: string, nullable: true }
+        conditionConfidence: { type: number, minimum: 0, maximum: 1 }
+        latitude: { type: number, nullable: true }
+        longitude: { type: number, nullable: true }
+        locationLabel: { type: string, nullable: true }
+        locationPrecisionType: { type: string, nullable: true }
+        locationConfidence: { type: number, minimum: 0, maximum: 1 }
+        locationSource: { type: string }
+        temporalType: { type: string, nullable: true }
+        neutralSummary: { type: string, nullable: true }
+        sourceLanguage: { type: string, nullable: true }
+        spatialCellId: { type: string, nullable: true }
+    SignalSubmitResponse:
+      type: object
+      required: [signalEventId, createdAt]
+      properties:
+        signalEventId: { type: string, format: uuid }
+        createdAt: { type: string, format: date-time }
+
+    # ── Clusters / Participation ─────────────────────────────────────
+    ClusterResponse:
+      type: object
+      description: |
+        Mirrors `Hali.Contracts.Clusters.ClusterResponseDto`. CIVIS internals
+        (civis_score, wrab, sds, macf, raw_confirmation_count, account_id,
+        device_id) are intentionally NOT present.
+      required:
+        [id, state, category, affectedCount, observingCount, createdAt, updatedAt, officialPosts]
+      properties:
+        id: { type: string, format: uuid }
+        state:
+          type: string
+          enum: [unconfirmed, active, possible_restoration, resolved]
+        category: { type: string }
+        subcategorySlug: { type: string, nullable: true }
+        title: { type: string, nullable: true }
+        summary: { type: string, nullable: true }
+        affectedCount: { type: integer }
+        observingCount: { type: integer }
+        createdAt: { type: string, format: date-time }
+        updatedAt: { type: string, format: date-time }
+        activatedAt: { type: string, format: date-time, nullable: true }
+        possibleRestorationAt: { type: string, format: date-time, nullable: true }
+        resolvedAt: { type: string, format: date-time, nullable: true }
+        officialPosts:
+          type: array
+          items: { $ref: '#/components/schemas/OfficialPostResponse' }
     ParticipationRequest:
       type: object
-      required: [type, idempotencyKey]
+      description: |
+        Mirrors `ParticipationRequestDto`. `type` accepts only the three core
+        participation values. Restoration votes use the dedicated endpoint
+        `POST /v1/clusters/{id}/restoration-response`.
+      required: [type, deviceHash]
       properties:
         type:
           type: string
-          enum: [affected, observing, no_longer_affected, restoration_yes, restoration_no, restoration_unsure]
-        contextText: { type: string, maxLength: 150, nullable: true }
-        idempotencyKey: { type: string }
+          enum: [affected, observing, no_longer_affected]
+        deviceHash: { type: string }
+        idempotencyKey: { type: string, nullable: true }
+    ContextRequest:
+      type: object
+      required: [text, deviceHash]
+      properties:
+        text: { type: string }
+        deviceHash: { type: string }
+    RestorationResponseRequest:
+      type: object
+      description: |
+        Mirrors `RestorationResponseRequestDto`. Field is `response`, not
+        `type`, and the accepted values are domain terms, not `restoration_*`.
+      required: [response, deviceHash]
+      properties:
+        response:
+          type: string
+          enum: [still_affected, restored, not_sure]
+        deviceHash: { type: string }
+
+    # ── Official Posts ───────────────────────────────────────────────
     OfficialPostCreateRequest:
       type: object
-      required: [officialPostType, title, body, scopes]
+      description: |
+        Mirrors `CreateOfficialPostRequestDto`. The geo-scope is passed as
+        the flat fields `localityId` / `corridorName` — there is no `scopes[]`
+        array on the backend.
+      required: [type, category, title, body]
       properties:
-        officialPostType:
+        type:
           type: string
           enum: [live_update, scheduled_disruption, advisory_public_notice]
-        category: { type: string, nullable: true }
+        category: { type: string }
         title: { type: string, maxLength: 220 }
         body: { type: string, maxLength: 5000 }
         startsAt: { type: string, format: date-time, nullable: true }
         endsAt: { type: string, format: date-time, nullable: true }
         relatedClusterId: { type: string, format: uuid, nullable: true }
-        scopes:
-          type: array
-          items:
-            type: object
-            properties:
-              localityId: { type: string, format: uuid, nullable: true }
-              corridorName: { type: string, nullable: true }
+        isRestorationClaim: { type: boolean, default: false }
+        localityId: { type: string, format: uuid, nullable: true }
+        corridorName: { type: string, nullable: true }
+    OfficialPostResponse:
+      type: object
+      required:
+        [id, institutionId, type, category, title, body, status,
+         isRestorationClaim, createdAt]
+      properties:
+        id: { type: string, format: uuid }
+        institutionId: { type: string, format: uuid }
+        type: { type: string }
+        category: { type: string }
+        title: { type: string }
+        body: { type: string }
+        startsAt: { type: string, format: date-time, nullable: true }
+        endsAt: { type: string, format: date-time, nullable: true }
+        status: { type: string }
+        relatedClusterId: { type: string, format: uuid, nullable: true }
+        isRestorationClaim: { type: boolean }
+        createdAt: { type: string, format: date-time }
+
+    # ── Users ────────────────────────────────────────────────────────
+    NotificationSettings:
+      type: object
+      properties:
+        clusterActivated: { type: boolean }
+        restorationPrompt: { type: boolean }
+        clusterResolved: { type: boolean }
+    UserMeResponse:
+      type: object
+      required: [id, status, createdAt, notificationSettings]
+      properties:
+        id: { type: string, format: uuid }
+        displayName: { type: string, nullable: true }
+        phoneE164: { type: string, nullable: true }
+        email: { type: string, nullable: true }
+        status: { type: string }
+        createdAt: { type: string, format: date-time }
+        notificationSettings:
+          $ref: '#/components/schemas/NotificationSettings'
+
+    # ── Home Feed ────────────────────────────────────────────────────
     PagedSection:
       type: object
       description: A paginated section of home feed items

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -372,8 +372,10 @@ paths:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         '422':
           description: |
-            One of: device_not_found, context_requires_affected_participation,
-            context_edit_window_expired
+            One of:
+              - device_not_found
+              - policy_blocked (reason=context_requires_affected_participation)
+              - policy_blocked (reason=context_edit_window_expired)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -402,7 +404,11 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         '422':
-          description: invalid_restoration_response or device_not_found
+          description: |
+            One of:
+              - invalid_restoration_response
+              - device_not_found
+              - policy_blocked (reason=restoration_requires_affected_participation)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -617,10 +623,14 @@ components:
       type: object
       description: |
         Standard error envelope. Most endpoints return `{ error }`; some 422
-        responses additionally include a stable `code` for programmatic handling.
+        responses additionally include a stable `code` for programmatic
+        handling. When `code` is `policy_blocked`, an optional `reason` field
+        carries the specific sub-reason (e.g.
+        `context_edit_window_expired`).
       properties:
         error: { type: string }
         code: { type: string, nullable: true }
+        reason: { type: string, nullable: true }
 
     TokenResponse:
       type: object
@@ -739,6 +749,41 @@ components:
         officialPosts:
           type: array
           items: { $ref: '#/components/schemas/OfficialPostResponse' }
+        myParticipation:
+          oneOf:
+            - $ref: '#/components/schemas/MyParticipation'
+            - type: 'null'
+          description: |
+            Per-caller participation snapshot. Null for unauthenticated callers
+            or callers with no participation row on this cluster. Used by the
+            mobile UI to gate the "Add Further Context" and restoration-response
+            CTAs server-side. The same gating is also enforced at the trust
+            boundary in POST /v1/clusters/{id}/context and
+            POST /v1/clusters/{id}/restoration-response.
+    MyParticipation:
+      type: object
+      description: |
+        Mirrors `Hali.Contracts.Clusters.MyParticipationDto`. Server's verdict
+        on what the calling user may currently do on this cluster.
+      required: [type, createdAt, canAddContext, canRespondToRestoration]
+      properties:
+        type:
+          type: string
+          enum:
+            [affected, observing, no_longer_affected,
+             restoration_yes, restoration_no, restoration_unsure]
+        createdAt: { type: string, format: date-time }
+        canAddContext:
+          type: boolean
+          description: |
+            True iff type=affected AND now is within ContextEditWindowMinutes
+            (default 2) of createdAt. Mobile must gate "Add Further Context"
+            on this flag — local timing alone is not sufficient.
+        canRespondToRestoration:
+          type: boolean
+          description: |
+            True iff type=affected. Mobile must only show the restoration
+            response CTA when this is true.
     ParticipationRequest:
       type: object
       description: |

--- a/apps/citizen-mobile/app/(app)/clusters/[id].tsx
+++ b/apps/citizen-mobile/app/(app)/clusters/[id].tsx
@@ -157,13 +157,19 @@ export default function ClusterDetailScreen(): React.ReactElement {
       setContextSubmitted(true);
     } catch (err) {
       // Server-side window check is the source of truth — surface the
-      // specific error if we somehow submitted late.
+      // specific error if we somehow submitted late. The 422 envelope now
+      // uses code=policy_blocked with a specific reason string; we still
+      // accept the legacy direct codes for forward compatibility.
       if (err instanceof Error) {
         if (/context_edit_window_expired/.test(err.message)) {
           setContextError('The 2-minute context window has closed.');
         } else if (/context_requires_affected/.test(err.message)) {
           setContextError(
             "You need to mark yourself as affected before adding context.",
+          );
+        } else if (/policy_blocked/.test(err.message)) {
+          setContextError(
+            'You can no longer add context to this cluster.',
           );
         } else {
           setContextError(err.message);
@@ -191,9 +197,22 @@ export default function ClusterDetailScreen(): React.ReactElement {
   }
 
   const cluster = clusterQuery.data;
+
+  // Server is the source of truth for both restricted CTAs. The local
+  // `localParticipation` / `windowOpen` state is kept as a UX hint (for the
+  // brief gap between mutation success and refetch) but is NOT sufficient
+  // on its own — see PR #50 follow-up Task 3 + the matching server-side
+  // 422 policy_blocked check in ClustersController.
+  const myP = cluster.myParticipation;
   const isPossibleRestoration = cluster.state === 'possible_restoration';
+  // Restoration response CTA: only when the caller is currently affected.
+  // Without `myParticipation` (unauthenticated or never participated) the
+  // banner is hidden even if the cluster is in possible_restoration.
+  const canShowRestorationBanner =
+    isPossibleRestoration && myP?.type === 'affected';
+  // Add Further Context: server's canAddContext is authoritative.
   const showContextBlock =
-    localParticipation === 'affected' && windowOpen && !contextSubmitted;
+    myP?.canAddContext === true && !contextSubmitted;
 
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
@@ -230,8 +249,10 @@ export default function ClusterDetailScreen(): React.ReactElement {
           observingCount={cluster.observingCount}
         />
 
-        {/* Restoration banner — only when state === possible_restoration */}
-        {isPossibleRestoration && (
+        {/* Restoration banner — gated by myParticipation.type === 'affected'.
+            Server enforces the same rule on POST and returns 422
+            policy_blocked / restoration_requires_affected_participation. */}
+        {canShowRestorationBanner && (
           <RestorationBanner
             onPress={() =>
               router.push(`/(modals)/restoration/${cluster.id}`)

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -111,6 +111,29 @@ export type ClusterState =
   | 'resolved'
   | 'recurring_context';
 
+export type ParticipationType =
+  | 'affected'
+  | 'observing'
+  | 'no_longer_affected'
+  | 'restoration_yes'
+  | 'restoration_no'
+  | 'restoration_unsure';
+
+/**
+ * Per-caller participation snapshot returned by GET /v1/clusters/{id}.
+ * Server is the source of truth for whether the two restricted CTAs may be
+ * shown — the UI MUST gate on these flags rather than on local state.
+ *
+ * Mirrors `Hali.Contracts.Clusters.MyParticipationDto` and is null for
+ * unauthenticated callers or callers with no participation row.
+ */
+export interface MyParticipation {
+  type: ParticipationType;
+  createdAt: string;
+  canAddContext: boolean;
+  canRespondToRestoration: boolean;
+}
+
 export interface ClusterResponse {
   id: string;
   state: ClusterState;
@@ -126,6 +149,7 @@ export interface ClusterResponse {
   possibleRestorationAt: string | null;
   resolvedAt: string | null;
   officialPosts: OfficialPostResponse[];
+  myParticipation: MyParticipation | null;
 }
 
 // ─── Home ─────────────────────────────────────────────────────────────────────

--- a/docs/arch/pr50-followup-gaps.md
+++ b/docs/arch/pr50-followup-gaps.md
@@ -1,0 +1,79 @@
+# PR #50 Follow-up Gaps
+
+Gaps discovered while working `fix/mobile-pr50-followups` (branched off
+`develop@0aabb71`). Items here were deferred because completing them requires
+work outside the scope of a mobile-only fix branch.
+
+---
+
+## Gap 1 — Canonical locality names cannot be rendered in the citizen app
+
+**Status:** Task 1 of the PR #50 follow-ups deferred in full.
+**Symptom:** `apps/citizen-mobile/app/(app)/settings/wards.tsx` renders
+followed wards as raw UUID strings (e.g. `a3f9c012-…`) and the "add ward"
+flow is a UUID `TextInput`, not a name picker.
+
+### Why it cannot be fixed in the mobile app alone
+
+The data exists in the database but is not exposed by any API:
+
+| Layer | State |
+|---|---|
+| `Locality` entity | Has `WardName`, `CityName`, `CountyName`, `WardCode` columns (`src/Hali.Infrastructure/Data/Signals/SignalsDbContext.cs:37-43`). |
+| `IFollowService.GetFollowedAsync` | Returns `Follow` entities (ID pairs only). No locality projection. |
+| `GET /v1/localities/followed` | Returns `{ localityIds: string[] }` only (`src/Hali.Api/Controllers/LocalitiesController.cs:34`). |
+| `GET /v1/localities/{id}` | Does not exist. |
+| `GET /v1/localities?search=` | Does not exist. |
+| `ClusterResponseDto` (home feed) | Does not include locality name (`src/Hali.Api/Controllers/HomeController.cs:230`). No client-side back-fill is possible. |
+| `FollowedLocalitiesResponse` (mobile type) | `{ localityIds: string[] }` — mirrors the wire shape (`apps/citizen-mobile/src/types/api.ts:80`). |
+| `LocalityContext` | Tracks IDs only. |
+
+There is no API path the mobile app can call to learn the name "South B"
+for any locality ID, so no purely-mobile change can render canonical names.
+
+### Required follow-up work (separate PR)
+
+Minimum scope to unblock the mobile fix:
+
+1. **Backend — extend follow read path**
+   - Update `IFollowService.GetFollowedAsync` (or add a sibling method) to
+     return locality projections, not bare `Follow` entities. Join the
+     `Locality` table.
+   - Update `LocalitiesController.GetFollowed` to return
+     `[{ id, wardName, cityName, countyName, wardCode }, ...]`.
+     Decide whether to keep `localityIds` for backwards compatibility or
+     break the shape (this branch would have broken it; safer to add a
+     parallel field).
+   - Update OpenAPI spec for `GET /v1/localities/followed`.
+   - Unit test the join.
+
+2. **Backend — add a name lookup or search endpoint**
+   Needed so the "add ward" UI can show names instead of asking users to
+   paste a UUID. Two options:
+   - `GET /v1/localities/{id}` — single lookup. Simpler, but the picker
+     still needs *some* way to find IDs. Only useful if combined with a
+     known locality list source.
+   - `GET /v1/localities?search=<q>&limit=20` — name search. Required for
+     a real picker. Needs PostgreSQL trigram or `LIKE` index on `ward_name`.
+     Define rate-limit policy and auth requirement.
+
+3. **Mobile — render and pick by name**
+   - Update `FollowedLocalitiesResponse` and `LocalityContext` to carry
+     `{ id, wardName, cityName, countyName }` for each followed entry.
+     Keep ID as the stable key passed to mutations.
+   - Replace the UUID `TextInput` in `wards.tsx` with a search-driven
+     picker against the new search endpoint.
+   - Update the home header pill (`home.tsx`, the only other consumer of
+     `activeLocalityId`) to show the active ward's `wardName`.
+   - Audit any cluster detail / composer surfaces for other UUID leakage
+     once the data plumbing is in place.
+
+### Acceptance criteria for the follow-up PR
+
+- Ward picker shows e.g. "South B" in `wards.tsx` instead of any UUID
+  fragment.
+- Home header pill shows the active ward's canonical name.
+- Adding a ward is a name search, not a UUID paste.
+- `GET /v1/localities/followed` documented in OpenAPI to include the new
+  fields.
+- No raw `account_id` or CIVIS internals introduced by the new responses.

--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -13,6 +13,7 @@ using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Enums;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Hali.Api.Controllers;
 
@@ -21,20 +22,26 @@ namespace Hali.Api.Controllers;
 public class ClustersController : ControllerBase
 {
 	private readonly IParticipationService _participation;
+	private readonly IParticipationRepository _participationRepo;
 	private readonly IClusterRepository _clusters;
 	private readonly IAuthRepository _auth;
 	private readonly IOfficialPostsService _officialPosts;
+	private readonly CivisOptions _civisOptions;
 
 	public ClustersController(
 		IParticipationService participation,
+		IParticipationRepository participationRepo,
 		IClusterRepository clusters,
 		IAuthRepository auth,
-		IOfficialPostsService officialPosts)
+		IOfficialPostsService officialPosts,
+		IOptions<CivisOptions> civisOptions)
 	{
 		_participation = participation;
+		_participationRepo = participationRepo;
 		_clusters = clusters;
 		_auth = auth;
 		_officialPosts = officialPosts;
+		_civisOptions = civisOptions.Value;
 	}
 
 	[HttpGet("{id:guid}")]
@@ -47,6 +54,29 @@ public class ClustersController : ControllerBase
 			return NotFound(new { error = "Cluster not found." });
 		}
 		var officialPosts = await _officialPosts.GetByClusterIdAsync(id, ct);
+
+		// Per-caller participation snapshot — only populated for
+		// authenticated callers. The mobile app gates "Add Further Context"
+		// and the restoration response CTA on these flags.
+		MyParticipationDto? myParticipation = null;
+		if (User.Identity?.IsAuthenticated == true
+			&& Guid.TryParse(User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"), out var callerAccountId))
+		{
+			var current = await _participationRepo.GetMostRecentByAccountAsync(id, callerAccountId, ct);
+			if (current != null)
+			{
+				var typeStr = ToSnakeCase(current.ParticipationType.ToString());
+				var isAffected = current.ParticipationType == ParticipationType.Affected;
+				var withinWindow = isAffected
+					&& DateTime.UtcNow <= current.CreatedAt.AddMinutes(_civisOptions.ContextEditWindowMinutes);
+				myParticipation = new MyParticipationDto(
+					typeStr,
+					current.CreatedAt,
+					CanAddContext: withinWindow,
+					CanRespondToRestoration: isAffected);
+			}
+		}
+
 		var dto = new ClusterResponseDto(
 			cluster.Id,
 			cluster.State.ToString().ToLowerInvariant(),
@@ -62,9 +92,24 @@ public class ClustersController : ControllerBase
 			cluster.PossibleRestorationAt,
 			cluster.ResolvedAt)
 		{
-			OfficialPosts = officialPosts
+			OfficialPosts = officialPosts,
+			MyParticipation = myParticipation,
 		};
 		return Ok(dto);
+	}
+
+	// PascalCase enum name → snake_case_lower, matching the global
+	// JsonStringEnumConverter naming policy used elsewhere in the API.
+	private static string ToSnakeCase(string pascal)
+	{
+		var sb = new System.Text.StringBuilder(pascal.Length + 4);
+		for (int i = 0; i < pascal.Length; i++)
+		{
+			char c = pascal[i];
+			if (i > 0 && char.IsUpper(c)) sb.Append('_');
+			sb.Append(char.ToLowerInvariant(c));
+		}
+		return sb.ToString();
 	}
 
 	[HttpPost("{id:guid}/participation")]
@@ -135,7 +180,8 @@ public class ClustersController : ControllerBase
 			return UnprocessableEntity(new
 			{
 				error = "Context requires an active affected participation.",
-				code = "context_requires_affected_participation"
+				code = "policy_blocked",
+				reason = "context_requires_affected_participation"
 			});
 		}
 		catch (InvalidOperationException ex2) when (ex2.Message == "CONTEXT_EDIT_WINDOW_EXPIRED")
@@ -143,7 +189,8 @@ public class ClustersController : ControllerBase
 			return UnprocessableEntity(new
 			{
 				error = "Context edit window has expired.",
-				code = "context_edit_window_expired"
+				code = "policy_blocked",
+				reason = "context_edit_window_expired"
 			});
 		}
 	}
@@ -171,7 +218,19 @@ public class ClustersController : ControllerBase
 		{
 			accountId = parsed;
 		}
-		await _participation.RecordRestorationResponseAsync(id, device.Id, accountId, dto.Response, ct);
-		return NoContent();
+		try
+		{
+			await _participation.RecordRestorationResponseAsync(id, device.Id, accountId, dto.Response, ct);
+			return NoContent();
+		}
+		catch (InvalidOperationException ex) when (ex.Message == "RESTORATION_REQUIRES_AFFECTED")
+		{
+			return UnprocessableEntity(new
+			{
+				error = "Restoration response requires an active affected participation.",
+				code = "policy_blocked",
+				reason = "restoration_requires_affected_participation"
+			});
+		}
 	}
 }

--- a/src/Hali.Application/Participation/IParticipationRepository.cs
+++ b/src/Hali.Application/Participation/IParticipationRepository.cs
@@ -11,6 +11,13 @@ public interface IParticipationRepository
 {
 	Task<Hali.Domain.Entities.Participation.Participation?> GetByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct);
 
+	/// <summary>
+	/// Returns the caller's most recent participation row on a cluster,
+	/// looked up by account_id. Used by GET /v1/clusters/{id} to populate
+	/// the myParticipation field for the authenticated caller.
+	/// </summary>
+	Task<Hali.Domain.Entities.Participation.Participation?> GetMostRecentByAccountAsync(Guid clusterId, Guid accountId, CancellationToken ct);
+
 	Task DeleteByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct);
 
 	Task AddAsync(Hali.Domain.Entities.Participation.Participation participation, CancellationToken ct);

--- a/src/Hali.Application/Participation/ParticipationService.cs
+++ b/src/Hali.Application/Participation/ParticipationService.cs
@@ -58,21 +58,30 @@ public class ParticipationService : IParticipationService
 
 	public async Task RecordRestorationResponseAsync(Guid clusterId, Guid deviceId, Guid? accountId, string response, CancellationToken ct)
 	{
-		if (1 == 0)
+		// Server-side gating: the caller must currently hold an `affected`
+		// participation on this cluster. The mobile app gates the CTA on
+		// myParticipation.canRespondToRestoration; this re-check enforces
+		// the rule at the trust boundary, not just the UI.
+		// Looked up by device first (matches how the controller resolves
+		// the caller); falls back to account_id if no device row exists.
+		var current = await _participationRepo.GetByDeviceAsync(clusterId, deviceId, ct);
+		if (current == null && accountId.HasValue)
 		{
+			current = await _participationRepo.GetMostRecentByAccountAsync(clusterId, accountId.Value, ct);
 		}
+		if (current == null || current.ParticipationType != ParticipationType.Affected)
+		{
+			throw new InvalidOperationException("RESTORATION_REQUIRES_AFFECTED");
+		}
+
 		ParticipationType participationType = response switch
 		{
-			"restored" => ParticipationType.RestorationYes, 
-			"still_affected" => ParticipationType.Affected, 
-			"not_sure" => ParticipationType.RestorationUnsure, 
-			_ => throw new InvalidOperationException("RESTORATION_INVALID_RESPONSE"), 
+			"restored" => ParticipationType.RestorationYes,
+			"still_affected" => ParticipationType.Affected,
+			"not_sure" => ParticipationType.RestorationUnsure,
+			_ => throw new InvalidOperationException("RESTORATION_INVALID_RESPONSE"),
 		};
-		if (1 == 0)
-		{
-		}
-		ParticipationType type = participationType;
-		await RecordParticipationAsync(clusterId, deviceId, accountId, type, null, ct);
+		await RecordParticipationAsync(clusterId, deviceId, accountId, participationType, null, ct);
 		await EvaluateRestorationAsync(clusterId, ct);
 	}
 

--- a/src/Hali.Contracts/Clusters/ClusterResponseDto.cs
+++ b/src/Hali.Contracts/Clusters/ClusterResponseDto.cs
@@ -20,4 +20,24 @@ public record ClusterResponseDto(
     DateTime? ResolvedAt)
 {
     public List<OfficialPostResponseDto> OfficialPosts { get; init; } = new();
+
+    /// <summary>
+    /// Per-caller participation summary used by the mobile UI to gate the
+    /// "Add Further Context" and restoration-response CTAs server-side.
+    /// Null for unauthenticated callers or when the caller has no
+    /// participation record on this cluster.
+    /// </summary>
+    public MyParticipationDto? MyParticipation { get; init; }
 }
+
+/// <summary>
+/// Snapshot of the authenticated caller's most recent participation on a
+/// cluster, plus the server's verdict on whether the two restricted CTAs
+/// may be shown. This is the source of truth — the mobile app must NOT
+/// gate these CTAs on local state alone.
+/// </summary>
+public record MyParticipationDto(
+    string Type,
+    DateTime CreatedAt,
+    bool CanAddContext,
+    bool CanRespondToRestoration);

--- a/src/Hali.Infrastructure/Participation/ParticipationRepository.cs
+++ b/src/Hali.Infrastructure/Participation/ParticipationRepository.cs
@@ -28,6 +28,14 @@ public class ParticipationRepository : IParticipationRepository
 			select p).FirstOrDefaultAsync(ct);
 	}
 
+	public Task<Hali.Domain.Entities.Participation.Participation?> GetMostRecentByAccountAsync(Guid clusterId, Guid accountId, CancellationToken ct)
+	{
+		return (from p in _db.Participations
+			where p.ClusterId == clusterId && p.AccountId == accountId
+			orderby p.CreatedAt descending
+			select p).FirstOrDefaultAsync(ct);
+	}
+
 	public async Task DeleteByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct)
 	{
 		List<Hali.Domain.Entities.Participation.Participation> existing = await _db.Participations.Where((Hali.Domain.Entities.Participation.Participation p) => p.ClusterId == clusterId && p.DeviceId == deviceId).ToListAsync(ct);

--- a/tests/Hali.Tests.Unit/Advisories/EvaluatePossibleRestorationJobTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/EvaluatePossibleRestorationJobTests.cs
@@ -91,6 +91,7 @@ public class EvaluatePossibleRestorationJobTests
         }
 
         public Task<ParticipationEntity?> GetByDeviceAsync(Guid c, Guid d, CancellationToken ct) => Task.FromResult<ParticipationEntity?>(null);
+        public Task<ParticipationEntity?> GetMostRecentByAccountAsync(Guid c, Guid a, CancellationToken ct) => Task.FromResult<ParticipationEntity?>(null);
         public Task DeleteByDeviceAsync(Guid c, Guid d, CancellationToken ct) => Task.CompletedTask;
         public Task AddAsync(ParticipationEntity p, CancellationToken ct) => Task.CompletedTask;
         public Task UpdateContextAsync(Guid id, string text, CancellationToken ct) => Task.CompletedTask;

--- a/tests/Hali.Tests.Unit/Advisories/RestorationEvaluationTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/RestorationEvaluationTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
@@ -61,6 +62,10 @@ public class RestorationEvaluationTests
 
         public Task<ParticipationEntity?> GetByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct)
             => Task.FromResult(_store.Find(x => x.ClusterId == clusterId && x.DeviceId == deviceId));
+
+        public Task<ParticipationEntity?> GetMostRecentByAccountAsync(Guid clusterId, Guid accountId, CancellationToken ct)
+            => Task.FromResult(_store.FindAll(x => x.ClusterId == clusterId && x.AccountId == accountId)
+                .OrderByDescending(x => x.CreatedAt).FirstOrDefault());
 
         public Task DeleteByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct)
         { _store.RemoveAll(x => x.ClusterId == clusterId && x.DeviceId == deviceId); return Task.CompletedTask; }

--- a/tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs
+++ b/tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs
@@ -24,6 +24,15 @@ internal sealed class FakeParticipationRepo : IParticipationRepository
 		return Task.FromResult(result);
 	}
 
+	public Task<Hali.Domain.Entities.Participation.Participation?> GetMostRecentByAccountAsync(Guid clusterId, Guid accountId, CancellationToken ct)
+	{
+		Hali.Domain.Entities.Participation.Participation result = (from x in _store
+			where x.ClusterId == clusterId && x.AccountId == accountId
+			orderby x.CreatedAt descending
+			select x).FirstOrDefault();
+		return Task.FromResult(result);
+	}
+
 	public Task DeleteByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct)
 	{
 		_store.RemoveAll((Hali.Domain.Entities.Participation.Participation x) => x.ClusterId == clusterId && x.DeviceId == deviceId);

--- a/tests/Hali.Tests.Unit/Participation/ParticipationServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Participation/ParticipationServiceTests.cs
@@ -128,11 +128,39 @@ public class ParticipationServiceTests
 		Assert.Equal("CONTEXT_EDIT_WINDOW_EXPIRED", (await Assert.ThrowsAsync<InvalidOperationException>(() => svc.AddContextAsync(ClusterId, DeviceA, "Late context", default(CancellationToken)))).Message);
 	}
 
+	// Restoration responses now require a current `affected` participation
+	// (server-side gating added in Task 3 of the PR #50 follow-ups). Each
+	// restoration test seeds the calling device(s) as affected first.
+	private static Task SeedAffectedAsync(ParticipationService svc, Guid deviceId)
+		=> svc.RecordParticipationAsync(ClusterId, deviceId, null, ParticipationType.Affected, null, default);
+
+	[Fact]
+	public async Task RecordRestorationResponse_WithoutAffectedParticipation_ThrowsRestorationRequiresAffected()
+	{
+		SignalCluster cluster = ActiveCluster();
+		var (svc, _, _) = Build(cluster);
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default));
+		Assert.Equal("RESTORATION_REQUIRES_AFFECTED", ex.Message);
+	}
+
+	[Fact]
+	public async Task RecordRestorationResponse_WithObservingParticipation_ThrowsRestorationRequiresAffected()
+	{
+		SignalCluster cluster = ActiveCluster();
+		var (svc, _, _) = Build(cluster);
+		await svc.RecordParticipationAsync(ClusterId, DeviceA, null, ParticipationType.Observing, null, default);
+		var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+			() => svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default));
+		Assert.Equal("RESTORATION_REQUIRES_AFFECTED", ex.Message);
+	}
+
 	[Fact]
 	public async Task RecordRestorationResponse_Restored_MapsToRestorationYes()
 	{
 		SignalCluster cluster = ActiveCluster();
 		var (svc, pRepo, _) = Build(cluster);
+		await SeedAffectedAsync(svc, DeviceA);
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default(CancellationToken));
 		Hali.Domain.Entities.Participation.Participation p = pRepo.All.Single((Hali.Domain.Entities.Participation.Participation x) => x.DeviceId == DeviceA);
 		Assert.Equal(ParticipationType.RestorationYes, p.ParticipationType);
@@ -143,6 +171,7 @@ public class ParticipationServiceTests
 	{
 		SignalCluster cluster = ActiveCluster();
 		var (svc, pRepo, _) = Build(cluster);
+		await SeedAffectedAsync(svc, DeviceA);
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "still_affected", default(CancellationToken));
 		Hali.Domain.Entities.Participation.Participation p = pRepo.All.Single((Hali.Domain.Entities.Participation.Participation x) => x.DeviceId == DeviceA);
 		Assert.Equal(ParticipationType.Affected, p.ParticipationType);
@@ -153,6 +182,7 @@ public class ParticipationServiceTests
 	{
 		SignalCluster cluster = ActiveCluster();
 		var (svc, pRepo, _) = Build(cluster);
+		await SeedAffectedAsync(svc, DeviceA);
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "not_sure", default(CancellationToken));
 		Hali.Domain.Entities.Participation.Participation p = pRepo.All.Single((Hali.Domain.Entities.Participation.Participation x) => x.DeviceId == DeviceA);
 		Assert.Equal(ParticipationType.RestorationUnsure, p.ParticipationType);
@@ -165,6 +195,8 @@ public class ParticipationServiceTests
 		(ParticipationService, FakeParticipationRepo, FakeClusterRepoForParticipation) tuple = Build(cluster);
 		var (svc, _, _) = tuple;
 		_ = tuple.Item3;
+		await SeedAffectedAsync(svc, DeviceA);
+		await SeedAffectedAsync(svc, DeviceB);
 		// Two votes needed (MinRestorationAffectedVotes=2)
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default(CancellationToken));
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceB, null, "restored", default(CancellationToken));
@@ -177,6 +209,8 @@ public class ParticipationServiceTests
 	{
 		SignalCluster cluster = ActiveCluster();
 		var (svc, _, cRepo) = Build(cluster);
+		await SeedAffectedAsync(svc, DeviceA);
+		await SeedAffectedAsync(svc, DeviceB);
 		// Two votes needed (MinRestorationAffectedVotes=2)
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default(CancellationToken));
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceB, null, "restored", default(CancellationToken));
@@ -196,6 +230,7 @@ public class ParticipationServiceTests
 			MinRestorationAffectedVotes = 3
 		};
 		var (svc, _, cRepo) = Build(cluster, opts);
+		await SeedAffectedAsync(svc, DeviceA);
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default(CancellationToken));
 		Assert.Equal(SignalState.Active, cluster.State);
 		Assert.Empty(cRepo.Decisions);


### PR DESCRIPTION
## Summary
Three follow-up fixes from PR #50 mobile UI review.

## Changes
- **Task 1: Locality names — deferred + gap documented.** The mobile ward
  picker and settings render raw UUIDs because no API exposes locality names.
  The Locality table has the columns, but `GET /v1/localities/followed`
  returns IDs only and there is no lookup or search endpoint. Documented the
  full backend + mobile follow-up scope in
  `docs/arch/pr50-followup-gaps.md` and continued (Option 3 chosen during
  pre-flight review).
- **Task 2: OpenAPI spec repaired against the C# backend source.**
  `02_openapi.yaml` walked endpoint-by-endpoint against
  `src/Hali.Api/Controllers/*` and `src/Hali.Contracts/**`. Bumped
  `info.version` 0.3.0 → 0.4.0. Removed stale `GET /v1/admin/orphaned-signals`
  (no controller). Corrected status codes (multiple endpoints actually return
  204, not 200/202). Rewrote SignalPreview / SignalSubmit / Participation /
  Context / Restoration / OfficialPostCreate request schemas which had
  significant drift from the actual DTOs. Added missing 429 / 502 / 409 / 422
  responses with a shared `ErrorResponse` envelope. Documented the JSON
  convention (camelCase properties + snake_case_lower enums).
- **Task 3: Server-side enforcement on context and restoration CTAs +
  `myParticipation` on cluster detail.** `GET /v1/clusters/{id}` now returns
  a `myParticipation` snapshot (`{ type, createdAt, canAddContext,
  canRespondToRestoration }`) when authenticated. The mobile cluster detail
  screen gates "Add Further Context" on `canAddContext` and the restoration
  response banner on `type === 'affected'` (it previously showed for every
  viewer of a `possible_restoration` cluster). The restoration POST also
  now refuses callers without a current affected participation —
  `RecordRestorationResponseAsync` was previously happy to record a
  restoration vote from any registered device. Both 422 envelopes use
  `code=policy_blocked` with a stable `reason` sub-field per task spec.

## Testing
- Backend: `dotnet test` — 168 unit tests passed (was 166; +2 new tests
  for `RESTORATION_REQUIRES_AFFECTED` gating). Integration tests: 15 passed.
- Verify `GET /v1/clusters/{id}` includes `myParticipation` field when
  authenticated; null when anonymous.
- Verify `POST /v1/clusters/{id}/restoration-response` returns 422
  `policy_blocked` for callers without a current affected participation.
- Verify `POST /v1/clusters/{id}/context` returns 422 `policy_blocked`
  outside the 2-minute window.
- Mobile cluster detail: confirm restoration banner only renders when
  the caller is currently affected, and "Add Further Context" only renders
  when the server says `canAddContext === true`.

## Out of scope (documented)
- Locality name rendering — see `docs/arch/pr50-followup-gaps.md` for the
  required backend extension and follow-up PR shape.

## Checklist
- [x] No new features introduced
- [x] No navigation structure changed
- [x] All enum values verified against backend source
- [x] `myParticipation` field documented in OpenAPI spec
- [x] No CIVIS internals exposed via public API
- [x] No migrations modified
- [x] No new dependencies introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)