### PR TITLE
feat(mobile): Phase A — design token foundation

### DIFF
--- a/apps/citizen-mobile/__tests__/theme/colors.test.ts
+++ b/apps/citizen-mobile/__tests__/theme/colors.test.ts
@@ -1,0 +1,140 @@
+// apps/citizen-mobile/__tests__/theme/colors.test.ts
+//
+// Unit tests for getConditionBadgePalette().
+// Locks in expected palette mappings and fallback behavior so
+// taxonomy additions don't silently break the badge color system.
+
+import { getConditionBadgePalette } from '../../src/theme/colors';
+
+describe('getConditionBadgePalette', () => {
+  describe('amber — power / water outages', () => {
+    it.each([
+      'No power',
+      'Power outage',
+      'Blackout',
+      'No water',
+      'Transformer fault',
+      'Sewage overflow',
+      'Bad smell from drains',
+      'Sewage smell',
+    ])('maps "%s" → amber', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('amber');
+    });
+  });
+
+  describe('orange — road difficulty', () => {
+    it.each([
+      'Difficult to pass',
+      'Pothole',
+      'Lane blocked',
+      'Slow moving traffic',
+      'Heavy traffic',
+      'Road damage',
+      'Partially blocked',
+      'Road narrowed',
+      'Obstruction on road',
+      'Sidewalk blocked',
+      'Walkway impassable',
+      'Crowded street',
+      'Uncollected garbage',
+      'Dumped waste',
+      'Overflowing bin',
+    ])('maps "%s" → orange', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('orange');
+    });
+  });
+
+  describe('red — impassable / blocked', () => {
+    it.each([
+      'Impassable road',
+      'Road blocked',
+      'Traffic blocked',
+      'Accident on N1',
+      'Crash reported',
+      'Collision ahead',
+    ])('maps "%s" → red', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('red');
+    });
+  });
+
+  describe('sky — flooding', () => {
+    it.each([
+      'Flooding on main road',
+      'Water on road',
+      'Partially flooded',
+      'Water on pavement',
+    ])('maps "%s" → sky', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('sky');
+    });
+  });
+
+  describe('violet — noise', () => {
+    it.each([
+      'Noise disturbance',
+      'Noisy construction',
+      'Loud music from venue',
+    ])('maps "%s" → violet', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('violet');
+    });
+  });
+
+  describe('stone — dust', () => {
+    it.each([
+      'Dust cloud',
+      'Dusty road after grading',
+    ])('maps "%s" → stone', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('stone');
+    });
+  });
+
+  describe('slate — darkness / no lighting', () => {
+    it.each([
+      'Dark area at night',
+      'No street lights',
+      'No light in underpass',
+    ])('maps "%s" → slate', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('slate');
+    });
+  });
+
+  describe('yellow — minor / intermittent conditions', () => {
+    it.each([
+      'Low pressure water',
+      'Weak pressure in taps',
+      'Unstable supply',
+      'Intermittent outage',
+      'Power going on and off',
+      'Air pollution visible',
+    ])('maps "%s" → yellow', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('yellow');
+    });
+  });
+
+  describe('emerald — restoration', () => {
+    it.each([
+      'Possible restoration underway',
+      'Power restored in area',
+      'Recovery in progress',
+    ])('maps "%s" → emerald', (label) => {
+      expect(getConditionBadgePalette(label)).toBe('emerald');
+    });
+  });
+
+  describe('muted — fallback', () => {
+    it('returns muted for an unrecognised condition', () => {
+      expect(getConditionBadgePalette('something completely unknown')).toBe('muted');
+    });
+
+    it('returns muted for an empty string', () => {
+      expect(getConditionBadgePalette('')).toBe('muted');
+    });
+  });
+
+  describe('case-insensitivity', () => {
+    it('matches regardless of input case', () => {
+      expect(getConditionBadgePalette('NO POWER')).toBe('amber');
+      expect(getConditionBadgePalette('FLOODING')).toBe('sky');
+      expect(getConditionBadgePalette('POTHOLE')).toBe('orange');
+    });
+  });
+});

