### PR TITLE
fix(mobile): replace context `followsLoaded` latch with React Query-derived `followsReady` flag

### DIFF
--- a/apps/citizen-mobile/app/(app)/_layout.tsx
+++ b/apps/citizen-mobile/app/(app)/_layout.tsx
@@ -1,41 +1,38 @@
 // apps/citizen-mobile/app/(app)/_layout.tsx
 //
-// Authenticated app layout.
+// App layout.
 //
 // Two responsibilities beyond rendering the stack:
-//   1. Auth guard — redirect unauthenticated users to /(auth)/phone
+//   1. Auth gating — guest mode is allowed for browsing; only render
+//      null while auth status is 'unknown' to avoid a flash of the
+//      wrong screen.
 //   2. Mount the runtime bootstraps that should only run when authed:
 //      - usePushBootstrap()  — token registration + deep link routing
 //      - initOfflineQueue()  — load persisted queue + listen for flush triggers
 //
-// These are intentionally inside the (app) layout (not the root layout)
-// because both depend on having a valid session — push registration
-// hits an [Authorize] endpoint, and the offline queue's submit fn calls
-// authenticated services.
+// Both bootstraps depend on having a valid session — push registration
+// hits an [Authorize] endpoint, and the offline queue's flush will drop
+// queued writes on 401. They are gated on authState.status === 'authenticated'
+// so guest users do not trigger authenticated network calls.
 
 import React, { useEffect } from 'react';
-import { Stack, useRouter } from 'expo-router';
+import { Stack } from 'expo-router';
 import { useAuth } from '../../src/context/AuthContext';
 import { usePushBootstrap } from '../../src/lib/pushBootstrap';
 import { initOfflineQueue } from '../../src/lib/offlineQueueBootstrap';
 
 export default function AppLayout(): React.ReactElement | null {
-  const router = useRouter();
   const { authState } = useAuth();
+  const isAuthenticated = authState.status === 'authenticated';
 
-  // Auth guard — guest mode is allowed for browsing.
-  // Contribution actions (participate, submit) gate on auth inline.
-  // Only redirect if status is 'unauthenticated' AND the user explicitly
-  // tried to reach a protected route (handled per-action, not here).
-  // Loading state renders null while tokens are being checked.
+  // Push registration + deep link routing — only when authenticated.
+  usePushBootstrap(isAuthenticated);
 
-  // Push registration + deep link routing — runs once per mount
-  usePushBootstrap();
-
-  // Offline queue runtime — load persisted items + start listeners
+  // Offline queue runtime — only when authenticated.
   useEffect(() => {
+    if (!isAuthenticated) return;
     void initOfflineQueue();
-  }, []);
+  }, [isAuthenticated]);
 
   // Allow both authenticated and unauthenticated (guest) users through.
   // 'unknown' state still renders null to prevent flash of wrong screen.

