### PR TITLE
chore: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,26 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability in Hali, please report it
+privately rather than opening a public issue.
+
+**Contact:** open a GitHub Security Advisory at:
+https://github.com/irvinesunday/Hali/security/advisories/new
+
+Please include:
+- Description of the vulnerability
+- Steps to reproduce
+- Potential impact
+- Any suggested fix if known
+
+We will acknowledge receipt within 48 hours and aim to resolve
+critical issues within 14 days.
+
+## Supported Versions
+
+| Version | Supported |
+|---|---|
+| develop (latest) | ✅ |
+| main (releases) | ✅ |
+| older branches | ❌ |


### PR DESCRIPTION
## Summary
- Adds a top-level \`SECURITY.md\` so GitHub surfaces a Security policy link on the repo and on every issue/PR template.
- Directs reporters to open a private GitHub Security Advisory instead of a public issue, with response SLAs (48h ack, 14d for critical).
- Documents which branches are currently supported (\`develop\`, \`main\`).

## Why
There was no published vulnerability-reporting channel. A private SECURITY.md is the standard GitHub-recognized way to receive responsible disclosures and is required for triggering the Security Advisory workflow.

## Test plan
- [ ] After merge, confirm the \"Security policy\" link appears in the repo's Security tab.
- [ ] Confirm the advisory link resolves to the new-advisory form.