--- a/apps/citizen-mobile/app/_layout.tsx
+++ b/apps/citizen-mobile/app/_layout.tsx
@@ -7,6 +7,13 @@ import { StatusBar } from 'expo-status-bar';
 import { AuthProvider } from '../src/context/AuthContext';
 import { LocalityProvider } from '../src/context/LocalityContext';
 import { ComposerProvider } from '../src/context/ComposerContext';
+import {
+  Geist_400Regular,
+  Geist_500Medium,
+  Geist_600SemiBold,
+  Geist_700Bold,
+  useFonts,
+} from '@expo-google-fonts/geist';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -16,6 +23,17 @@ const queryClient = new QueryClient({
 });
 
 export default function RootLayout() {
+  const [fontsLoaded] = useFonts({
+    Geist_400Regular,
+    Geist_500Medium,
+    Geist_600SemiBold,
+    Geist_700Bold,
+  });
+
+  if (!fontsLoaded) {
+    return null; // SplashScreen.preventAutoHideAsync() handles this
+  }
+
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
       <SafeAreaProvider>

--- a/apps/citizen-mobile/app/_layout.tsx
+++ b/apps/citizen-mobile/app/_layout.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StatusBar } from 'expo-status-bar';
+import * as SplashScreen from 'expo-splash-screen';
 import { AuthProvider } from '../src/context/AuthContext';
 import { LocalityProvider } from '../src/context/LocalityContext';
 import { ComposerProvider } from '../src/context/ComposerContext';
@@ -14,6 +15,8 @@ import {
   Geist_700Bold,
   useFonts,
 } from '@expo-google-fonts/geist';
+
+SplashScreen.preventAutoHideAsync();
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -30,8 +33,14 @@ export default function RootLayout() {
     Geist_700Bold,
   });
 
