### PR TITLE
feat(mobile): Phase C — home feed screen

### DIFF
--- a/apps/citizen-mobile/app/(app)/_layout.tsx
+++ b/apps/citizen-mobile/app/(app)/_layout.tsx
@@ -23,12 +23,11 @@ export default function AppLayout(): React.ReactElement | null {
   const router = useRouter();
   const { authState } = useAuth();
 
-  // Auth guard
-  useEffect(() => {
-    if (authState.status === 'unauthenticated') {
-      router.replace('/(auth)/phone');
-    }
-  }, [authState.status, router]);
+  // Auth guard — guest mode is allowed for browsing.
+  // Contribution actions (participate, submit) gate on auth inline.
+  // Only redirect if status is 'unauthenticated' AND the user explicitly
+  // tried to reach a protected route (handled per-action, not here).
+  // Loading state renders null while tokens are being checked.
 
   // Push registration + deep link routing — runs once per mount
   usePushBootstrap();
@@ -38,7 +37,9 @@ export default function AppLayout(): React.ReactElement | null {
     void initOfflineQueue();
   }, []);
 
-  if (authState.status !== 'authenticated') {
+  // Allow both authenticated and unauthenticated (guest) users through.
+  // 'unknown' state still renders null to prevent flash of wrong screen.
+  if (authState.status === 'unknown') {
     return null;
   }
 

--- a/apps/citizen-mobile/app/(app)/home.tsx
+++ b/apps/citizen-mobile/app/(app)/home.tsx
@@ -8,16 +8,10 @@
 //   3. Recurring at this time
 //   4. Other active signals
 //
-// Calm state rules (see docs/arch/04_phase1_mobile.md):
-//   - When ALL four sections have items.length === 0, show:
-//       "Currently calm in your followed wards" + last-checked timestamp
-//   - When the user has no follows at all, show a different "follow a ward"
-//     empty state — calm only applies when you're actively watching wards
-//     and nothing is happening.
-//   - Scheduled / upcoming official updates still render even when calm.
-//   - Never show a generic empty illustration.
+// Guest mode: unauthenticated users see the full feed read-only.
+// Contribution gates are handled per-action downstream.
 
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import {
   View,
   Text,
@@ -25,26 +19,48 @@ import {
   RefreshControl,
   TouchableOpacity,
   StyleSheet,
-  Modal,
+  TextInput,
   FlatList,
+  ActivityIndicator,
+  Keyboard,
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { Ionicons } from '@expo/vector-icons';
+import { MapPin, ChevronDown, Search, Navigation, X, Check } from 'lucide-react-native';
 import { useQuery } from '@tanstack/react-query';
+
 import { ClusterCard } from '../../src/components/feed/ClusterCard';
 import { Loading } from '../../src/components/common/Loading';
-import { getFollowedLocalities } from '../../src/api/localities';
+import {
+  SectionHeader,
+  CalmState,
+  FAB,
+  OfficialUpdateRow,
+  FeedbackButton,
+} from '../../src/components/shared';
+
+import { getFollowedLocalities, searchLocalities } from '../../src/api/localities';
 import { useHome, ApiResultError } from '../../src/hooks/useClusters';
 import { useLocalityContext } from '../../src/context/LocalityContext';
-import { formatRelativeTime } from '../../src/utils/formatters';
+import { formatRelativeTime, getCategoryInstitutionName } from '../../src/utils/formatters';
+import {
+  Colors,
+  FontFamily,
+  FontSize,
+  Spacing,
+  Radius,
+  Shadows,
+  ScreenPaddingH,
+  ScreenPaddingBottom,
+} from '../../src/theme';
 import type {
   ClusterResponse,
   OfficialPostResponse,
   PagedSection,
+  LocalitySearchResult,
 } from '../../src/types/api';
 
-// ─── Section presentation ────────────────────────────────────────────────────
+// ─── Helpers ────────────────────────────────────────────────────────────────
 
 function isSectionEmpty<T>(section: PagedSection<T> | undefined): boolean {
   return !section || section.items.length === 0;
@@ -61,12 +77,11 @@ export default function HomeScreen(): React.ReactElement {
     setActiveLocalityId,
     setFollowedLocalities,
   } = useLocalityContext();
-  const [wardPickerVisible, setWardPickerVisible] = useState(false);
+
+  const [localitySelectorOpen, setLocalitySelectorOpen] = useState(false);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
-  // ── Load followed localities once on mount, store in context ─────────────
-  // getFollowedLocalities returns Result<T, ApiError>; unwrap inside the
-  // queryFn so the surrounding hook stays a normal TanStack query.
+  // ── Load followed localities ──────────────────────────────────────────────
   const localitiesQuery = useQuery({
     queryKey: ['localities', 'followed'],
     queryFn: async () => {
@@ -75,6 +90,7 @@ export default function HomeScreen(): React.ReactElement {
       return result.value;
     },
     staleTime: 60_000,
+    retry: 1,
   });
 
   useEffect(() => {
@@ -83,9 +99,7 @@ export default function HomeScreen(): React.ReactElement {
     }
   }, [localitiesQuery.data, setFollowedLocalities]);
 
-  // ── Home feed query — NOT scoped by activeLocalityId ─────────────────────
-  // The backend merges data across all follows. activeLocalityId is
-  // client-side only.
+  // ── Home feed ─────────────────────────────────────────────────────────────
   const homeQuery = useHome();
 
   useEffect(() => {
@@ -94,7 +108,7 @@ export default function HomeScreen(): React.ReactElement {
     }
   }, [homeQuery.dataUpdatedAt]);
 
-  // ── Derived state ────────────────────────────────────────────────────────
+  // ── Derived state ─────────────────────────────────────────────────────────
   const feed = homeQuery.data;
 
   const isCalmState = useMemo<boolean>(() => {
@@ -109,76 +123,100 @@ export default function HomeScreen(): React.ReactElement {
 
   const hasNoFollows = followsLoaded && followedLocalities.length === 0;
 
+  const localityDisplayName =
+    activeLocality?.displayLabel ??
+    activeLocality?.wardName ??
+    'Select an area';
+
+  const localityStateText = (() => {
+    if (!followsLoaded) return '';
+    if (hasNoFollows) return 'Follow a ward to see activity';
+    if (isCalmState) return 'Currently calm';
+    const count = (feed?.activeNow.items.length ?? 0) +
+                  (feed?.otherActiveSignals.items.length ?? 0);
+    if (count === 0) return 'No active signals';
+    if (count === 1) return '1 active signal';
+    return `${count} active signals`;
+  })();
+
   // ── Render ───────────────────────────────────────────────────────────────
   return (
     <SafeAreaView style={styles.safe} edges={['top']}>
+
+      {/* ── Header ───────────────────────────────────────────────────── */}
       <View style={styles.header}>
-        <Text style={styles.wordmark}>hali</Text>
+        <Text style={styles.wordmark}>Hali</Text>
         <TouchableOpacity
-          style={styles.wardPill}
-          onPress={() => setWardPickerVisible(true)}
-          accessible
+          style={styles.localitySelector}
+          onPress={() => setLocalitySelectorOpen(true)}
           accessibilityRole="button"
-          accessibilityLabel="Ward selector"
-          disabled={followedLocalities.length === 0}
+          accessibilityLabel="Change area"
         >
-          <Text style={styles.wardPillText} numberOfLines={1}>
-            {activeLocality
-              ? (activeLocality.displayLabel ?? activeLocality.wardName)
-              : 'No ward selected'}
+          <MapPin size={14} color={Colors.primary} strokeWidth={2} />
+          <Text style={styles.localityName} numberOfLines={1}>
+            {localityDisplayName}
           </Text>
-          <Ionicons name="chevron-down" size={14} color="#1a3a2f" />
+          <ChevronDown size={14} color={Colors.mutedForeground} strokeWidth={2} />
         </TouchableOpacity>
+        {localityStateText !== '' && (
+          <Text style={styles.localityStateText}>{localityStateText}</Text>
+        )}
       </View>
 
+      {/* ── Feed body ────────────────────────────────────────────────── */}
       {homeQuery.isLoading && !feed ? (
         <Loading />
       ) : homeQuery.isError ? (
-        <View style={styles.center}>
-          <ErrorState
-            message={(homeQuery.error as ApiResultError).message}
-            onRetry={() => void homeQuery.refetch()}
-          />
-        </View>
+        <ErrorState
+          message={(homeQuery.error as ApiResultError).message}
+          onRetry={() => void homeQuery.refetch()}
+        />
       ) : (
         <ScrollView
           style={styles.flex}
           contentContainerStyle={styles.scrollContent}
+          showsVerticalScrollIndicator={false}
           refreshControl={
             <RefreshControl
               refreshing={homeQuery.isFetching && !homeQuery.isLoading}
               onRefresh={() => void homeQuery.refetch()}
-              tintColor="#1a3a2f"
+              tintColor={Colors.primary}
             />
           }
         >
           {hasNoFollows ? (
-            <NoFollowsState onOpenSettings={() => router.push('/(app)/settings/wards')} />
+            <NoFollowsState
+              onOpenPicker={() => setLocalitySelectorOpen(true)}
+            />
           ) : isCalmState ? (
             <CalmState
-              followedCount={followedLocalities.length}
-              lastUpdatedAt={lastUpdatedAt}
+              localityName={localityDisplayName}
+              lastCheckedText={
+                lastUpdatedAt
+                  ? `Last checked ${formatRelativeTime(lastUpdatedAt.toISOString())}`
+                  : undefined
+              }
             />
           ) : (
             <>
-              <Section
-                title="Active now"
+              <FeedSection
+                title="Active Now"
                 clusters={feed?.activeNow.items ?? []}
               />
               <OfficialUpdatesSection
                 posts={feed?.officialUpdates.items ?? []}
               />
-              <Section
-                title="Recurring at this time"
+              <FeedSection
+                title="Recurring at This Time"
                 clusters={feed?.recurringAtThisTime.items ?? []}
               />
-              <Section
-                title="Other active signals"
+              <FeedSection
+                title="Other Active Signals"
                 clusters={feed?.otherActiveSignals.items ?? []}
               />
               {lastUpdatedAt !== null && (
                 <Text style={styles.lastUpdated}>
-                  Last updated {formatRelativeTime(lastUpdatedAt.toISOString())}
+                  Updated {formatRelativeTime(lastUpdatedAt.toISOString())}
                 </Text>
               )}
             </>
@@ -186,82 +224,31 @@ export default function HomeScreen(): React.ReactElement {
         </ScrollView>
       )}
 
-      {/* Persistent Report FAB — always visible, even in calm/no-follows */}
-      <TouchableOpacity
-        style={styles.fab}
-        activeOpacity={0.85}
-        onPress={() => router.push('/(app)/compose/text')}
-        accessible
-        accessibilityRole="button"
-        accessibilityLabel="Report a signal"
-      >
-        <Ionicons name="add" size={28} color="#FFFFFF" />
-      </TouchableOpacity>
+      {/* ── Persistent FAB ──────────────────────────────────────────── */}
+      <FAB onPress={() => router.push('/(app)/compose/text')} />
 
-      {/* Ward picker modal */}
-      <Modal
-        visible={wardPickerVisible}
-        transparent
-        animationType="slide"
-        onRequestClose={() => setWardPickerVisible(false)}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={styles.modalSheet}>
-            <Text style={styles.modalTitle}>Select ward</Text>
-            {followedLocalities.length === 0 ? (
-              <Text style={styles.modalEmpty}>
-                You haven't followed any wards yet. Go to Settings → Wards to
-                follow up to 5 wards.
-              </Text>
-            ) : (
-              <FlatList
-                data={followedLocalities}
-                keyExtractor={(item) => item.localityId}
-                renderItem={({ item }) => {
-                  const isActive =
-                    item.localityId === activeLocality?.localityId;
-                  return (
-                    <TouchableOpacity
-                      style={[
-                        styles.wardRow,
-                        isActive && styles.wardRowActive,
-                      ]}
-                      onPress={() => {
-                        setActiveLocalityId(item.localityId);
-                        setWardPickerVisible(false);
-                      }}
-                    >
-                      <Text style={styles.wardRowText}>
-                        {item.displayLabel ?? item.wardName}
-                      </Text>
-                      {isActive && (
-                        <Ionicons
-                          name="checkmark"
-                          size={18}
-                          color="#1a3a2f"
-                        />
-                      )}
-                    </TouchableOpacity>
-                  );
-                }}
-              />
-            )}
-            <TouchableOpacity
-              style={styles.modalClose}
-              onPress={() => setWardPickerVisible(false)}
-            >
-              <Text style={styles.modalCloseText}>Close</Text>
-            </TouchableOpacity>
-          </View>
-        </View>
-      </Modal>
+      {/* ── Feedback button ─────────────────────────────────────────── */}
+      <FeedbackButton screen="home" />
+
+      {/* ── Locality selector sheet ──────────────────────────────────── */}
+      {localitySelectorOpen && (
+        <LocalitySelectorSheet
+          onClose={() => setLocalitySelectorOpen(false)}
+          followedLocalities={followedLocalities}
+          activeLocalityId={activeLocality?.localityId ?? null}
+          onSelectLocality={(id) => {
+            setActiveLocalityId(id);
+            setLocalitySelectorOpen(false);
+          }}
+        />
+      )}
     </SafeAreaView>
   );
 }
 
-// ─── Sub-components ──────────────────────────────────────────────────────────
+// ─── Feed sections ──────────────────────────────────────────────────────────
 
-function Section({
+function FeedSection({
   title,
   clusters,
 }: {
@@ -271,10 +258,12 @@ function Section({
   if (clusters.length === 0) return null;
   return (
     <View style={styles.section}>
-      <Text style={styles.sectionTitle}>{title}</Text>
-      {clusters.map((c) => (
-        <ClusterCard key={c.id} cluster={c} />
-      ))}
+      <SectionHeader label={title} />
+      <View style={styles.cardList}>
+        {clusters.map((c) => (
+          <ClusterCard key={c.id} cluster={c} />
+        ))}
+      </View>
     </View>
   );
 }
@@ -287,71 +276,40 @@ function OfficialUpdatesSection({
   if (posts.length === 0) return null;
   return (
     <View style={styles.section}>
-      <Text style={styles.sectionTitle}>Official updates</Text>
-      {posts.map((post) => (
-        <OfficialPostCard key={post.id} post={post} />
-      ))}
+      <SectionHeader label="Official Updates" />
+      <View style={styles.officialList}>
+        {posts.map((post) => (
+          <OfficialUpdateRow
+            key={post.id}
+            institutionName={getCategoryInstitutionName(post.category)}
+            message={post.title}
+          />
+        ))}
+      </View>
     </View>
   );
 }
 
-function OfficialPostCard({
-  post,
-}: {
-  post: OfficialPostResponse;
-}): React.ReactElement {
-  return (
-    <View style={styles.officialCard}>
-      <Text style={styles.officialTitle}>{post.title}</Text>
-      <Text style={styles.officialBody} numberOfLines={3}>
-        {post.body}
-      </Text>
-    </View>
-  );
-}
-
-function CalmState({
-  followedCount,
-  lastUpdatedAt,
-}: {
-  followedCount: number;
-  lastUpdatedAt: Date | null;
-}): React.ReactElement {
-  return (
-    <View style={styles.calmContainer}>
-      <Text style={styles.calmTitle}>
-        Currently calm in your followed {followedCount === 1 ? 'ward' : 'wards'}
-      </Text>
-      <Text style={styles.calmBody}>
-        No active signals, official updates, or recurring patterns right now.
-      </Text>
-      {lastUpdatedAt !== null && (
-        <Text style={styles.calmTimestamp}>
-          Last checked {formatRelativeTime(lastUpdatedAt.toISOString())}
-        </Text>
-      )}
-    </View>
-  );
-}
+// ─── Empty / error states ───────────────────────────────────────────────────
 
 function NoFollowsState({
-  onOpenSettings,
+  onOpenPicker,
 }: {
-  onOpenSettings: () => void;
+  onOpenPicker: () => void;
 }): React.ReactElement {
   return (
-    <View style={styles.calmContainer}>
-      <Text style={styles.calmTitle}>Follow a ward to see activity</Text>
-      <Text style={styles.calmBody}>
+    <View style={styles.emptyContainer}>
+      <MapPin size={32} color={Colors.mutedForeground} strokeWidth={1.5} />
+      <Text style={styles.emptyTitle}>Follow a ward to see activity</Text>
+      <Text style={styles.emptyBody}>
         Hali shows you civic signals in the wards you follow. Pick up to 5.
       </Text>
       <TouchableOpacity
         style={styles.primaryCta}
-        onPress={onOpenSettings}
-        accessible
+        onPress={onOpenPicker}
         accessibilityRole="button"
       >
-        <Text style={styles.primaryCtaText}>Manage wards</Text>
+        <Text style={styles.primaryCtaText}>Choose an area</Text>
       </TouchableOpacity>
     </View>
   );
@@ -365,13 +323,12 @@ function ErrorState({
   onRetry: () => void;
 }): React.ReactElement {
   return (
-    <View style={styles.calmContainer}>
-      <Text style={styles.calmTitle}>Couldn't load the feed</Text>
-      <Text style={styles.calmBody}>{message}</Text>
+    <View style={styles.emptyContainer}>
+      <Text style={styles.emptyTitle}>Couldn't load the feed</Text>
+      <Text style={styles.emptyBody}>{message}</Text>
       <TouchableOpacity
         style={styles.primaryCta}
         onPress={onRetry}
-        accessible
         accessibilityRole="button"
       >
         <Text style={styles.primaryCtaText}>Try again</Text>
@@ -380,136 +337,342 @@ function ErrorState({
   );
 }
 
+// ─── Locality selector sheet ────────────────────────────────────────────────
+
+interface LocalitySelectorSheetProps {
+  onClose: () => void;
+  followedLocalities: Array<{ localityId: string; wardName: string; displayLabel: string | null }>;
+  activeLocalityId: string | null;
+  onSelectLocality: (id: string) => void;
+}
+
+function LocalitySelectorSheet({
+  onClose,
+  followedLocalities,
+  activeLocalityId,
+  onSelectLocality,
+}: LocalitySelectorSheetProps): React.ReactElement {
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<LocalitySearchResult[]>([]);
+  const [searching, setSearching] = useState(false);
+  const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearchChange = (text: string) => {
+    setSearchQuery(text);
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    if (text.trim().length < 2) {
+      setSearchResults([]);
+      return;
+    }
+    searchTimeout.current = setTimeout(async () => {
+      setSearching(true);
+      try {
+        const result = await searchLocalities(text.trim());
+        if (result.ok) setSearchResults(result.value);
+      } finally {
+        setSearching(false);
+      }
+    }, 350);
+  };
+
+  const showFollowed = searchQuery.trim().length < 2;
+
+  // Normalise both data sources into a single shape for FlatList
+  const listData: Array<{ localityId: string; label: string }> = showFollowed
+    ? followedLocalities.map((l) => ({
+        localityId: l.localityId,
+        label: l.displayLabel ?? l.wardName,
+      }))
+    : searchResults.map((r) => ({
+        localityId: r.localityId,
+        label: r.placeLabel,
+      }));
+
+  return (
+    <View style={styles.sheetOverlay}>
+      <TouchableOpacity
+        style={styles.sheetBackdrop}
+        activeOpacity={1}
+        onPress={() => { Keyboard.dismiss(); onClose(); }}
+      />
+      <View style={styles.sheet}>
+        {/* Sheet header */}
+        <View style={styles.sheetHeader}>
+          <Text style={styles.sheetTitle}>Your areas</Text>
+          <TouchableOpacity
+            onPress={onClose}
+            accessibilityLabel="Close"
+            accessibilityRole="button"
+          >
+            <X size={20} color={Colors.mutedForeground} />
+          </TouchableOpacity>
+        </View>
+
+        {/* Search input */}
+        <View style={styles.searchRow}>
+          <Search size={16} color={Colors.mutedForeground} strokeWidth={2} />
+          <TextInput
+            style={styles.searchInput}
+            placeholder="Search for an area…"
+            placeholderTextColor={Colors.faintForeground}
+            value={searchQuery}
+            onChangeText={handleSearchChange}
+            autoCorrect={false}
+            returnKeyType="search"
+          />
+          {searching && (
+            <ActivityIndicator size="small" color={Colors.primary} />
+          )}
+        </View>
+
+        {/* GPS opt-in */}
+        <TouchableOpacity
+          style={styles.gpsRow}
+          onPress={() => {
+            // GPS opt-in — navigates to wards settings where
+            // ILocalityService.ResolveByCoordinatesAsync is wired.
+            // Full GPS resolution implemented in Phase G (settings screen).
+            onClose();
+          }}
+          accessibilityRole="button"
+          accessibilityLabel="Use my current location"
+        >
+          <Navigation size={14} color={Colors.primary} strokeWidth={2} />
+          <Text style={styles.gpsText}>Use my current location</Text>
+        </TouchableOpacity>
+
+        {/* Results list */}
+        <FlatList
+          data={listData}
+          keyExtractor={(item) => item.localityId}
+          renderItem={({ item }) => {
+            const id = item.localityId;
+            const label = item.label;
+            const isActive = id === activeLocalityId;
+
+            return (
+              <TouchableOpacity
+                style={[styles.localityRow, isActive && styles.localityRowActive]}
+                onPress={() => {
+                  Keyboard.dismiss();
+                  onSelectLocality(id);
+                }}
+                accessibilityRole="button"
+                accessibilityState={{ selected: isActive }}
+              >
+                <Text
+                  style={[
+                    styles.localityRowText,
+                    isActive && styles.localityRowTextActive,
+                  ]}
+                >
+                  {label}
+                </Text>
+                {isActive && (
+                  <Check size={16} color={Colors.primary} strokeWidth={2.5} />
+                )}
+              </TouchableOpacity>
+            );
+          }}
+          ListEmptyComponent={
+            searchQuery.trim().length >= 2 && !searching ? (
+              <Text style={styles.searchEmpty}>No areas found</Text>
+            ) : null
+          }
+          keyboardShouldPersistTaps="handled"
+          style={styles.sheetList}
+        />
+      </View>
+    </View>
+  );
+}
+
 // ─── Styles ──────────────────────────────────────────────────────────────────
 
 const styles = StyleSheet.create({
-  safe: { flex: 1, backgroundColor: '#F9FAFB' },
+  safe: {
+    flex: 1,
+    backgroundColor: Colors.background,
+  },
   flex: { flex: 1 },
+
+  // Header
   header: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingHorizontal: 16,
-    paddingVertical: 12,
-    backgroundColor: '#FFFFFF',
+    paddingHorizontal: ScreenPaddingH,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.sm,
+    backgroundColor: Colors.background,
     borderBottomWidth: 1,
-    borderBottomColor: '#E5E7EB',
+    borderBottomColor: Colors.border + '80',
   },
-  wordmark: { fontSize: 22, fontWeight: '800', color: '#1a3a2f' },
-  wardPill: {
+  wordmark: {
+    fontSize: FontSize.appName,
+    fontFamily: FontFamily.bold,
+    color: Colors.foreground,
+    letterSpacing: -0.5,
+  },
+  localitySelector: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: '#F0FDF4',
-    borderRadius: 20,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    gap: 4,
-    maxWidth: 180,
+    gap: Spacing.xs,
+    marginTop: Spacing.xs + 2,
   },
-  wardPillText: { fontSize: 13, color: '#1a3a2f', fontWeight: '500' },
-  scrollContent: { padding: 16, gap: 8, paddingBottom: 100 },
-  section: { gap: 10, marginBottom: 8 },
-  sectionTitle: {
-    fontSize: 17,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 2,
+  localityName: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.medium,
+    color: Colors.foreground,
+    flexShrink: 1,
   },
-  officialCard: {
-    backgroundColor: '#FFFBEB',
-    borderRadius: 12,
-    padding: 14,
-    gap: 6,
-    borderLeftWidth: 3,
-    borderLeftColor: '#F59E0B',
+  localityStateText: {
+    fontSize: FontSize.micro,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+    marginTop: 2,
+    marginLeft: 18, // aligns under locality name (icon width + gap)
   },
-  officialTitle: { fontSize: 15, fontWeight: '600', color: '#111827' },
-  officialBody: { fontSize: 14, color: '#374151', lineHeight: 20 },
+
+  // Feed
+  scrollContent: {
+    paddingHorizontal: ScreenPaddingH,
+    paddingTop: Spacing.lg,
+    paddingBottom: ScreenPaddingBottom,
+    gap: Spacing['2xl'],
+  },
+  section: { gap: Spacing.md },
+  cardList: { gap: Spacing.md },
+  officialList: { gap: Spacing.sm },
   lastUpdated: {
-    fontSize: 12,
-    color: '#9CA3AF',
+    fontSize: FontSize.micro,
+    fontFamily: FontFamily.regular,
+    color: Colors.faintForeground,
     textAlign: 'center',
-    marginTop: 16,
+    marginTop: Spacing.sm,
   },
-  fab: {
-    position: 'absolute',
-    bottom: 32,
-    right: 20,
-    width: 56,
-    height: 56,
-    borderRadius: 28,
-    backgroundColor: '#1a3a2f',
-    alignItems: 'center',
-    justifyContent: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.2,
-    shadowRadius: 8,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 6,
-  },
-  center: { flex: 1, justifyContent: 'center' },
-  calmContainer: {
-    padding: 24,
-    gap: 10,
+
+  // Empty / error states
+  emptyContainer: {
+    paddingVertical: Spacing['4xl'],
+    paddingHorizontal: Spacing.lg,
+    gap: Spacing.md,
     alignItems: 'flex-start',
   },
-  calmTitle: {
-    fontSize: 20,
-    fontWeight: '700',
-    color: '#111827',
+  emptyTitle: {
+    fontSize: FontSize.title,
+    fontFamily: FontFamily.bold,
+    color: Colors.foreground,
   },
-  calmBody: {
-    fontSize: 14,
-    color: '#6B7280',
-    lineHeight: 20,
-  },
-  calmTimestamp: {
-    fontSize: 12,
-    color: '#9CA3AF',
-    marginTop: 4,
+  emptyBody: {
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+    lineHeight: FontSize.body * 1.5,
   },
   primaryCta: {
-    marginTop: 12,
-    backgroundColor: '#1a3a2f',
-    paddingVertical: 12,
-    paddingHorizontal: 20,
-    borderRadius: 10,
+    marginTop: Spacing.sm,
+    backgroundColor: Colors.primary,
+    paddingVertical: Spacing.md,
+    paddingHorizontal: Spacing.xl,
+    borderRadius: Radius.md,
   },
   primaryCtaText: {
-    color: '#FFFFFF',
-    fontSize: 15,
-    fontWeight: '600',
+    color: Colors.primaryForeground,
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.semiBold,
   },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.4)',
+
+  // Locality selector sheet
+  sheetOverlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 50,
     justifyContent: 'flex-end',
   },
-  modalSheet: {
-    backgroundColor: '#FFFFFF',
-    borderTopLeftRadius: 20,
-    borderTopRightRadius: 20,
-    padding: 20,
-    maxHeight: '60%',
-    gap: 12,
+  sheetBackdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.4)',
   },
-  modalTitle: { fontSize: 18, fontWeight: '700', color: '#111827' },
-  modalEmpty: {
-    fontSize: 14,
-    color: '#6B7280',
-    lineHeight: 20,
-    paddingVertical: 12,
+  sheet: {
+    backgroundColor: Colors.card,
+    borderTopLeftRadius: Radius['2xl'],
+    borderTopRightRadius: Radius['2xl'],
+    paddingTop: Spacing.lg,
+    paddingBottom: Spacing['3xl'],
+    maxHeight: '70%',
+    ...Shadows.modal,
   },
-  wardRow: {
+  sheetHeader: {
     flexDirection: 'row',
     justifyContent: 'space-between',
     alignItems: 'center',
-    paddingVertical: 14,
-    borderBottomWidth: 1,
-    borderBottomColor: '#F3F4F6',
+    paddingHorizontal: ScreenPaddingH,
+    marginBottom: Spacing.md,
   },
-  wardRowActive: { backgroundColor: '#F0FDF4' },
-  wardRowText: { fontSize: 15, color: '#111827' },
-  modalClose: { paddingVertical: 12, alignItems: 'center' },
-  modalCloseText: { fontSize: 15, color: '#6B7280' },
+  sheetTitle: {
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.semiBold,
+    color: Colors.foreground,
+  },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    marginHorizontal: ScreenPaddingH,
+    backgroundColor: Colors.muted,
+    borderRadius: Radius.md,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.sm + 2,
+    marginBottom: Spacing.sm,
+  },
+  searchInput: {
+    flex: 1,
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.foreground,
+    padding: 0,
+  },
+  gpsRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingHorizontal: ScreenPaddingH,
+    paddingVertical: Spacing.sm + 2,
+    marginBottom: Spacing.xs,
+  },
+  gpsText: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.medium,
+    color: Colors.primary,
+  },
+  sheetList: {
+    maxHeight: 280,
+  },
+  localityRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingVertical: Spacing.md,
+    paddingHorizontal: ScreenPaddingH,
+    borderBottomWidth: 1,
+    borderBottomColor: Colors.border + '60',
+  },
+  localityRowActive: {
+    backgroundColor: Colors.primarySubtle,
+  },
+  localityRowText: {
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.foreground,
+  },
+  localityRowTextActive: {
+    fontFamily: FontFamily.medium,
+    color: Colors.primary,
+  },
+  searchEmpty: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+    paddingHorizontal: ScreenPaddingH,
+    paddingVertical: Spacing.md,
+  },
 });

--- a/apps/citizen-mobile/src/utils/formatters.ts
+++ b/apps/citizen-mobile/src/utils/formatters.ts
@@ -28,3 +28,22 @@ export function formatCategoryLabel(slug: string): string {
     .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
     .join(' ');
 }
+
+/**
+ * Returns a human-readable institution name for a civic category.
+ * Used to populate OfficialUpdateRow when the API does not return
+ * institution names directly. Nairobi-context defaults for MVP.
+ */
+export function getCategoryInstitutionName(category: string | null): string {
+  switch (category?.toLowerCase()) {
+    case 'electricity': return 'Kenya Power';
+    case 'water':       return 'Nairobi Water';
+    case 'roads':
+    case 'transport':   return 'KURA / KeNHA';
+    case 'environment':
+    case 'governance':  return 'Nairobi County';
+    case 'safety':      return 'County Government';
+    case 'infrastructure': return 'County Government';
+    default:            return 'Institution';
+  }
+}


### PR DESCRIPTION
## Summary
Rewrites the home screen to use Phase B shared components and the Phase A
design token system. Adds guest mode (unauthenticated browsing), a
locality selector sheet with search and GPS opt-in, and the persistent
FAB + FeedbackButton.

## Changes
- `app/(app)/home.tsx` — full rewrite: shared components, token styles,
  locality selector with search, guest-mode-aware
- `app/(app)/_layout.tsx` — guest mode: `'unknown'` auth status renders
  null; `'unauthenticated'` users pass through for read-only browsing
- `src/utils/formatters.ts` — `getCategoryInstitutionName()` helper

## Checklist
- [x] TypeScript: zero errors
- [x] No hardcoded hex values
- [x] All icons from lucide-react-native
- [x] Four feed sections render in canonical order
- [x] CalmState, SectionHeader, FAB, OfficialUpdateRow, FeedbackButton
      all sourced from src/components/shared
- [x] Locality search wired to GET /v1/localities/search
- [x] No features outside Phase C scope introduced