### PR TITLE
chore(docs): wire lesson recording to every PR close point

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -564,3 +564,16 @@ In the same commit that fixes the issue:
 
 This is mandatory — not optional. The lesson must be recorded in the same
 commit as the fix so the fix and the lesson are permanently linked in history.
+
+### At the end of every session that included a git push
+
+Before declaring a session complete, check whether the pushed PR has any
+Copilot comments not yet recorded in `docs/arch/LESSONS_LEARNED.md`.
+
+Use the end-of-session check in `docs/arch/COPILOT_RESOLUTION_SKILL.md`
+(Situation B). If unrecorded lessons exist, append them and push the
+lesson commit to the PR branch before closing the session.
+
+This applies to ALL sessions — not just sessions explicitly about Copilot
+comments. A Phase B component PR, an integration test PR, a migration fix —
+all of them get the end-of-session check.

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -11,11 +11,11 @@ to a real past failure. Do not skip any item.
 
 ### CI Failures
 - [ ] If CI fails on a push you made: fix the failure AND record a lesson in
-      LESSONS_LEARNED.md in the same commit that fixes the CI issue
+      docs/arch/LESSONS_LEARNED.md in the same commit that fixes the CI issue
 - [ ] CI failure lesson format: same template as Copilot lessons, with
       "What Copilot flagged" replaced by "What CI reported"
 - [ ] Never push a second time to fix CI without first checking if the root
-      cause is already covered in LESSONS_LEARNED.md — if it is, note
+      cause is already covered in docs/arch/LESSONS_LEARNED.md — if it is, note
       "Existing lesson N reinforced" rather than creating a duplicate
 
 ### Formatting

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -9,6 +9,15 @@ This checklist exists because Copilot and CI have repeatedly caught issues
 that should have been caught before the PR was opened. Every item below maps
 to a real past failure. Do not skip any item.
 
+### CI Failures
+- [ ] If CI fails on a push you made: fix the failure AND record a lesson in
+      LESSONS_LEARNED.md in the same commit that fixes the CI issue
+- [ ] CI failure lesson format: same template as Copilot lessons, with
+      "What Copilot flagged" replaced by "What CI reported"
+- [ ] Never push a second time to fix CI without first checking if the root
+      cause is already covered in LESSONS_LEARNED.md — if it is, note
+      "Existing lesson N reinforced" rather than creating a duplicate
+
 ### Formatting
 - [ ] C# files: run `dotnet format --verify-no-changes` — zero violations
 - [ ] TypeScript files: run `npx tsc --noEmit` — zero errors