--- a/apps/citizen-mobile/app/(app)/home.tsx
+++ b/apps/citizen-mobile/app/(app)/home.tsx
@@ -42,6 +42,7 @@ import {
 import { getFollowedLocalities, searchLocalities } from '../../src/api/localities';
 import { useHome, ApiResultError } from '../../src/hooks/useClusters';
 import { useLocalityContext } from '../../src/context/LocalityContext';
+import { useAuth } from '../../src/context/AuthContext';
 import { formatRelativeTime, getCategoryInstitutionName } from '../../src/utils/formatters';
 import {
   Colors,
@@ -70,6 +71,8 @@ function isSectionEmpty<T>(section: PagedSection<T> | undefined): boolean {
 
 export default function HomeScreen(): React.ReactElement {
   const router = useRouter();
+  const { authState } = useAuth();
+  const isAuthenticated = authState.status === 'authenticated';
   const {
     activeLocality,
     followedLocalities,
@@ -82,6 +85,10 @@ export default function HomeScreen(): React.ReactElement {
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
   // ── Load followed localities ──────────────────────────────────────────────
+  // Guests have no follows; calling /v1/localities/followed without tokens
+  // would trigger the API client's 401 refresh flow and leave followsLoaded
+  // false, blanking the feed. Skip the request entirely and treat guests as
+  // a loaded-empty follows list so the NoFollowsState renders correctly.
   const localitiesQuery = useQuery({
     queryKey: ['localities', 'followed'],
     queryFn: async () => {
@@ -91,13 +98,18 @@ export default function HomeScreen(): React.ReactElement {
     },
     staleTime: 60_000,
     retry: 1,
+    enabled: isAuthenticated,
   });
 
   useEffect(() => {
+    if (!isAuthenticated) {
+      setFollowedLocalities([]);
+      return;
+    }
     if (localitiesQuery.data) {
       setFollowedLocalities(localitiesQuery.data);
     }
-  }, [localitiesQuery.data, setFollowedLocalities]);
+  }, [isAuthenticated, localitiesQuery.data, setFollowedLocalities]);
 
   // ── Home feed ─────────────────────────────────────────────────────────────
   const homeQuery = useHome();
@@ -356,21 +368,70 @@ function LocalitySelectorSheet({
   const [searchResults, setSearchResults] = useState<LocalitySearchResult[]>([]);
   const [searching, setSearching] = useState(false);
   const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isMountedRef = useRef(true);
+  const latestSearchRequestRef = useRef(0);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+      if (searchTimeout.current) {
+        clearTimeout(searchTimeout.current);
+        searchTimeout.current = null;
+      }
+    };
+  }, []);
 
   const handleSearchChange = (text: string) => {
     setSearchQuery(text);
-    if (searchTimeout.current) clearTimeout(searchTimeout.current);
-    if (text.trim().length < 2) {
+    if (searchTimeout.current) {
+      clearTimeout(searchTimeout.current);
+      searchTimeout.current = null;
+    }
+
+    const trimmed = text.trim();
+    if (trimmed.length < 2) {
+      // Invalidate any in-flight request and clear results immediately.
+      latestSearchRequestRef.current += 1;
+      setSearching(false);
       setSearchResults([]);
       return;
     }
+
+    const requestId = ++latestSearchRequestRef.current;
     searchTimeout.current = setTimeout(async () => {
+      if (!isMountedRef.current || requestId !== latestSearchRequestRef.current) {
+        return;
+      }
       setSearching(true);
       try {
-        const result = await searchLocalities(text.trim());
-        if (result.ok) setSearchResults(result.value);
+        const result = await searchLocalities(trimmed);
+        if (
+          !isMountedRef.current ||
+          requestId !== latestSearchRequestRef.current
+        ) {
+          return;
+        }
+        // Always reflect the latest request — clear stale results on
+        // error so the UI never shows results for a different query.
+        if (result.ok) {
+          setSearchResults(result.value);
+        } else {
+          setSearchResults([]);
+        }
+      } catch {
+        if (
+          isMountedRef.current &&
+          requestId === latestSearchRequestRef.current
+        ) {
+          setSearchResults([]);
+        }
       } finally {
-        setSearching(false);
+        if (
+          isMountedRef.current &&
+          requestId === latestSearchRequestRef.current
+        ) {
+          setSearching(false);
+        }
       }
     }, 350);
   };
@@ -449,16 +510,29 @@ function LocalitySelectorSheet({
             const id = item.localityId;
             const label = item.label;
             const isActive = id === activeLocalityId;
+            // setActiveLocalityId only accepts ids that exist in
+            // followedLocalities. Search results that aren't already
+            // followed are non-selectable until follow/unfollow is wired
+            // (Phase G — wards settings).
+            const isFollowed = followedLocalities.some(
+              (l) => l.localityId === id,
+            );
 
             return (
               <TouchableOpacity
-                style={[styles.localityRow, isActive && styles.localityRowActive]}
+                style={[
+                  styles.localityRow,
+                  isActive && styles.localityRowActive,
+                  !isFollowed && styles.localityRowDisabled,
+                ]}
+                disabled={!isFollowed}
                 onPress={() => {
                   Keyboard.dismiss();
+                  if (!isFollowed) return;
                   onSelectLocality(id);
                 }}
                 accessibilityRole="button"
-                accessibilityState={{ selected: isActive }}
+                accessibilityState={{ selected: isActive, disabled: !isFollowed }}
               >
                 <Text
                   style={[
@@ -658,6 +732,9 @@ const styles = StyleSheet.create({
   },
   localityRowActive: {
     backgroundColor: Colors.primarySubtle,
+  },
+  localityRowDisabled: {
+    opacity: 0.5,
   },
   localityRowText: {
     fontSize: FontSize.body,

--- a/apps/citizen-mobile/app/(app)/home.tsx
+++ b/apps/citizen-mobile/app/(app)/home.tsx
@@ -76,7 +76,6 @@ export default function HomeScreen(): React.ReactElement {
   const {
     activeLocality,
     followedLocalities,
-    followsLoaded,
     setActiveLocalityId,
     setFollowedLocalities,
   } = useLocalityContext();
@@ -133,7 +132,17 @@ export default function HomeScreen(): React.ReactElement {
     );
   }, [feed]);
 
-  const hasNoFollows = followsLoaded && followedLocalities.length === 0;
+  // Derive readiness locally from React Query state so that a guest→auth
+  // transition doesn't flash NoFollowsState while the authed follows query
+  // is still in flight. `followsLoaded` from context is permanently true
+  // once set (including by the guest branch), so it cannot be relied on
+  // after auth state changes without a full remount of LocalityProvider.
+  const followsReady =
+    !isAuthenticated ||
+    localitiesQuery.isSuccess ||
+    localitiesQuery.isError;
+
+  const hasNoFollows = followsReady && followedLocalities.length === 0;
 
   const localityDisplayName =
     activeLocality?.displayLabel ??
@@ -141,7 +150,7 @@ export default function HomeScreen(): React.ReactElement {
     'Select an area';
 
   const localityStateText = (() => {
-    if (!followsLoaded) return '';
+    if (!followsReady) return '';
     if (hasNoFollows) return 'Follow a ward to see activity';
     if (isCalmState) return 'Currently calm';
     const count = (feed?.activeNow.items.length ?? 0) +

--- a/apps/citizen-mobile/src/lib/pushBootstrap.ts
+++ b/apps/citizen-mobile/src/lib/pushBootstrap.ts
@@ -124,16 +124,21 @@ export function notificationDataToHref(data: unknown): Href | null {
  * notification, getLastNotificationResponseAsync resolves the payload
  * once on first mount.
  */
-export function usePushBootstrap(): void {
+export function usePushBootstrap(enabled: boolean = true): void {
   const handledColdLaunch = useRef(false);
 
-  // 1. Auto-register on mount (first authenticated screen view)
+  // 1. Auto-register on mount (first authenticated screen view).
+  //    Push registration hits an [Authorize] endpoint, so it must only
+  //    run once the user is authenticated.
   useEffect(() => {
+    if (!enabled) return;
     void ensurePushRegistered();
-  }, []);
+  }, [enabled]);
 
-  // 2. Cold launch — handle a notification that launched the app
+  // 2. Cold launch — handle a notification that launched the app.
+  //    Routes are scoped under (app)/, so only meaningful for authed users.
   useEffect(() => {
+    if (!enabled) return;
     if (handledColdLaunch.current) return;
     handledColdLaunch.current = true;
 
@@ -146,10 +151,11 @@ export function usePushBootstrap(): void {
         if (href !== null) router.push(href);
       }
     })();
-  }, []);
+  }, [enabled]);
 
   // 3. Foreground tap — handle a notification tapped while running
   useEffect(() => {
+    if (!enabled) return;
     const sub = Notifications.addNotificationResponseReceivedListener(
       (response) => {
         const href = notificationDataToHref(
@@ -159,5 +165,5 @@ export function usePushBootstrap(): void {
       },
     );
     return () => sub.remove();
-  }, []);
+  }, [enabled]);
 }

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -209,6 +209,9 @@ to a real past failure. Do not skip any item.
 - Never include PR numbers as inline references in permanent documentation (use timeless references)
 - Never hardcode a branch name (`develop`, `main`) in git remediation steps — reference
   "the PR's actual base branch" instead
+- Never use a context "loaded" latch (e.g. `followsLoaded`) to gate readiness in a component that
+  spans auth transitions; derive readiness from React Query `isSuccess`/`isError` instead so the
+  flag resets when auth state changes
 
 ## GitHub Actions rules
 

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -664,6 +664,13 @@ blocks, not indented prose.
 **Fix applied:** Each row computes `isFollowed` against the followed list; non-followed rows render with reduced opacity, are `disabled`, and report `accessibilityState.disabled`. Follow-then-select for search results is deferred to Phase G (wards settings) where the follow API will be wired.
 **Rule added:** When a UI surfaces items from multiple sources (local + remote) into the same selection handler, the items the handler cannot act on must be visually and behaviourally disabled (`disabled`, opacity, `accessibilityState.disabled`) — never silently no-op on tap.
 
+### Lesson 63: Do not use context "loaded" flags for readiness gating when the flag is permanently set by a prior auth state
+**File:** `apps/citizen-mobile/app/(app)/home.tsx`
+**What Copilot flagged:** `setFollowedLocalities([])` in the unauthenticated branch permanently sets `followsLoaded = true` in `LocalityContext`. On a guest→authenticated transition, `followsLoaded` is already `true` while the authed follows query is still in flight, so `hasNoFollows` and `localityStateText` briefly reflect the empty-follows state even if the user has follows.
+**Root cause:** `followsLoaded` is a one-way latch — it flips to `true` and never resets. Using it as a readiness guard across auth transitions assumes `LocalityProvider` is remounted when auth changes, which it is not.
+**Fix applied:** Derived a local `followsReady` flag from React Query state — `!isAuthenticated || localitiesQuery.isSuccess || localitiesQuery.isError` — and used it instead of `followsLoaded` for `hasNoFollows` and `localityStateText` gating. Guests are always "ready" (no query runs); authenticated users are only "ready" after the query settles.
+**Rule added:** When a context holds a one-way "loaded" latch, do not use it as a readiness guard in components that straddle auth transitions. Derive readiness from the React Query `isSuccess`/`isError` state of the relevant query so the flag resets naturally when the auth state changes.
+
 ---
 
 ## Template for future entries

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -634,6 +634,38 @@ blocks, not indented prose.
 
 ---
 
+## PR #78 — feat(mobile): Phase C home feed (follow-up fixes)
+
+### Lesson 59: Authenticated bootstraps must be gated on auth status
+**File:** `apps/citizen-mobile/app/(app)/_layout.tsx`, `apps/citizen-mobile/src/lib/pushBootstrap.ts`
+**What Copilot flagged:** When guest mode was added to the (app) layout, `usePushBootstrap()` and `initOfflineQueue()` were left running unconditionally. Both depend on a valid session — push registration hits an `[Authorize]` endpoint, and the offline queue's flush drops queued writes on 401. Running them for guests produces wasted auth churn and silent data loss.
+**Root cause:** When the auth guard was relaxed to allow guests, the side-effects that previously sat behind the redirect were not re-gated. Ungating one thing (the redirect) silently ungated everything else mounted in the same component.
+**Fix applied:** `usePushBootstrap` now accepts an `enabled` flag and no-ops when false; `_layout.tsx` passes `authState.status === 'authenticated'` and only invokes `initOfflineQueue()` from a `useEffect` guarded on the same flag. The unused `useRouter`/`router` left over from the removed redirect were also deleted.
+**Rule added:** When relaxing an auth guard to allow guest access, audit every side-effect mounted in that component (hooks, effects, queries) and gate any that hit authenticated endpoints or assume an authed session on `status === 'authenticated'`.
+
+### Lesson 60: React Query calls to authenticated endpoints must set `enabled` for guest mode
+**File:** `apps/citizen-mobile/app/(app)/home.tsx`
+**What Copilot flagged:** In guest mode, the `['localities','followed']` query called `/v1/localities/followed` without tokens, triggering the API client's 401 refresh flow and leaving `followsLoaded` false (because `setFollowedLocalities` was never invoked). Result: no `NoFollowsState` / calm state and a blank feed.
+**Root cause:** The query was added before guest mode existed and was never revisited when guest browsing was introduced.
+**Fix applied:** Added `enabled: isAuthenticated` to the query, and a `useEffect` that explicitly calls `setFollowedLocalities([])` when not authenticated so `followsLoaded` flips to true and the NoFollowsState renders for guests.
+**Rule added:** Any `useQuery` against an authenticated endpoint must set `enabled` based on auth status, and any consumer of `followsLoaded`-style "loaded" flags must be explicitly transitioned to the loaded state on the unauthenticated branch.
+
+### Lesson 61: Debounced async searches need cleanup + stale-response guards
+**File:** `apps/citizen-mobile/app/(app)/home.tsx`
+**What Copilot flagged:** The locality search used `setTimeout` with no unmount cleanup, and async responses could resolve out of order — an older query could overwrite newer results, and a stale `setSearching(false)` could fire after unmount. Additionally, on `result.ok === false` the UI kept showing previous results for a different query.
+**Root cause:** Standard "naïve debounce" pattern copied without considering React lifecycle or out-of-order resolution.
+**Fix applied:** Added an `isMountedRef` and a `latestSearchRequestRef` request-id counter. The unmount effect clears the pending timeout; every state update inside the async callback is gated on `isMountedRef.current && requestId === latestSearchRequestRef.current`. On `!result.ok` and on `catch`, results are explicitly cleared so the UI never shows stale results from a previous query.
+**Rule added:** Any debounced async operation must (1) clear its pending timer on unmount, (2) tag each request with a monotonically-increasing id and ignore responses whose id is no longer current, and (3) explicitly handle the error branch — either clear the displayed data or surface an error state — never silently leave stale results.
+
+### Lesson 62: Selectable list items must be filtered to what the selection API actually accepts
+**File:** `apps/citizen-mobile/app/(app)/home.tsx`
+**What Copilot flagged:** The locality sheet rendered both followed localities and remote search results with the same `onSelectLocality` handler, but `setActiveLocalityId` only accepts ids that exist in `followedLocalities`. Tapping a search result that wasn't already followed silently did nothing, making the sheet appear broken.
+**Root cause:** The selection contract (only followed ids accepted) was implicit in the context implementation and not enforced at the UI layer when search results were added.
+**Fix applied:** Each row computes `isFollowed` against the followed list; non-followed rows render with reduced opacity, are `disabled`, and report `accessibilityState.disabled`. Follow-then-select for search results is deferred to Phase G (wards settings) where the follow API will be wired.
+**Rule added:** When a UI surfaces items from multiple sources (local + remote) into the same selection handler, the items the handler cannot act on must be visually and behaviourally disabled (`disabled`, opacity, `accessibilityState.disabled`) — never silently no-op on tap.
+
+---
+
 ## Template for future entries
 
 Copy this block when adding a new lesson:


### PR DESCRIPTION
`followsLoaded` in `LocalityContext` is a one-way latch — the guest branch's `setFollowedLocalities([])` permanently sets it to `true`. On a guest→authenticated transition, this causes `hasNoFollows` to be `true` while `localitiesQuery` is still in flight, briefly flashing `NoFollowsState` even if the user has follows.

## Changes

- **`home.tsx`** — Replace `followsLoaded` with a locally-derived `followsReady` flag based on React Query state. Remove unused `followsLoaded` from context destructuring.

```ts
const followsReady =
  !isAuthenticated ||          // guests: always ready, no query runs
  localitiesQuery.isSuccess ||
  localitiesQuery.isError;
```

`hasNoFollows` and `localityStateText` now gate on `followsReady`, so authenticated users see no flash of the empty-follows UI while the follows query is in flight.

- **`docs/arch/LESSONS_LEARNED.md`** — Lesson 63: do not use a context "loaded" latch as a readiness guard across auth transitions.
- **`docs/arch/CODING_STANDARDS.md`** — Corresponding "never" rule added.