+  useEffect(() => {
+    if (fontsLoaded) {
+      SplashScreen.hideAsync();
+    }
+  }, [fontsLoaded]);
+
   if (!fontsLoaded) {
-    return null; // SplashScreen.preventAutoHideAsync() handles this
+    return null;
   }
 
   return (

--- a/apps/citizen-mobile/package-lock.json
+++ b/apps/citizen-mobile/package-lock.json
@@ -8,6 +8,7 @@
       "name": "hali-citizen-mobile",
       "version": "1.0.0",
       "dependencies": {
+        "@expo-google-fonts/geist": "^0.4.1",
         "@expo/vector-icons": "^14.0.0",
         "@react-native-async-storage/async-storage": "3.0.2",
         "@react-native-community/netinfo": "^12.0.1",
@@ -1455,6 +1456,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/@expo-google-fonts/geist": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@expo-google-fonts/geist/-/geist-0.4.1.tgz",
+      "integrity": "sha512-UOBwoTJkKC0ViMOS8gjlQyUcT/5PX0phCroz/8z0DP1+7FcoD1RGGeG//nVQYWbT3y/ze4XoE63gSunml9Wdbw==",
+      "license": "MIT AND OFL-1.1"
     },
     "node_modules/@expo-google-fonts/material-symbols": {
       "version": "0.4.28",

--- a/apps/citizen-mobile/package.json
+++ b/apps/citizen-mobile/package.json
@@ -12,6 +12,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
+    "@expo-google-fonts/geist": "^0.4.1",
     "@expo/vector-icons": "^14.0.0",
     "@react-native-async-storage/async-storage": "3.0.2",
     "@react-native-community/netinfo": "^12.0.1",

--- a/apps/citizen-mobile/src/theme/animations.ts
+++ b/apps/citizen-mobile/src/theme/animations.ts
@@ -1,0 +1,154 @@
+/**
+ * Hali design token — animation presets for Reanimated 2.
+ *
+ * Six animations ported from the web MVP's globals.css keyframes.
+ * All use withTiming or withRepeat/withSequence from react-native-reanimated.
+ *
+ * Usage:
+ *   const style = useAnimatedStyle(() => Animations.pulseSoft(opacity, scale));
+ *
+ * Each export is a hook-ready config object, not a pre-built hook.
+ * Screens and components call useAnimatedStyle with these configs.
+ */
+
+import {
+  withTiming,
+  withRepeat,
+  withSequence,
+  Easing,
+} from 'react-native-reanimated';
+
+/**
+ * pulse-soft — live indicator dot breathing.
+ * opacity 1→0.5, scale 1→1.15, 2s infinite.
+ * Used by: LiveDot component.
+ */
+export const pulseSoftConfig = {
+  duration: 1000,
+  easing: Easing.inOut(Easing.ease),
+};
+
+export function startPulseSoft(opacityValue: { value: number }, scaleValue: { value: number }) {
+  opacityValue.value = withRepeat(
+    withSequence(
+      withTiming(0.5, pulseSoftConfig),
+      withTiming(1, pulseSoftConfig),
+    ),
+    -1,
+    true,
+  );
+  scaleValue.value = withRepeat(
+    withSequence(
+      withTiming(1.15, pulseSoftConfig),
+      withTiming(1, pulseSoftConfig),
+    ),
+    -1,
+    true,
+  );
+}
+
+/**
+ * count-pop — count value change feedback.
+ * scale 1→1.15→1, 300ms.
+ * Used by: animated count displays in ClusterDetail.
+ */
+export function triggerCountPop(scaleValue: { value: number }) {
+  scaleValue.value = withSequence(
+    withTiming(1.15, { duration: 150, easing: Easing.out(Easing.ease) }),
+    withTiming(1, { duration: 150, easing: Easing.in(Easing.ease) }),
+  );
+}
+
+/**
+ * fade-up — element entering the feed.
+ * opacity 0→1, translateY 8→0, 300ms ease-out.
+ * Used by: ClusterCard, feed sections on mount.
+ */
+export const fadeUpConfig = {
+  opacity: {
+    from: 0,
+    to: 1,
+    duration: 300,
+    easing: Easing.out(Easing.ease),
+  },
+  translateY: {
+    from: 8,
+    to: 0,
+    duration: 300,
+    easing: Easing.out(Easing.ease),
+  },
+};
+
+export function startFadeUp(
+  opacityValue: { value: number },
+  translateYValue: { value: number },
+) {
+  opacityValue.value = withTiming(1, {
+    duration: fadeUpConfig.opacity.duration,
+    easing: fadeUpConfig.opacity.easing,
+  });
+  translateYValue.value = withTiming(0, {
+    duration: fadeUpConfig.translateY.duration,
+    easing: fadeUpConfig.translateY.easing,
+  });
+}
+
+/**
+ * modal-content — bottom sheet entrance.
+ * opacity 0→1, translateY 24→0, scale 0.96→1, 300ms cubic.
+ * Used by: OfficialUpdateSheet, LocalitySelector, FeedbackSheet.
+ */
+export const modalContentConfig = {
+  duration: 300,
+  easing: Easing.bezier(0.16, 1, 0.3, 1),
+};
+
+export function startModalContent(
+  opacityValue: { value: number },
+  translateYValue: { value: number },
+  scaleValue: { value: number },
+) {
+  opacityValue.value = withTiming(1, modalContentConfig);
+  translateYValue.value = withTiming(0, modalContentConfig);
+  scaleValue.value = withTiming(1, modalContentConfig);
+}
+
+/**
+ * breathe — FAB persistent breathing pulse.
+ * scale 1→1.03→1, 3s infinite ease-in-out.
+ * Used by: FAB component.
+ */
+export function startBreathe(scaleValue: { value: number }) {
+  scaleValue.value = withRepeat(
+    withSequence(
+      withTiming(1.03, {
+        duration: 1500,
+        easing: Easing.inOut(Easing.ease),
+      }),
+      withTiming(1, {
+        duration: 1500,
+        easing: Easing.inOut(Easing.ease),
+      }),
+    ),
+    -1,
+    true,
+  );
+}
+
+/**
+ * slide-in-right — detail screen entrance.
+ * opacity 0→1, translateX 16→0, 350ms cubic.
+ * Used by: ClusterDetail section reveal.
+ */
+export const slideInRightConfig = {
+  duration: 350,
+  easing: Easing.bezier(0.16, 1, 0.3, 1),
+};
+
+export function startSlideInRight(
+  opacityValue: { value: number },
+  translateXValue: { value: number },
+) {
+  opacityValue.value = withTiming(1, slideInRightConfig);
+  translateXValue.value = withTiming(0, slideInRightConfig);
+}

--- a/apps/citizen-mobile/src/theme/animations.ts
+++ b/apps/citizen-mobile/src/theme/animations.ts
@@ -4,11 +4,15 @@
  * Six animations ported from the web MVP's globals.css keyframes.
  * All use withTiming or withRepeat/withSequence from react-native-reanimated.
  *
- * Usage:
- *   const style = useAnimatedStyle(() => Animations.pulseSoft(opacity, scale));
+ * Usage — imperative helpers start or trigger animations on shared values:
+ *   startPulseSoft(opacity, scale);
+ *   triggerCountPop(scale);
  *
- * Each export is a hook-ready config object, not a pre-built hook.
- * Screens and components call useAnimatedStyle with these configs.
+ * Separate *Config exports can be used when building animated styles:
+ *   fadeUpConfig.opacity / fadeUpConfig.translateY
+ *
+ * This module exports imperative animation helpers (`start*` / `trigger*`)
+ * plus separate `*Config` objects. It does not export pre-built hooks.
  */
 
 import {
@@ -16,6 +20,7 @@ import {
   withRepeat,
   withSequence,
   Easing,
+  type SharedValue,
 } from 'react-native-reanimated';
 
 /**
@@ -28,7 +33,7 @@ export const pulseSoftConfig = {
   easing: Easing.inOut(Easing.ease),
 };
 
-export function startPulseSoft(opacityValue: { value: number }, scaleValue: { value: number }) {
+export function startPulseSoft(opacityValue: SharedValue<number>, scaleValue: SharedValue<number>) {
   opacityValue.value = withRepeat(
     withSequence(
       withTiming(0.5, pulseSoftConfig),
@@ -52,7 +57,7 @@ export function startPulseSoft(opacityValue: { value: number }, scaleValue: { va
  * scale 1→1.15→1, 300ms.
  * Used by: animated count displays in ClusterDetail.
  */
-export function triggerCountPop(scaleValue: { value: number }) {
+export function triggerCountPop(scaleValue: SharedValue<number>) {
   scaleValue.value = withSequence(
     withTiming(1.15, { duration: 150, easing: Easing.out(Easing.ease) }),
     withTiming(1, { duration: 150, easing: Easing.in(Easing.ease) }),
@@ -80,8 +85,8 @@ export const fadeUpConfig = {
 };
 
 export function startFadeUp(
-  opacityValue: { value: number },
-  translateYValue: { value: number },
+  opacityValue: SharedValue<number>,
+  translateYValue: SharedValue<number>,
 ) {
   opacityValue.value = withTiming(1, {
     duration: fadeUpConfig.opacity.duration,
@@ -104,9 +109,9 @@ export const modalContentConfig = {
 };
 
 export function startModalContent(
-  opacityValue: { value: number },
-  translateYValue: { value: number },
-  scaleValue: { value: number },
+  opacityValue: SharedValue<number>,
+  translateYValue: SharedValue<number>,
+  scaleValue: SharedValue<number>,
 ) {
   opacityValue.value = withTiming(1, modalContentConfig);
   translateYValue.value = withTiming(0, modalContentConfig);
@@ -118,7 +123,7 @@ export function startModalContent(
  * scale 1→1.03→1, 3s infinite ease-in-out.
  * Used by: FAB component.
  */
-export function startBreathe(scaleValue: { value: number }) {
+export function startBreathe(scaleValue: SharedValue<number>) {
   scaleValue.value = withRepeat(
     withSequence(
       withTiming(1.03, {
@@ -146,8 +151,8 @@ export const slideInRightConfig = {
 };
 
 export function startSlideInRight(
-  opacityValue: { value: number },
-  translateXValue: { value: number },
+  opacityValue: SharedValue<number>,
+  translateXValue: SharedValue<number>,
 ) {
   opacityValue.value = withTiming(1, slideInRightConfig);
   translateXValue.value = withTiming(0, slideInRightConfig);

--- a/apps/citizen-mobile/src/theme/colors.ts
+++ b/apps/citizen-mobile/src/theme/colors.ts
@@ -1,0 +1,171 @@
+/**
+ * Hali design token — colour system.
+ *
+ * Source: MVP demo globals.css (OKLCH values converted to hex).
+ * Primary brand colour is a muted civic teal — calm and trustworthy,
+ * not urgent or alarming. All condition badge colours match Tailwind
+ * semantic classes used in the web MVP.
+ *
+ * Do not change these values without updating the web MVP globals.css
+ * to keep the two surfaces visually consistent.
+ */
+
+export const Colors = {
+  // ── Brand ──────────────────────────────────────────────────────────────
+  primary: '#2D8A8F',        // oklch(0.55 0.12 190) — civic teal
+  primaryForeground: '#FFFFFF',
+  primarySubtle: '#E8F4F5',  // primary/10 equivalent
+
+  // ── Surface ────────────────────────────────────────────────────────────
+  background: '#F7FAFA',     // oklch(0.98 0.005 200) — near-white, cool tint
+  card: '#FFFFFF',
+  cardForeground: '#383D42', // oklch(0.25 0.02 220)
+
+  // ── Text ───────────────────────────────────────────────────────────────
+  foreground: '#383D42',     // primary text
+  mutedForeground: '#757B82',// oklch(0.50 0.02 220) — secondary text
+  faintForeground: '#9CA3AF',// very subtle labels, timestamps
+
+  // ── UI Chrome ──────────────────────────────────────────────────────────
+  border: '#E2E7E7',         // oklch(0.90 0.01 200)
+  muted: '#EEF1F1',          // oklch(0.95 0.005 200) — section backgrounds
+  input: '#E8EDED',          // oklch(0.92 0.01 200)
+
+  // ── Semantic ───────────────────────────────────────────────────────────
+  destructive: '#D4603A',    // oklch(0.60 0.15 30)
+  emerald: '#059669',        // restoration / calm / positive
+  emeraldSubtle: '#ECFDF5',
+
+  // ── Condition badge colours ────────────────────────────────────────────
+  // Each entry: { bg, text, border }
+  // Used by ConditionBadge component — must map every condition slug
+  // that CSI-NLP can return. Add new slugs here as taxonomy expands.
+  conditionBadge: {
+    // Power / water outages — amber
+    amber: {
+      bg: '#FFFBEB',
+      text: '#B45309',
+      border: '#FDE68A',
+    },
+    // Road difficulty — orange
+    orange: {
+      bg: '#FFF7ED',
+      text: '#C2410C',
+      border: '#FED7AA',
+    },
+    // Impassable / blocked — red
+    red: {
+      bg: '#FEF2F2',
+      text: '#B91C1C',
+      border: '#FECACA',
+    },
+    // Flooding / water on road — sky
+    sky: {
+      bg: '#F0F9FF',
+      text: '#0369A1',
+      border: '#BAE6FD',
+    },
+    // Noise disturbance — violet
+    violet: {
+      bg: '#F5F3FF',
+      text: '#6D28D9',
+      border: '#DDD6FE',
+    },
+    // Dust — stone
+    stone: {
+      bg: '#FAFAF9',
+      text: '#57534E',
+      border: '#D6D3D1',
+    },
+    // Dark / no lighting — slate
+    slate: {
+      bg: '#F8FAFC',
+      text: '#475569',
+      border: '#CBD5E1',
+    },
+    // Yellow — slow moving, minor conditions
+    yellow: {
+      bg: '#FEFCE8',
+      text: '#A16207',
+      border: '#FEF08A',
+    },
+    // Restoration / possible recovery — emerald
+    emerald: {
+      bg: '#ECFDF5',
+      text: '#047857',
+      border: '#A7F3D0',
+    },
+    // Fallback
+    muted: {
+      bg: '#EEF1F1',
+      text: '#757B82',
+      border: '#E2E7E7',
+    },
+  },
+} as const;
+
+/**
+ * Maps a condition label string to a conditionBadge palette key.
+ * Extend this map as new conditions are added to the taxonomy.
+ *
+ * Returns 'muted' for any unrecognised condition — never throws.
+ */
+export function getConditionBadgePalette(
+  condition: string,
+): keyof typeof Colors.conditionBadge {
+  const c = condition.toLowerCase();
+
+  if (
+    c.includes('no power') || c.includes('power outage') ||
+    c.includes('blackout') || c.includes('no water') ||
+    c.includes('transformer') || c.includes('sewage') ||
+    c.includes('bad smell') || c.includes('sewage smell')
+  ) return 'amber';
+
+  if (
+    c.includes('difficult') || c.includes('pothole') ||
+    c.includes('lane blocked') || c.includes('slow') ||
+    c.includes('heavy traffic') || c.includes('road damage') ||
+    c.includes('partially blocked') || c.includes('road narrowed') ||
+    c.includes('obstruction') || c.includes('sidewalk') ||
+    c.includes('walkway') || c.includes('crowded') ||
+    c.includes('uncollected') || c.includes('dumped') ||
+    c.includes('overflowing')
+  ) return 'orange';
+
+  if (
+    c.includes('impassable') || c.includes('road blocked') ||
+    c.includes('traffic blocked') || c.includes('accident') ||
+    c.includes('crash') || c.includes('collision')
+  ) return 'red';
+
+  if (
+    c.includes('flood') || c.includes('water on road') ||
+    c.includes('partially flooded') || c.includes('water on')
+  ) return 'sky';
+
+  if (
+    c.includes('noise') || c.includes('noisy') || c.includes('loud')
+  ) return 'violet';
+
+  if (
+    c.includes('dust') || c.includes('dusty')
+  ) return 'stone';
+
+  if (
+    c.includes('dark') || c.includes('no street') || c.includes('no light')
+  ) return 'slate';
+
+  if (
+    c.includes('low pressure') || c.includes('weak pressure') ||
+    c.includes('unstable') || c.includes('intermittent') ||
+    c.includes('going on') || c.includes('air pollution')
+  ) return 'yellow';
+
+  if (
+    c.includes('restoration') || c.includes('possible restoration') ||
+    c.includes('restored') || c.includes('recovery')
+  ) return 'emerald';
+
+  return 'muted';
+}

--- a/apps/citizen-mobile/src/theme/colors.ts
+++ b/apps/citizen-mobile/src/theme/colors.ts
@@ -38,8 +38,12 @@ export const Colors = {
 
   // ── Condition badge colours ────────────────────────────────────────────
   // Each entry: { bg, text, border }
-  // Used by ConditionBadge component — must map every condition slug
-  // that CSI-NLP can return. Add new slugs here as taxonomy expands.
+  // Keys are palette names (amber, orange, red, …), not condition slugs.
+  // Condition labels (free-text strings from CSI-NLP) are mapped to these
+  // palette keys by getConditionBadgePalette() below. When CSI-NLP returns
+  // a new condition label, add its matching clause in that function — do not
+  // add new palette keys here unless the condition genuinely requires a
+  // distinct colour family.
   conditionBadge: {
     // Power / water outages — amber
     amber: {
@@ -145,7 +149,7 @@ export function getConditionBadgePalette(
   ) return 'sky';
 
   if (
-    c.includes('noise') || c.includes('noisy') || c.includes('loud')
+    c.includes('noise') || c.includes('noisy') || /\bloud\b/.test(c)
   ) return 'violet';
 
   if (

--- a/apps/citizen-mobile/src/theme/index.ts
+++ b/apps/citizen-mobile/src/theme/index.ts
@@ -1,0 +1,6 @@
+export * from './colors';
+export * from './typography';
+export * from './spacing';
+export * from './radius';
+export * from './shadows';
+export * from './animations';

--- a/apps/citizen-mobile/src/theme/radius.ts
+++ b/apps/citizen-mobile/src/theme/radius.ts
@@ -1,0 +1,21 @@
+/**
+ * Hali design token — border radius scale.
+ * Base radius: 12dp (--radius: 0.75rem equivalent from web MVP).
+ */
+
+export const Radius = {
+  /** 4dp — tight, for inner elements */
+  xs: 4,
+  /** 8dp */
+  sm: 8,
+  /** 10dp */
+  md: 10,
+  /** 12dp — standard card radius */
+  lg: 12,
+  /** 16dp — large cards, modals */
+  xl: 16,
+  /** 24dp — sheets, large containers */
+  '2xl': 24,
+  /** 9999dp — pill shapes, badges, FAB */
+  full: 9999,
+} as const;

--- a/apps/citizen-mobile/src/theme/shadows.ts
+++ b/apps/citizen-mobile/src/theme/shadows.ts
@@ -1,0 +1,39 @@
+/**
+ * Hali design token — shadow definitions.
+ * React Native shadows require separate iOS / Android treatment.
+ * Use the spread operator to apply: { ...Shadows.card }
+ */
+
+import { Platform } from 'react-native';
+
+const iosShadow = (
+  opacity: number,
+  radius: number,
+  offsetY: number,
+) => ({
+  shadowColor: '#000',
+  shadowOffset: { width: 0, height: offsetY },
+  shadowOpacity: opacity,
+  shadowRadius: radius,
+});
+
+const androidElevation = (elevation: number) => ({
+  elevation,
+});
+
+function shadow(opacity: number, radius: number, offsetY: number, elevation: number) {
+  return Platform.OS === 'ios'
+    ? iosShadow(opacity, radius, offsetY)
+    : androidElevation(elevation);
+}
+
+export const Shadows = {
+  /** Subtle card resting shadow */
+  card: shadow(0.06, 3, 1, 2),
+  /** Card hover / elevated state */
+  cardElevated: shadow(0.10, 6, 3, 4),
+  /** FAB shadow */
+  fab: shadow(0.15, 8, 4, 6),
+  /** Modal / sheet shadow */
+  modal: shadow(0.20, 16, 8, 10),
+} as const;

--- a/apps/citizen-mobile/src/theme/spacing.ts
+++ b/apps/citizen-mobile/src/theme/spacing.ts
@@ -1,0 +1,29 @@
+/**
+ * Hali design token — spacing scale.
+ * Base unit: 4dp. All values are multiples of 4.
+ */
+
+export const Spacing = {
+  /** 4dp */
+  xs: 4,
+  /** 8dp */
+  sm: 8,
+  /** 12dp */
+  md: 12,
+  /** 16dp — standard screen/card padding (p-4 equivalent) */
+  lg: 16,
+  /** 20dp */
+  xl: 20,
+  /** 24dp — section gap (space-y-6 equivalent) */
+  '2xl': 24,
+  /** 32dp */
+  '3xl': 32,
+  /** 48dp */
+  '4xl': 48,
+} as const;
+
+/** Horizontal padding for all full-width screen content */
+export const ScreenPaddingH = Spacing.lg;
+
+/** Vertical padding at bottom of scrollable screens (above nav bar) */
+export const ScreenPaddingBottom = 96;

--- a/apps/citizen-mobile/src/theme/spacing.ts
+++ b/apps/citizen-mobile/src/theme/spacing.ts
@@ -20,10 +20,12 @@ export const Spacing = {
   '3xl': 32,
   /** 48dp */
   '4xl': 48,
+  /** 96dp */
+  '6xl': 96,
 } as const;
 
 /** Horizontal padding for all full-width screen content */
 export const ScreenPaddingH = Spacing.lg;
 
 /** Vertical padding at bottom of scrollable screens (above nav bar) */
-export const ScreenPaddingBottom = 96;
+export const ScreenPaddingBottom = Spacing['6xl'];

--- a/apps/citizen-mobile/src/theme/typography.ts
+++ b/apps/citizen-mobile/src/theme/typography.ts
@@ -3,7 +3,10 @@
  *
  * Font: Geist (sans-serif) loaded via @expo-google-fonts/geist.
  * Scale derived from the web MVP's Tailwind classes.
- * All sizes in dp (density-independent pixels).
+ * FontSize values are in dp (density-independent pixels).
+ * LineHeightMultiplier values are ratios — multiply by FontSize to get an
+ * absolute dp value for React Native's TextStyle.lineHeight:
+ *   lineHeight: FontSize.body * LineHeightMultiplier.normal  // → 21
  */
 
 export const FontFamily = {
@@ -32,7 +35,8 @@ export const FontSize = {
   micro: 10,
 } as const;
 
-export const LineHeight = {
+/** Ratio multipliers — use as: lineHeight = FontSize.* * LineHeightMultiplier.* */
+export const LineHeightMultiplier = {
   tight: 1.2,
   snug: 1.35,
   normal: 1.5,

--- a/apps/citizen-mobile/src/theme/typography.ts
+++ b/apps/citizen-mobile/src/theme/typography.ts
@@ -1,0 +1,46 @@
+/**
+ * Hali design token — typography scale.
+ *
+ * Font: Geist (sans-serif) loaded via @expo-google-fonts/geist.
+ * Scale derived from the web MVP's Tailwind classes.
+ * All sizes in dp (density-independent pixels).
+ */
+
+export const FontFamily = {
+  regular: 'Geist_400Regular',
+  medium: 'Geist_500Medium',
+  semiBold: 'Geist_600SemiBold',
+  bold: 'Geist_700Bold',
+} as const;
+
+export const FontSize = {
+  /** App name "Hali" header */
+  appName: 24,
+  /** Screen/modal titles */
+  title: 20,
+  /** Card titles, prominent labels */
+  cardTitle: 15,
+  /** Body text, descriptions */
+  body: 14,
+  /** Secondary body — institution names, context */
+  bodySmall: 13,
+  /** Condition badges, meta counts */
+  badge: 12,
+  /** Section headers (uppercase) */
+  sectionHeader: 10,
+  /** Micro labels — timestamps, updated-at */
+  micro: 10,
+} as const;
+
+export const LineHeight = {
+  tight: 1.2,
+  snug: 1.35,
+  normal: 1.5,
+} as const;
+
+export const LetterSpacing = {
+  /** For section header uppercase labels */
+  wide: 0.8,
+  /** Default */
+  normal: 0,
+} as const;


### PR DESCRIPTION
## Summary
Establishes the complete design token layer for citizen-mobile. All visual
constants (colours, typography, spacing, radius, shadows, animations) are
now in a single \`src/theme/\` module, sourced from the web MVP design system.
No existing components are modified in this PR — the token system is purely
additive. Phase B (shared components) will consume these tokens to apply the
MVP look and feel to all screens.

## Changes
- \`src/theme/colors.ts\` — brand palette + full condition badge colour map with \`getConditionBadgePalette()\` helper
- \`src/theme/typography.ts\` — Geist font family + size/line-height/letter-spacing scale
- \`src/theme/spacing.ts\` — 4dp-base spacing scale + \`ScreenPaddingH\`/\`ScreenPaddingBottom\` constants
- \`src/theme/radius.ts\` — border radius scale (xs → full)
- \`src/theme/shadows.ts\` — iOS/Android shadow definitions for card/elevated/FAB/modal
- \`src/theme/animations.ts\` — 6 Reanimated 2 animation presets (pulseSoft, countPop, fadeUp, modalContent, breathe, slideInRight)
- \`src/theme/index.ts\` — barrel export
- \`app/_layout.tsx\` — Geist font loading via \`useFonts\`
- \`package.json\` — \`@expo-google-fonts/geist\` added (installed with \`--legacy-peer-deps\` due to \`@testing-library/react-native\` peer dep conflict with expo-router@55)

## Notes
- \`@expo-google-fonts/geist\` install required \`--legacy-peer-deps\` because \`expo-router@55.0.10\` declares a peer of \`@testing-library/react-native@>=13.2.0\` but the project pins \`^12.9.0\`. The conflict is in devDependencies only and does not affect runtime.
- Pre-existing TypeScript errors in \`src/types/api.ts\` (duplicate \`ParticipationType\`) and \`__tests__/api/clusters.test.ts\` — not introduced by this PR.
- All 7 theme files: zero TypeScript errors.

## Checklist
- [x] TypeScript: zero errors in theme files
- [x] \`@expo-google-fonts/geist\` installed and added to package.json
- [x] Geist font wired into \`_layout.tsx\` via \`useFonts\`
- [x] No existing functionality changed
- [x] No features outside Phase A scope introduced
- [x] No existing components modified — purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)