### PR TITLE
feat(mobile): Phase F — auth screens token migration

### DIFF
--- a/apps/citizen-mobile/app/(auth)/otp.tsx
+++ b/apps/citizen-mobile/app/(auth)/otp.tsx
@@ -235,6 +235,7 @@ export default function OtpScreen(): React.ReactElement {
               label={STRINGS.AUTH.OTP_SUBMIT}
               onPress={handleSubmit}
               accessibilityLabel={STRINGS.AUTH.OTP_SUBMIT_LABEL}
+              style={styles.submitButton}
             />
           )}
 
@@ -322,6 +323,7 @@ const styles = StyleSheet.create({
     color: Colors.foreground,
   },
   loadingIndicator: { marginVertical: Spacing.sm },
+  submitButton: { alignSelf: 'stretch' },
   errorText: {
     fontSize: FontSize.bodySmall,
     fontFamily: FontFamily.regular,

--- a/apps/citizen-mobile/app/(auth)/otp.tsx
+++ b/apps/citizen-mobile/app/(auth)/otp.tsx
@@ -314,7 +314,7 @@ const styles = StyleSheet.create({
   },
   otpBoxError: {
     borderColor: Colors.destructive,
-    backgroundColor: Colors.destructive + '10',
+    backgroundColor: Colors.destructiveSubtle,
   },
   otpChar: {
     fontSize: 22,

--- a/apps/citizen-mobile/app/(auth)/otp.tsx
+++ b/apps/citizen-mobile/app/(auth)/otp.tsx
@@ -18,64 +18,54 @@ import {
   Platform,
 } from 'react-native';
 import { router, useLocalSearchParams } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
+import { ArrowLeft } from 'lucide-react-native';
 import * as Device from 'expo-device';
 import * as Application from 'expo-application';
 import * as Crypto from 'expo-crypto';
 import { verifyOtp } from '../../src/api/auth';
 import { useAuth } from '../../src/context/AuthContext';
+import { Button } from '../../src/components/common/Button';
 import { STRINGS } from '../../src/config/strings';
 import { decodeAccountIdFromJwt } from '../../src/utils/jwt';
+import {
+  Colors,
+  FontFamily,
+  FontSize,
+  Spacing,
+  Radius,
+  ScreenPaddingH,
+} from '../../src/theme';
 
 type ScreenState = 'idle' | 'loading' | 'error';
-
 const OTP_LENGTH = 6;
 
-/**
- * Derive a stable device fingerprint hash using expo-crypto.
- * Uses Expo Device / Application identifiers that are available without
- * extra permissions. Returns a SHA-256 hex digest of the joined parts.
- *
- * NOTE: Do NOT use Node's `Buffer` in React Native — it is not available
- * in Hermes without a polyfill. Use expo-crypto instead.
- */
 async function getDeviceFingerprintHash(): Promise<string> {
-  const parts: string[] = [
+  const parts = [
     Device.modelName ?? 'unknown',
     Device.osName ?? 'unknown',
     Device.osVersion ?? 'unknown',
     Device.brand ?? 'unknown',
     Application.applicationId ?? 'unknown',
   ];
-  const joined = parts.join('|');
   return Crypto.digestStringAsync(
     Crypto.CryptoDigestAlgorithm.SHA256,
-    joined,
+    parts.join('|'),
   );
-}
-
-function getPlatform(): string {
-  return Platform.OS; // 'ios' | 'android' | 'web'
-}
-
-function getAppVersion(): string {
-  return Application.nativeApplicationVersion ?? '1.0.0';
 }
 
 export default function OtpScreen(): React.ReactElement {
   const { destination } = useLocalSearchParams<{ destination: string }>();
   const { signIn } = useAuth();
 
-  const [otp, setOtp] = useState<string>('');
+  const [otp, setOtp] = useState('');
   const [screenState, setScreenState] = useState<ScreenState>('idle');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState('');
 
   const inputRef = useRef<TextInput>(null);
 
-  // Auto-focus on mount
   useEffect(() => {
-    const timer = setTimeout(() => {
-      inputRef.current?.focus();
-    }, 300);
+    const timer = setTimeout(() => inputRef.current?.focus(), 300);
     return () => clearTimeout(timer);
   }, []);
 
@@ -102,13 +92,11 @@ export default function OtpScreen(): React.ReactElement {
       destination,
       otp,
       deviceFingerprintHash,
-      platform: getPlatform(),
-      appVersion: getAppVersion(),
+      platform: Platform.OS,
+      appVersion: Application.nativeApplicationVersion ?? '1.0.0',
     });
 
     if (result.ok) {
-      // The backend's /v1/auth/verify response does NOT include accountId —
-      // it's embedded in the JWT `sub` claim. Decode it client-side.
       const accountId = decodeAccountIdFromJwt(result.value.accessToken);
       if (accountId === null) {
         setScreenState('error');
@@ -138,10 +126,7 @@ export default function OtpScreen(): React.ReactElement {
     setTimeout(() => inputRef.current?.focus(), 100);
   }, [otp, screenState, destination, signIn]);
 
-  // Auto-submit when 6 digits are entered.
-  // Dependency list is intentionally narrow — depending on `otp.length` rather
-  // than the full `otp` string avoids recreating the effect on each keystroke.
-  // handleSubmit is guarded by the length and screenState checks above.
+  // Auto-submit on 6th digit
   const otpLength = otp.length;
   useEffect(() => {
     if (otpLength === OTP_LENGTH && screenState === 'idle') {
@@ -156,138 +141,151 @@ export default function OtpScreen(): React.ReactElement {
       : destination ?? '';
 
   return (
-    <KeyboardAvoidingView
-      style={styles.flex}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-    >
-      <View style={styles.container}>
-        <Text style={styles.title}>{STRINGS.AUTH.OTP_TITLE}</Text>
-        <Text style={styles.subtitle}>
-          {STRINGS.AUTH.OTP_SUBTITLE_PREFIX}
-          <Text style={styles.destinationText}>{maskedDestination}</Text>
-        </Text>
-
-        {/* Hidden input that captures the keyboard */}
-        <TextInput
-          ref={inputRef}
-          style={styles.hiddenInput}
-          value={otp}
-          onChangeText={(text) => {
-            const clean = text.replace(/\D/g, '').slice(0, OTP_LENGTH);
-            setOtp(clean);
-            if (screenState === 'error') {
-              setScreenState('idle');
-              setErrorMessage('');
-            }
-          }}
-          keyboardType="number-pad"
-          maxLength={OTP_LENGTH}
-          autoComplete="one-time-code"
-          textContentType="oneTimeCode"
-          importantForAutofill="yes"
-          accessible
-          accessibilityLabel={STRINGS.AUTH.OTP_INPUT_LABEL}
-          editable={screenState !== 'loading'}
-        />
-
-        {/* Visible OTP boxes */}
-        <View style={styles.otpBoxRow}>
-          {Array.from({ length: OTP_LENGTH }).map((_, i) => {
-            const char = otp[i] ?? '';
-            const isActive = i === otp.length && screenState !== 'loading';
-            return (
-              <TouchableOpacity
-                key={i}
-                style={[
-                  styles.otpBox,
-                  isActive && styles.otpBoxActive,
-                  screenState === 'error' && styles.otpBoxError,
-                ]}
-                onPress={() => inputRef.current?.focus()}
-                accessible={false}
-              >
-                <Text style={styles.otpChar}>
-                  {screenState === 'loading' && char !== '' ? '•' : char}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
-        </View>
-
-        {screenState === 'loading' && (
-          <ActivityIndicator
-            style={styles.loadingIndicator}
-            color="#1a3a2f"
-            size="small"
-            accessible
-            accessibilityLabel={STRINGS.AUTH.OTP_VERIFYING}
-          />
-        )}
-
-        {screenState === 'error' && errorMessage !== '' && (
-          <Text
-            style={styles.errorText}
-            accessible
-            accessibilityRole="alert"
-            accessibilityLiveRegion="polite"
-          >
-            {errorMessage}
-          </Text>
-        )}
-
-        {/* Manual submit fallback if auto-submit fails */}
-        {screenState !== 'loading' && otp.length === OTP_LENGTH && (
-          <TouchableOpacity
-            style={styles.button}
-            onPress={handleSubmit}
-            accessible
-            accessibilityRole="button"
-            accessibilityLabel={STRINGS.AUTH.OTP_SUBMIT_LABEL}
-          >
-            <Text style={styles.buttonText}>{STRINGS.AUTH.OTP_SUBMIT}</Text>
-          </TouchableOpacity>
-        )}
-
+    <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        {/* Back button */}
         <TouchableOpacity
-          style={styles.resendContainer}
+          style={styles.backButton}
           onPress={() => router.back()}
-          accessible
+          hitSlop={12}
           accessibilityRole="button"
-          accessibilityLabel={STRINGS.AUTH.OTP_RESEND}
+          accessibilityLabel="Back to phone entry"
         >
-          <Text style={styles.resendText}>{STRINGS.AUTH.OTP_RESEND}</Text>
+          <ArrowLeft size={24} color={Colors.foreground} strokeWidth={2} />
         </TouchableOpacity>
-      </View>
-    </KeyboardAvoidingView>
+
+        <View style={styles.container}>
+          <Text style={styles.title}>{STRINGS.AUTH.OTP_TITLE}</Text>
+          <Text style={styles.subtitle}>
+            {STRINGS.AUTH.OTP_SUBTITLE_PREFIX}
+            <Text style={styles.destinationText}>{maskedDestination}</Text>
+          </Text>
+
+          {/* Hidden input captures the keyboard */}
+          <TextInput
+            ref={inputRef}
+            style={styles.hiddenInput}
+            value={otp}
+            onChangeText={(text) => {
+              const clean = text.replace(/\D/g, '').slice(0, OTP_LENGTH);
+              setOtp(clean);
+              if (screenState === 'error') {
+                setScreenState('idle');
+                setErrorMessage('');
+              }
+            }}
+            keyboardType="number-pad"
+            maxLength={OTP_LENGTH}
+            autoComplete="one-time-code"
+            textContentType="oneTimeCode"
+            importantForAutofill="yes"
+            accessibilityLabel={STRINGS.AUTH.OTP_INPUT_LABEL}
+            editable={screenState !== 'loading'}
+          />
+
+          {/* Visible OTP digit boxes */}
+          <View style={styles.otpBoxRow}>
+            {Array.from({ length: OTP_LENGTH }).map((_, i) => {
+              const char = otp[i] ?? '';
+              const isActive = i === otp.length && screenState !== 'loading';
+              return (
+                <TouchableOpacity
+                  key={i}
+                  style={[
+                    styles.otpBox,
+                    isActive && styles.otpBoxActive,
+                    screenState === 'error' && styles.otpBoxError,
+                  ]}
+                  onPress={() => inputRef.current?.focus()}
+                  accessible={false}
+                >
+                  <Text style={styles.otpChar}>
+                    {screenState === 'loading' && char !== '' ? '•' : char}
+                  </Text>
+                </TouchableOpacity>
+              );
+            })}
+          </View>
+
+          {screenState === 'loading' && (
+            <ActivityIndicator
+              style={styles.loadingIndicator}
+              color={Colors.primary}
+              size="small"
+              accessibilityLabel={STRINGS.AUTH.OTP_VERIFYING}
+            />
+          )}
+
+          {screenState === 'error' && errorMessage !== '' && (
+            <Text
+              style={styles.errorText}
+              accessibilityRole="alert"
+              accessibilityLiveRegion="polite"
+            >
+              {errorMessage}
+            </Text>
+          )}
+
+          {/* Manual submit fallback */}
+          {screenState !== 'loading' && otp.length === OTP_LENGTH && (
+            <Button
+              label={STRINGS.AUTH.OTP_SUBMIT}
+              onPress={handleSubmit}
+              accessibilityLabel={STRINGS.AUTH.OTP_SUBMIT_LABEL}
+            />
+          )}
+
+          <TouchableOpacity
+            style={styles.resendContainer}
+            onPress={() => router.back()}
+            accessibilityRole="button"
+            accessibilityLabel={STRINGS.AUTH.OTP_RESEND}
+          >
+            <Text style={styles.resendText}>{STRINGS.AUTH.OTP_RESEND}</Text>
+          </TouchableOpacity>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: '#FFFFFF' },
+  safe: { flex: 1, backgroundColor: Colors.card },
+  flex: { flex: 1 },
+  backButton: {
+    paddingHorizontal: ScreenPaddingH,
+    paddingTop: Spacing.md,
+    paddingBottom: Spacing.xs,
+    alignSelf: 'flex-start',
+  },
   container: {
     flex: 1,
-    paddingHorizontal: 24,
-    paddingTop: 64,
-    paddingBottom: 32,
+    paddingHorizontal: ScreenPaddingH,
+    paddingTop: Spacing['2xl'],
+    paddingBottom: Spacing['3xl'],
     alignItems: 'center',
   },
   title: {
     fontSize: 28,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 8,
+    fontFamily: FontFamily.bold,
+    color: Colors.foreground,
+    marginBottom: Spacing.sm,
     alignSelf: 'flex-start',
   },
   subtitle: {
-    fontSize: 15,
-    color: '#6B7280',
-    marginBottom: 40,
-    lineHeight: 22,
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+    marginBottom: Spacing['3xl'],
+    lineHeight: FontSize.body * 1.5,
     alignSelf: 'flex-start',
   },
   destinationText: {
-    color: '#111827',
-    fontWeight: '600',
+    fontFamily: FontFamily.semiBold,
+    color: Colors.foreground,
   },
   hiddenInput: {
     position: 'absolute',
@@ -297,62 +295,47 @@ const styles = StyleSheet.create({
   },
   otpBoxRow: {
     flexDirection: 'row',
-    gap: 10,
-    marginBottom: 24,
+    gap: Spacing.sm + 2,
+    marginBottom: Spacing['2xl'],
   },
   otpBox: {
     width: 48,
     height: 56,
     borderWidth: 1.5,
-    borderColor: '#D1D5DB',
-    borderRadius: 8,
+    borderColor: Colors.border,
+    borderRadius: Radius.sm,
     justifyContent: 'center',
     alignItems: 'center',
-    backgroundColor: '#F9FAFB',
+    backgroundColor: Colors.muted,
   },
   otpBoxActive: {
-    borderColor: '#1a3a2f',
-    backgroundColor: '#F0FDF4',
+    borderColor: Colors.primary,
+    backgroundColor: Colors.primarySubtle,
   },
   otpBoxError: {
-    borderColor: '#DC2626',
-    backgroundColor: '#FEF2F2',
+    borderColor: Colors.destructive,
+    backgroundColor: Colors.destructive + '10',
   },
   otpChar: {
     fontSize: 22,
-    fontWeight: '700',
-    color: '#111827',
+    fontFamily: FontFamily.bold,
+    color: Colors.foreground,
   },
-  loadingIndicator: {
-    marginVertical: 8,
-  },
+  loadingIndicator: { marginVertical: Spacing.sm },
   errorText: {
-    fontSize: 14,
-    color: '#DC2626',
-    marginBottom: 16,
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.destructive,
+    marginBottom: Spacing.lg,
     textAlign: 'center',
   },
-  button: {
-    backgroundColor: '#1a3a2f',
-    borderRadius: 10,
-    paddingVertical: 16,
-    paddingHorizontal: 48,
-    alignItems: 'center',
-    marginBottom: 16,
-    width: '100%',
-  },
-  buttonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
-  },
   resendContainer: {
-    marginTop: 8,
-    padding: 8,
+    marginTop: Spacing.md,
+    padding: Spacing.sm,
   },
   resendText: {
-    fontSize: 14,
-    color: '#1a3a2f',
-    fontWeight: '500',
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.medium,
+    color: Colors.primary,
   },
 });

--- a/apps/citizen-mobile/app/(auth)/phone.tsx
+++ b/apps/citizen-mobile/app/(auth)/phone.tsx
@@ -9,31 +9,34 @@ import {
   View,
   Text,
   TextInput,
-  TouchableOpacity,
-  ActivityIndicator,
   StyleSheet,
   KeyboardAvoidingView,
   Platform,
 } from 'react-native';
 import { router } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
 import { requestOtp } from '../../src/api/auth';
+import { Button } from '../../src/components/common/Button';
 import { STRINGS } from '../../src/config/strings';
+import { normaliseKenyaPhone, isValidKenyaPhoneInput } from '../../src/utils/phone';
 import {
-  normaliseKenyaPhone,
-  isValidKenyaPhoneInput,
-} from '../../src/utils/phone';
+  Colors,
+  FontFamily,
+  FontSize,
+  Spacing,
+  Radius,
+  ScreenPaddingH,
+} from '../../src/theme';
 
 type ScreenState = 'idle' | 'loading' | 'error';
-
 const KENYA_PREFIX = '+254';
 
 export default function PhoneScreen(): React.ReactElement {
-  const [phoneInput, setPhoneInput] = useState<string>('');
+  const [phoneInput, setPhoneInput] = useState('');
   const [screenState, setScreenState] = useState<ScreenState>('idle');
-  const [errorMessage, setErrorMessage] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState('');
 
-  const isSubmittable =
-    screenState !== 'loading' && isValidKenyaPhoneInput(phoneInput);
+  const isSubmittable = screenState !== 'loading' && isValidKenyaPhoneInput(phoneInput);
 
   async function handleSubmit(): Promise<void> {
     const destination = normaliseKenyaPhone(phoneInput);
@@ -42,21 +45,13 @@ export default function PhoneScreen(): React.ReactElement {
     setScreenState('loading');
     setErrorMessage('');
 
-    const result = await requestOtp({
-      destination,
-      authMethod: 'phone_otp',
-    });
+    const result = await requestOtp({ destination, authMethod: 'phone_otp' });
 
     if (result.ok) {
       setScreenState('idle');
-      router.push({
-        pathname: '/(auth)/otp',
-        params: { destination },
-      });
+      router.push({ pathname: '/(auth)/otp', params: { destination } });
     } else {
       setScreenState('error');
-      // Auth rate limit comes back as HTTP 429 with { error: "..." } —
-      // no code field, so we detect by status instead.
       setErrorMessage(
         result.error.status === 429
           ? STRINGS.AUTH.OTP_RATE_LIMIT
@@ -66,157 +61,135 @@ export default function PhoneScreen(): React.ReactElement {
   }
 
   return (
-    <KeyboardAvoidingView
-      style={styles.flex}
-      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-    >
-      <View style={styles.container}>
-        <Text style={styles.title}>{STRINGS.AUTH.PHONE_TITLE}</Text>
-        <Text style={styles.subtitle}>{STRINGS.AUTH.PHONE_SUBTITLE}</Text>
+    <SafeAreaView style={styles.safe} edges={['top', 'bottom']}>
+      <KeyboardAvoidingView
+        style={styles.flex}
+        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      >
+        <View style={styles.container}>
+          <Text style={styles.title}>{STRINGS.AUTH.PHONE_TITLE}</Text>
+          <Text style={styles.subtitle}>{STRINGS.AUTH.PHONE_SUBTITLE}</Text>
 
-        <View style={styles.inputRow}>
-          <View
-            style={styles.prefixContainer}
-            accessible
-            accessibilityLabel="Country code Kenya plus two five four"
-          >
-            <Text style={styles.prefixText}>{KENYA_PREFIX}</Text>
+          <View style={styles.inputRow}>
+            <View
+              style={styles.prefixContainer}
+              accessible
+              accessibilityLabel="Country code Kenya plus two five four"
+            >
+              <Text style={styles.prefixText}>{KENYA_PREFIX}</Text>
+            </View>
+            <TextInput
+              style={styles.input}
+              value={phoneInput}
+              onChangeText={(text) => {
+                setPhoneInput(text);
+                if (screenState === 'error') {
+                  setScreenState('idle');
+                  setErrorMessage('');
+                }
+              }}
+              keyboardType="phone-pad"
+              placeholder={STRINGS.AUTH.PHONE_PLACEHOLDER}
+              placeholderTextColor={Colors.faintForeground}
+              maxLength={12}
+              returnKeyType="done"
+              onSubmitEditing={isSubmittable ? handleSubmit : undefined}
+              autoFocus
+              accessibilityLabel={STRINGS.AUTH.PHONE_INPUT_LABEL}
+              accessibilityHint={STRINGS.AUTH.PHONE_INPUT_HINT}
+              editable={screenState !== 'loading'}
+            />
           </View>
-          <TextInput
-            style={styles.input}
-            value={phoneInput}
-            onChangeText={(text) => {
-              setPhoneInput(text);
-              if (screenState === 'error') {
-                setScreenState('idle');
-                setErrorMessage('');
-              }
-            }}
-            keyboardType="phone-pad"
-            placeholder={STRINGS.AUTH.PHONE_PLACEHOLDER}
-            placeholderTextColor="#9CA3AF"
-            maxLength={12}
-            returnKeyType="done"
-            onSubmitEditing={isSubmittable ? handleSubmit : undefined}
-            autoFocus
-            accessible
-            accessibilityLabel={STRINGS.AUTH.PHONE_INPUT_LABEL}
-            accessibilityHint={STRINGS.AUTH.PHONE_INPUT_HINT}
-            editable={screenState !== 'loading'}
-          />
-        </View>
 
-        {screenState === 'error' && errorMessage !== '' && (
-          <Text
-            style={styles.errorText}
-            accessible
-            accessibilityRole="alert"
-            accessibilityLiveRegion="polite"
-          >
-            {errorMessage}
-          </Text>
-        )}
-
-        <TouchableOpacity
-          style={[styles.button, !isSubmittable && styles.buttonDisabled]}
-          onPress={handleSubmit}
-          disabled={!isSubmittable}
-          accessible
-          accessibilityRole="button"
-          accessibilityLabel={STRINGS.AUTH.PHONE_SUBMIT_LABEL}
-          accessibilityState={{
-            disabled: !isSubmittable,
-            busy: screenState === 'loading',
-          }}
-        >
-          {screenState === 'loading' ? (
-            <ActivityIndicator color="#FFFFFF" size="small" />
-          ) : (
-            <Text style={styles.buttonText}>{STRINGS.AUTH.PHONE_SUBMIT}</Text>
+          {screenState === 'error' && errorMessage !== '' && (
+            <Text
+              style={styles.errorText}
+              accessibilityRole="alert"
+              accessibilityLiveRegion="polite"
+            >
+              {errorMessage}
+            </Text>
           )}
-        </TouchableOpacity>
 
-        <Text style={styles.note}>{STRINGS.AUTH.PHONE_NOTE}</Text>
-      </View>
-    </KeyboardAvoidingView>
+          <Button
+            label={STRINGS.AUTH.PHONE_SUBMIT}
+            onPress={handleSubmit}
+            disabled={!isSubmittable}
+            loading={screenState === 'loading'}
+          />
+
+          <Text style={styles.note}>{STRINGS.AUTH.PHONE_NOTE}</Text>
+        </View>
+      </KeyboardAvoidingView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
-  flex: { flex: 1, backgroundColor: '#FFFFFF' },
+  safe: { flex: 1, backgroundColor: Colors.card },
+  flex: { flex: 1 },
   container: {
     flex: 1,
-    paddingHorizontal: 24,
-    paddingTop: 64,
-    paddingBottom: 32,
+    paddingHorizontal: ScreenPaddingH,
+    paddingTop: Spacing['4xl'],
+    paddingBottom: Spacing['3xl'],
   },
   title: {
     fontSize: 28,
-    fontWeight: '700',
-    color: '#111827',
-    marginBottom: 8,
+    fontFamily: FontFamily.bold,
+    color: Colors.foreground,
+    marginBottom: Spacing.sm,
   },
   subtitle: {
-    fontSize: 15,
-    color: '#6B7280',
-    marginBottom: 32,
-    lineHeight: 22,
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+    marginBottom: Spacing['3xl'],
+    lineHeight: FontSize.body * 1.5,
   },
   inputRow: {
     flexDirection: 'row',
     borderWidth: 1.5,
-    borderColor: '#D1D5DB',
-    borderRadius: 10,
+    borderColor: Colors.border,
+    borderRadius: Radius.md,
     overflow: 'hidden',
-    marginBottom: 8,
+    marginBottom: Spacing.sm,
   },
   prefixContainer: {
-    backgroundColor: '#F3F4F6',
-    paddingHorizontal: 14,
-    paddingVertical: 14,
+    backgroundColor: Colors.muted,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.lg,
     justifyContent: 'center',
     borderRightWidth: 1,
-    borderRightColor: '#D1D5DB',
+    borderRightColor: Colors.border,
   },
   prefixText: {
-    fontSize: 16,
-    color: '#374151',
-    fontWeight: '600',
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.semiBold,
+    color: Colors.foreground,
   },
   input: {
     flex: 1,
     fontSize: 18,
-    paddingHorizontal: 14,
-    paddingVertical: 14,
-    color: '#111827',
+    fontFamily: FontFamily.regular,
+    paddingHorizontal: Spacing.lg,
+    paddingVertical: Spacing.lg,
+    color: Colors.foreground,
     letterSpacing: 0.5,
   },
   errorText: {
-    fontSize: 14,
-    color: '#DC2626',
-    marginBottom: 12,
-    marginTop: 4,
-  },
-  button: {
-    backgroundColor: '#1a3a2f',
-    borderRadius: 10,
-    paddingVertical: 16,
-    alignItems: 'center',
-    marginTop: 8,
-  },
-  buttonDisabled: {
-    backgroundColor: '#9CA3AF',
-  },
-  buttonText: {
-    color: '#FFFFFF',
-    fontSize: 16,
-    fontWeight: '600',
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.destructive,
+    marginBottom: Spacing.md,
+    marginTop: Spacing.xs,
   },
   note: {
-    fontSize: 13,
-    color: '#9CA3AF',
-    marginTop: 20,
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.faintForeground,
+    marginTop: Spacing.xl,
     textAlign: 'center',
-    lineHeight: 19,
+    lineHeight: FontSize.bodySmall * 1.5,
   },
 });

--- a/apps/citizen-mobile/app/(auth)/phone.tsx
+++ b/apps/citizen-mobile/app/(auth)/phone.tsx
@@ -116,6 +116,12 @@ export default function PhoneScreen(): React.ReactElement {
             onPress={handleSubmit}
             disabled={!isSubmittable}
             loading={screenState === 'loading'}
+            accessibilityRole="button"
+            accessibilityLabel={STRINGS.AUTH.PHONE_SUBMIT_LABEL}
+            accessibilityState={{
+              disabled: !isSubmittable,
+              busy: screenState === 'loading',
+            }}
           />
 
           <Text style={styles.note}>{STRINGS.AUTH.PHONE_NOTE}</Text>

--- a/apps/citizen-mobile/expo-env.d.ts
+++ b/apps/citizen-mobile/expo-env.d.ts
@@ -1,3 +1,0 @@
-/// <reference types="expo/types" />
-
-// NOTE: This file should not be edited and should be in your git ignore

--- a/apps/citizen-mobile/expo-env.d.ts
+++ b/apps/citizen-mobile/expo-env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="expo/types" />
+
+// NOTE: This file should not be edited and should be in your git ignore

--- a/apps/citizen-mobile/src/theme/colors.ts
+++ b/apps/citizen-mobile/src/theme/colors.ts
@@ -33,6 +33,7 @@ export const Colors = {
 
   // ── Semantic ───────────────────────────────────────────────────────────
   destructive: '#D4603A',    // oklch(0.60 0.15 30)
+  destructiveSubtle: '#FBEDE7', // destructive/10 equivalent — error backgrounds
   emerald: '#059669',        // restoration / calm / positive
   emeraldSubtle: '#ECFDF5',
 

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -876,3 +876,35 @@ box background to use it.
 string-concatenating onto a colour token (`Colors.x + '10'`). If a subtle
 variant is needed, add a `<name>Subtle` token in `theme/colors.ts` next to
 the base token and use that — same pattern as `primarySubtle`."
+
+### Lesson 3: Migrating to shared `<Button>` can collapse a full-width CTA inside a centered container
+**File:** `apps/citizen-mobile/app/(auth)/otp.tsx`
+**What Copilot flagged:** The OTP screen's container uses
+`alignItems: 'center'`, so the new `<Button>` no longer stretches to full
+width like the prior `width: '100%'` CTA — shrinking the tap target and
+hurting usability.
+**Root cause:** The token-migration sweep replaced the styled
+`TouchableOpacity` with `<Button>` without accounting for the parent's
+`alignItems: 'center'` cross-axis behaviour.
+**Fix applied:** Passed `style={{ alignSelf: 'stretch' }}` (via a
+`submitButton` style) to the `<Button>` so it expands to the container's
+full width.
+**Rule added:** Pre-Commit Checklist → Mobile Layout → "When swapping a
+full-width CTA for the shared `<Button>` inside a parent that uses
+`alignItems: 'center'`, pass `alignSelf: 'stretch'` (or `width: '100%'`) so
+the button retains its full-width tap target."
+
+### Lesson 4: Keep the PR description's "files modified" list in sync after every follow-up commit
+**File:** PR-level
+**What Copilot flagged:** PR #82's description claimed "No other files
+modified", but follow-up commits also touched
+`docs/arch/LESSONS_LEARNED.md` and `apps/citizen-mobile/src/theme/colors.ts`
+(adding `destructiveSubtle`).
+**Root cause:** PR body was written for the initial commit and not refreshed
+after the Copilot-fix follow-up that added a token and a lesson entry.
+**Fix applied:** Updated PR #82 description to list the additional modified
+files.
+**Rule added:** Pre-Commit Checklist → PR hygiene → "After any follow-up
+commit that adds files outside the original PR scope (new tokens, lesson
+entries, etc.), update the PR description's modified-files list in the same
+session — extends Lesson #81/7."

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -841,3 +841,38 @@ the approach changed in a follow-up commit.
 **Rule added:** Pre-Commit Checklist → PR hygiene → "After any commit that
 materially changes the approach described in the PR body, update the PR
 description in the same session — don't leave reviewers a stale narrative."
+
+## PR #82 — feat(mobile): Phase F — auth screens token migration
+
+### Lesson 1: Migrating a CTA to a shared `<Button>` must preserve the prior accessibility contract
+**File:** `apps/citizen-mobile/app/(auth)/phone.tsx`
+**What Copilot flagged:** The new `<Button>` call dropped the descriptive
+`accessibilityLabel` (`PHONE_SUBMIT_LABEL`) and `accessibilityState`
+(`disabled`/`busy`) that the previous `TouchableOpacity` had — an a11y
+regression for the loading/disabled states.
+**Root cause:** Token-migration sweep replaced the element wholesale and
+forgot that `accessibilityLabel`/`accessibilityState` are not implicit on
+`<Button>` and must be passed explicitly via the forwarded props.
+**Fix applied:** Passed `accessibilityRole="button"`, `accessibilityLabel`,
+and `accessibilityState={{ disabled, busy }}` through `<Button>` (it forwards
+extra props to its `TouchableOpacity`).
+**Rule added:** Pre-Commit Checklist → Mobile A11y → "When migrating a CTA to
+the shared `<Button>` component, diff the prior props and re-pass any
+`accessibilityLabel`/`accessibilityState`/`accessibilityRole` that existed —
+`<Button>` does not infer loading/disabled into `accessibilityState`."
+
+### Lesson 2: Don't string-concatenate alpha onto a hex token — add a real subtle token
+**File:** `apps/citizen-mobile/app/(auth)/otp.tsx`, `apps/citizen-mobile/src/theme/colors.ts`
+**What Copilot flagged:** `backgroundColor: Colors.destructive + '10'` relies
+on the token always being a hex string and bakes in an implicit alpha. Fragile
+if the token format ever changes (e.g. to `rgb()`), and inconsistent with the
+existing `Colors.primarySubtle` pattern.
+**Root cause:** Reached for an inline alpha trick instead of extending the
+design-token surface.
+**Fix applied:** Added `Colors.destructiveSubtle` (`#FBEDE7`) alongside the
+existing `primarySubtle`/`emeraldSubtle` tokens, and switched the OTP error
+box background to use it.
+**Rule added:** Pre-Commit Checklist → Theming → "Never compose alpha by
+string-concatenating onto a colour token (`Colors.x + '10'`). If a subtle
+variant is needed, add a `<name>Subtle` token in `theme/colors.ts` next to
+the base token and use that — same pattern as `primarySubtle`."


### PR DESCRIPTION
## Summary
Token migration for both auth screens. Business logic unchanged.

## Changes
- `(auth)/phone.tsx` — tokens, SafeAreaView, Button component (a11y label/state forwarded through to preserve loading/disabled contract)
- `(auth)/otp.tsx` — tokens, SafeAreaView, lucide ArrowLeft back button, Button component (alignSelf:'stretch' to preserve full-width tap target), OTP box states use primarySubtle/destructiveSubtle tokens
- `src/theme/colors.ts` — added `destructiveSubtle` token (matches the existing `primarySubtle`/`emeraldSubtle` pattern; replaces an alpha string-concat in the OTP error box)
- `docs/arch/LESSONS_LEARNED.md` — recorded PR #82 lessons 1–4 from the Copilot review rounds

## Checklist
- [x] TypeScript: zero errors
- [x] No hardcoded hex values
- [x] All icons from lucide-react-native
- [x] Business logic unchanged in both screens