--- a/docs/arch/COPILOT_RESOLUTION_SKILL.md
+++ b/docs/arch/COPILOT_RESOLUTION_SKILL.md
@@ -200,3 +200,95 @@ After all comments on a PR are processed, post a summary comment:
 
 All changes committed and pushed. Ready for re-review.
 ```
+
+---
+
+## Mandatory: Lesson Recording Step (runs at every PR close point)
+
+This step runs in TWO situations — not just when addressing Copilot comments:
+
+### Situation A: You just addressed Copilot comments on a PR
+After fixing code, replying to threads, and resolving conversations:
+
+1. Check if a lesson entry already exists for this PR:
+   ```bash
+   grep "## PR #<N>" docs/arch/LESSONS_LEARNED.md
+   ```
+
+2. If no entry exists, OR if this specific issue is not yet documented:
+   Append a new entry using the template in LESSONS_LEARNED.md.
+
+3. This append MUST happen in the same commit as the code fix.
+   Never commit the fix without the lesson. Never commit the lesson without the fix.
+
+### Situation B: You are finishing ANY session that pushed to a PR branch
+
+SKIP this check if Situation A already ran in this session.
+Situation A is considered to have run if the session prompt contained
+any of: "address Copilot", "fix Copilot", "resolve Copilot", or
+explicitly referenced COPILOT_RESOLUTION_SKILL.md as the primary task.
+In that case, all lessons were already captured — do not re-fetch.
+
+At the end of every session that included a `git push origin <branch>`,
+run the following before declaring the session complete:
+
+```bash
+# Get the PR number for the current branch
+BRANCH=$(git branch --show-current)
+PR_NUMBER=$(gh pr list \
+  --repo irvinesunday/Hali \
+  --head "$BRANCH" \
+  --state open \
+  --json number \
+  --jq '.[0].number' 2>/dev/null)
+
+if [ -n "$PR_NUMBER" ]; then
+  echo "Checking PR #$PR_NUMBER for unrecorded Copilot comments..."
+
+  # Fetch all Copilot inline comments
+  gh api repos/irvinesunday/Hali/pulls/${PR_NUMBER}/comments \
+    --jq '.[] | select(.user.login | test("copilot";"i")) |
+          "COMMENT: " + .path + " | " + (.body | split("\n")[0])' \
+    2>/dev/null
+
+  # Fetch all Copilot review bodies
+  gh api repos/irvinesunday/Hali/pulls/${PR_NUMBER}/reviews \
+    --jq '.[] | select(.user.login | test("copilot";"i")) |
+          select(.body != "") |
+          "REVIEW: " + (.body | split("\n")[0])' \
+    2>/dev/null
+fi
+```
+
+If this output shows Copilot comments that are NOT yet in LESSONS_LEARNED.md:
+  - Append the lessons NOW, before the session ends
+  - Commit them to the current branch with message:
+    `docs: record Copilot lessons from PR #N`
+  - Push to the PR branch
+
+If the PR has no Copilot comments, or all are already recorded: continue normally.
+
+### What a lesson entry must contain
+
+```markdown
+## PR #N — [PR title]
+
+### Lesson [sequential number]: [one-line description]
+**File:** `path/to/file` (or "PR-level" if not file-specific)
+**What Copilot flagged:** [direct quote or close paraphrase]
+**Root cause:** [why did Claude Code generate this — be specific]
+**Fix applied:** [what changed]
+**Rule in CODING_STANDARDS.md:** [existing rule name, or "New rule added: [text]"]
+```
+
+### What counts as a lesson worth recording
+
+RECORD:
+- Any Copilot inline review comment on a file
+- Any Copilot PR-level review body with a specific concern
+- Any CI failure caused by code Claude Code generated
+
+DO NOT RECORD:
+- Copilot comments that say "Looks good" or are purely positive
+- Dependabot PR activity
+- Comments on files Claude Code did not touch in this PR

--- a/docs/arch/COPILOT_RESOLUTION_SKILL.md
+++ b/docs/arch/COPILOT_RESOLUTION_SKILL.md
@@ -240,9 +240,9 @@ PR_NUMBER=$(gh pr list \
   --head "$BRANCH" \
   --state open \
   --json number \
-  --jq '.[0].number' 2>/dev/null)
+  --jq '.[0].number // empty' 2>/dev/null)
 
-if [ -n "$PR_NUMBER" ]; then
+if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
   echo "Checking PR #$PR_NUMBER for unrecorded Copilot comments..."
 
   # Fetch all Copilot inline comments
@@ -278,7 +278,7 @@ If the PR has no Copilot comments, or all are already recorded: continue normall
 **What Copilot flagged:** [direct quote or close paraphrase]
 **Root cause:** [why did Claude Code generate this — be specific]
 **Fix applied:** [what changed]
-**Rule in CODING_STANDARDS.md:** [existing rule name, or "New rule added: [text]"]
+**Rule added:** [text of new rule or existing rule name this reinforces]
 ```
 
 ### What counts as a lesson worth recording

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -609,6 +609,31 @@ blocks, not indented prose.
 
 ---
 
+## PR #77 — chore(docs): wire lesson recording to every PR close point
+
+### Lesson 56: jq `// empty` guard needed when extracting PR number from gh pr list
+**File:** `docs/arch/COPILOT_RESOLUTION_SKILL.md`
+**What Copilot flagged:** `gh pr list ... --jq '.[0].number'` outputs the literal string `null` when no matching PR is found. Because `null` is non-empty, the subsequent `if [ -n "$PR_NUMBER" ]` guard passes and the script hits invalid API endpoints with `null` as the PR number.
+**Root cause:** Shell guard `[ -n "$VAR" ]` tests string non-emptiness, not JSON null. When jq produces `null` (a valid JSON output, not an empty string), the shell variable is set to the four-character string `"null"` and the guard incorrectly evaluates to true.
+**Fix applied:** Changed `--jq '.[0].number'` to `--jq '.[0].number // empty'` so jq emits nothing when the field is absent, and added `&& [ "$PR_NUMBER" != "null" ]` as a belt-and-suspenders guard against the literal string `"null"`.
+**Rule added:** When using `gh pr list ... --jq '.[0].field'` in shell scripts, always append `// empty` to the jq expression and guard the variable against the literal string `"null"` before use.
+
+### Lesson 57: Lesson template field names must match the canonical template in LESSONS_LEARNED.md
+**File:** `docs/arch/COPILOT_RESOLUTION_SKILL.md`
+**What Copilot flagged:** The lesson-entry template in the new Situation B section used `**Rule in CODING_STANDARDS.md:**` but the canonical template (LESSONS_LEARNED.md lines 12–19) uses `**Rule added:**`. Divergent field names break searchability and grep patterns that look for consistent headings.
+**Root cause:** The template was written ad hoc in the skill file without cross-checking the established template in LESSONS_LEARNED.md.
+**Fix applied:** Changed `**Rule in CODING_STANDARDS.md:** [existing rule name, or "New rule added: [text]"]` to `**Rule added:** [text of new rule or existing rule name this reinforces]` to match the canonical field name.
+**Rule added:** Any lesson-entry template written outside LESSONS_LEARNED.md must use identical field names to the canonical template — verify against the `## Template for future entries` block before publishing.
+
+### Lesson 58: File references in documentation must use full repo-relative paths
+**File:** `docs/arch/CODING_STANDARDS.md`
+**What Copilot flagged:** The new CI Failures checklist section referenced `LESSONS_LEARNED.md` without the repo-relative prefix, violating the rule already in CODING_STANDARDS.md: "File references in Markdown docs must use the full repo-relative path."
+**Root cause:** The rule exists as a checklist item but was not applied when writing the new section in the same file — Claude Code did not re-check the checklist against the new content before committing.
+**Fix applied:** Updated both bare `LESSONS_LEARNED.md` references to `docs/arch/LESSONS_LEARNED.md`.
+**Rule added:** Existing rule reinforced: "File references in Markdown docs must use the full repo-relative path, not just the filename."
+
+---
+
 ## Template for future entries
 
 Copy this block when adding a new lesson:


### PR DESCRIPTION
## Summary
Closes the gap where lessons were only captured reactively (when
explicitly asked to address Copilot comments). After this lands,
Claude Code performs an end-of-session check on every PR push and
records any Copilot findings not yet in LESSONS_LEARNED.md.

## The gap this closes
| Trigger | Before | After |
|---|---|---|
| Explicit 'address Copilot comments' prompt | ✅ recorded | ✅ recorded |
| CI failure fix | ❌ not recorded | ✅ recorded |
| Any session ending with git push | ❌ not recorded | ✅ recorded |

## Changes
- COPILOT_RESOLUTION_SKILL.md: Situation B end-of-session check added
- CODING_STANDARDS.md: CI failure lesson recording added to checklist
- CLAUDE.md: end-of-session check made mandatory for all sessions

## Checklist
- [ ] COPILOT_RESOLUTION_SKILL.md has Situation A and Situation B blocks
- [ ] CODING_STANDARDS.md has CI Failures section
- [ ] CLAUDE.md references end-of-session check
- [ ] No source files modified