### PR TITLE
fix: Agent C Phase 1 follow-up — 4 gate items

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -739,6 +739,17 @@ components:
           - institution_id (UUID, present only for institution accounts)
           - jti, iat (standard)
   schemas:
+    CivicCategory:
+      type: string
+      enum:
+        - roads
+        - transport
+        - electricity
+        - water
+        - environment
+        - safety
+        - governance
+        - infrastructure
     FeedbackRequest:
       type: object
       required: [rating]
@@ -817,7 +828,7 @@ components:
       required:
         [category, subcategorySlug, conditionConfidence, location, shouldSuggestJoin]
       properties:
-        category: { type: string }
+        category: { $ref: '#/components/schemas/CivicCategory' }
         subcategorySlug: { type: string }
         conditionSlug: { type: string, nullable: true }
         conditionConfidence: { type: number, minimum: 0, maximum: 1 }
@@ -837,7 +848,7 @@ components:
         idempotencyKey: { type: string }
         deviceHash: { type: string }
         freeText: { type: string }
-        category: { type: string }
+        category: { $ref: '#/components/schemas/CivicCategory' }
         subcategorySlug: { type: string }
         conditionSlug: { type: string, nullable: true }
         conditionConfidence: { type: number, minimum: 0, maximum: 1 }
@@ -872,7 +883,7 @@ components:
         state:
           type: string
           enum: [unconfirmed, active, possible_restoration, resolved]
-        category: { type: string }
+        category: { $ref: '#/components/schemas/CivicCategory' }
         subcategorySlug: { type: string, nullable: true }
         title: { type: string, nullable: true }
         summary: { type: string, nullable: true }
@@ -964,7 +975,7 @@ components:
         type:
           type: string
           enum: [live_update, scheduled_disruption, advisory_public_notice]
-        category: { type: string }
+        category: { $ref: '#/components/schemas/CivicCategory' }
         title: { type: string, maxLength: 220 }
         body: { type: string, maxLength: 5000 }
         startsAt: { type: string, format: date-time, nullable: true }
@@ -982,7 +993,7 @@ components:
         id: { type: string, format: uuid }
         institutionId: { type: string, format: uuid }
         type: { type: string }
-        category: { type: string }
+        category: { $ref: '#/components/schemas/CivicCategory' }
         title: { type: string }
         body: { type: string }
         startsAt: { type: string, format: date-time, nullable: true }

--- a/Hali.sln
+++ b/Hali.sln
@@ -41,5 +41,7 @@ Global
 		{11111111-0000-0000-0000-000000000007}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{11111111-0000-0000-0000-000000000008}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{11111111-0000-0000-0000-000000000008}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{11111111-0000-0000-0000-000000000008}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{11111111-0000-0000-0000-000000000008}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/apps/citizen-mobile/app/index.tsx
+++ b/apps/citizen-mobile/app/index.tsx
@@ -4,6 +4,7 @@ import React, { useEffect } from 'react';
 import { View, Text, StyleSheet } from 'react-native';
 import { useRouter } from 'expo-router';
 import { useAuthContext } from '../src/context/AuthContext';
+import { Colors } from '../src/theme/colors';
 
 export default function SplashScreen() {
   const router = useRouter();
@@ -29,7 +30,7 @@ export default function SplashScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#1a3a2f',
+    backgroundColor: Colors.primary,
     alignItems: 'center',
     justifyContent: 'center',
     gap: 8,
@@ -37,8 +38,8 @@ const styles = StyleSheet.create({
   wordmark: {
     fontSize: 52,
     fontWeight: '800',
-    color: '#fff',
+    color: Colors.primaryForeground,
     letterSpacing: -1,
   },
-  tagline: { fontSize: 16, color: '#86efac' },
+  tagline: { fontSize: 16, color: Colors.primarySubtle },
 });

--- a/apps/citizen-mobile/src/components/common/Empty.tsx
+++ b/apps/citizen-mobile/src/components/common/Empty.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
+import { Colors } from '../../theme/colors';
 
 interface EmptyProps {
   message: string;
@@ -23,10 +24,10 @@ const styles = StyleSheet.create({
     paddingHorizontal: 16,
     alignItems: 'center',
   },
-  message: { fontSize: 15, color: '#6b7280', textAlign: 'center' },
+  message: { fontSize: 15, color: Colors.mutedForeground, textAlign: 'center' },
   subMessage: {
     fontSize: 13,
-    color: '#9ca3af',
+    color: Colors.faintForeground,
     textAlign: 'center',
     marginTop: 4,
   },

--- a/apps/citizen-mobile/src/components/common/TextInput.tsx
+++ b/apps/citizen-mobile/src/components/common/TextInput.tsx
@@ -6,6 +6,7 @@ import {
   StyleSheet,
   type TextInputProps,
 } from 'react-native';
+import { Colors } from '../../theme/colors';
 
 interface HaliTextInputProps extends TextInputProps {
   label?: string;
@@ -25,7 +26,7 @@ export function TextInput({
       {label ? <Text style={styles.label}>{label}</Text> : null}
       <RNTextInput
         style={[styles.input, error ? styles.inputError : null, style]}
-        placeholderTextColor="#9ca3af"
+        placeholderTextColor={Colors.faintForeground}
         {...rest}
       />
       {error ? <Text style={styles.error}>{error}</Text> : null}
@@ -36,18 +37,18 @@ export function TextInput({
 
 const styles = StyleSheet.create({
   wrapper: { gap: 4 },
-  label: { fontSize: 14, fontWeight: '500', color: '#374151' },
+  label: { fontSize: 14, fontWeight: '500', color: Colors.foreground },
   input: {
     borderWidth: 1.5,
-    borderColor: '#d1d5db',
+    borderColor: Colors.border,
     borderRadius: 10,
     paddingHorizontal: 14,
     paddingVertical: 12,
     fontSize: 16,
-    color: '#111827',
-    backgroundColor: '#fff',
+    color: Colors.foreground,
+    backgroundColor: Colors.card,
   },
-  inputError: { borderColor: '#dc2626' },
-  error: { fontSize: 13, color: '#dc2626' },
-  hint: { fontSize: 13, color: '#6b7280' },
+  inputError: { borderColor: Colors.destructive },
+  error: { fontSize: 13, color: Colors.destructive },
+  hint: { fontSize: 13, color: Colors.mutedForeground },
 });

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -1073,3 +1073,26 @@ a CLI silently ignore a user-supplied option."
 **Root cause:** Treated the delayed dismiss as fire-and-forget without considering navigation races.
 **Fix applied:** Stored the timer in a `useRef`, cleared it in a `useEffect` cleanup, and cleared any prior timer before scheduling a new one.
 **Rule added:** React Native → "Any `setTimeout`/`setInterval` started inside a component must be tracked in a `useRef` and cleared in a `useEffect` cleanup. Never leave a pending timer that calls navigation or state setters."
+
+## PR #90 — Agent C Phase 1 follow-up — 4 gate items
+
+### Lesson 1: Don't add an optional formula parameter without wiring a real value through the caller
+**File:** `src/Hali.Application/Clusters/CivisCalculator.cs`, `CivisEvaluationService.cs`
+**What Copilot flagged:** `ComputeMacf` gained a `locationConfidence` parameter with default `1.0`, but the only production caller didn't pass anything — so the new geo-uncertainty branch was dead logic.
+**Root cause:** Implemented the formula spec literally without checking whether the surrounding code had a way to source the input. Default-1.0 made it compile and pass tests but the feature was unreachable in production.
+**Fix applied:** Added `IClusterRepository.GetMinLocationConfidenceAsync` (queries `MIN(signal_events.location_confidence)` for the cluster), implemented it in `ClusterRepository`, and wired it through `CivisEvaluationService` so the MACF call now receives a real value.
+**Rule added:** C# → "When adding an optional parameter that drives non-trivial logic, the same PR must wire a real value at the production call site. Defaulting and leaving callers untouched produces dead branches that pass tests but never fire."
+
+### Lesson 2: Cite the actual source-of-truth document in formula header comments
+**File:** `src/Hali.Application/Clusters/CivisCalculator.cs`
+**What Copilot flagged:** Header comment said "MACF formula per mvp_locked_decisions.md §9", but `mvp_locked_decisions.md` only contains the simple `clamp(ceil(base_floor + log2(SDS + 1)))` formula. The extended formula with `SensitivityUplift` and `geoUncertainty` actually lives in `docs/arch/05_civis_engine.md` and `docs/arch/00_session_patch_notes.md`.
+**Root cause:** Cited the document the prompt referenced rather than verifying which doc actually contains the formula.
+**Fix applied:** Updated the comment to point to `docs/arch/05_civis_engine.md` (and `00_session_patch_notes.md`).
+**Rule added:** Docs → "Before citing a doc reference in a code comment, grep that doc for the symbols/terms you're claiming it defines. If they're not there, find the doc that does and cite it."
+
+### Lesson 3: New formula branches need unit tests for each new input dimension
+**File:** `tests/Hali.Tests.Unit/Clusters/CivisCalculatorTests.cs`
+**What Copilot flagged:** `ComputeMacf` gained `isSafetyCategory` and `locationConfidence` parameters, but no unit test exercised them — only the legacy code paths were covered.
+**Root cause:** Relied on existing default-arg call sites still passing as evidence the change was safe. That validates backward compatibility, not the new behavior.
+**Fix applied:** Added three tests: safety uplift, low-confidence geo uplift (including the boundary at exactly 0.5, which must NOT uplift), and combined safety + low-confidence path.
+**Rule added:** Tests → "When adding a parameter that creates a new branch in a calculation, add at least one unit test per new branch AND a boundary test for any threshold the branch uses. Backward-compat tests do not substitute."

--- a/src/Hali.Application/Clusters/CivisCalculator.cs
+++ b/src/Hali.Application/Clusters/CivisCalculator.cs
@@ -4,10 +4,30 @@ namespace Hali.Application.Clusters;
 
 public static class CivisCalculator
 {
-	public static int ComputeMacf(double sds, CivisCategoryOptions opts)
+	// MACF formula per mvp_locked_decisions.md §9:
+	//   rawMacf = BaseFloor
+	//           + Alpha * Log2(1 + SDS)
+	//           + SensitivityUplift            // 1 for safety, 0 otherwise
+	//           + geoUncertainty * 0.5         // geoUncertainty = 0.5 when locationConfidence < 0.5, else 0
+	// Alpha = 1.0 for all MVP categories.
+	// Optional parameters default to safe values (non-safety, full confidence)
+	// so existing callers and tests retain their previous behavior.
+	public static int ComputeMacf(
+		double sds,
+		CivisCategoryOptions opts,
+		bool isSafetyCategory = false,
+		double locationConfidence = 1.0)
 	{
-		double a = (double)opts.BaseFloor + Math.Log2(sds + 1.0);
-		int value = (int)Math.Ceiling(a);
+		const double alpha = 1.0;
+		double sensitivityUplift = isSafetyCategory ? 1.0 : 0.0;
+		double geoUncertainty = locationConfidence < 0.5 ? 0.5 : 0.0;
+
+		double rawMacf = (double)opts.BaseFloor
+			+ alpha * Math.Log2(1.0 + sds)
+			+ sensitivityUplift
+			+ geoUncertainty * 0.5;
+
+		int value = (int)Math.Ceiling(rawMacf);
 		return Math.Clamp(value, opts.MacfMin, opts.MacfMax);
 	}
 

--- a/src/Hali.Application/Clusters/CivisCalculator.cs
+++ b/src/Hali.Application/Clusters/CivisCalculator.cs
@@ -4,7 +4,7 @@ namespace Hali.Application.Clusters;
 
 public static class CivisCalculator
 {
-	// MACF formula per mvp_locked_decisions.md §9:
+	// MACF formula per docs/arch/05_civis_engine.md (and 00_session_patch_notes.md):
 	//   rawMacf = BaseFloor
 	//           + Alpha * Log2(1 + SDS)
 	//           + SensitivityUplift            // 1 for safety, 0 otherwise

--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -39,7 +39,7 @@ public class CivisEvaluationService : ICivisEvaluationService
 			int wrabCount = await _repo.ComputeWrabCountAsync(clusterId, _options.WrabRollingWindowDays, ct);
 			int effectiveWrab = Math.Max(wrabCount, opts.BaseFloor);
 			double sds = CivisCalculator.ComputeSds(await _repo.ComputeActiveMassCountAsync(clusterId, _options.ActiveMassHorizonHours, ct), wrabCount, opts.BaseFloor);
-			int macf = CivisCalculator.ComputeMacf(sds, opts);
+			int macf = CivisCalculator.ComputeMacf(sds, opts, cluster.Category == CivicCategory.Safety);
 			int uniqueDevices = await _repo.CountUniqueDevicesAsync(clusterId, ct);
 			DateTime now = DateTime.UtcNow;
 			cluster.Wrab = effectiveWrab;

--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -39,7 +39,12 @@ public class CivisEvaluationService : ICivisEvaluationService
 			int wrabCount = await _repo.ComputeWrabCountAsync(clusterId, _options.WrabRollingWindowDays, ct);
 			int effectiveWrab = Math.Max(wrabCount, opts.BaseFloor);
 			double sds = CivisCalculator.ComputeSds(await _repo.ComputeActiveMassCountAsync(clusterId, _options.ActiveMassHorizonHours, ct), wrabCount, opts.BaseFloor);
-			int macf = CivisCalculator.ComputeMacf(sds, opts, cluster.Category == CivicCategory.Safety);
+			double minLocationConfidence = await _repo.GetMinLocationConfidenceAsync(clusterId, ct);
+			int macf = CivisCalculator.ComputeMacf(
+				sds,
+				opts,
+				cluster.Category == CivicCategory.Safety,
+				minLocationConfidence);
 			int uniqueDevices = await _repo.CountUniqueDevicesAsync(clusterId, ct);
 			DateTime now = DateTime.UtcNow;
 			cluster.Wrab = effectiveWrab;

--- a/src/Hali.Application/Clusters/IClusterRepository.cs
+++ b/src/Hali.Application/Clusters/IClusterRepository.cs
@@ -25,6 +25,13 @@ public interface IClusterRepository
 
 	Task<int> CountUniqueDevicesAsync(Guid clusterId, CancellationToken ct);
 
+	/// <summary>
+	/// Returns the minimum (worst-case) location_confidence across all signal_events
+	/// linked to the cluster. Used by the MACF geo-uncertainty uplift. Returns 1.0
+	/// (full confidence) if the cluster has no linked events with a confidence value.
+	/// </summary>
+	Task<double> GetMinLocationConfidenceAsync(Guid clusterId, CancellationToken ct);
+
 	Task<IReadOnlyList<SignalCluster>> GetActiveClustersForDecayAsync(CancellationToken ct);
 
 	Task<IReadOnlyList<SignalCluster>> GetPossibleRestorationClustersAsync(CancellationToken ct);

--- a/src/Hali.Infrastructure/Clusters/ClusterRepository.cs
+++ b/src/Hali.Infrastructure/Clusters/ClusterRepository.cs
@@ -85,6 +85,17 @@ public class ClusterRepository : IClusterRepository
 		return await _db.ClusterEventLinks.Where((ClusterEventLink l) => l.ClusterId == clusterId && l.LinkedAt >= cutoff).CountAsync(ct);
 	}
 
+	public async Task<double> GetMinLocationConfidenceAsync(Guid clusterId, CancellationToken ct)
+	{
+		decimal? min = await _db.Database.SqlQuery<decimal?>($@"
+			SELECT MIN(se.location_confidence) AS ""Value""
+			FROM cluster_event_links cel
+			JOIN signal_events se ON se.id = cel.signal_event_id
+			WHERE cel.cluster_id = {clusterId}
+			  AND se.location_confidence IS NOT NULL").FirstOrDefaultAsync(ct);
+		return min.HasValue ? (double)min.Value : 1.0;
+	}
+
 	public async Task<int> CountUniqueDevicesAsync(Guid clusterId, CancellationToken ct)
 	{
 		return await _db.Database.SqlQuery<int>($"SELECT COUNT(DISTINCT se.device_id)::int AS \"Value\"\n               FROM cluster_event_links cel\n               JOIN signal_events se ON se.id = cel.signal_event_id\n               WHERE cel.cluster_id = {clusterId} AND se.device_id IS NOT NULL").FirstOrDefaultAsync(ct);

--- a/tests/Hali.Tests.Integration/Signals/SignalIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Signals/SignalIntegrationTests.cs
@@ -26,16 +26,16 @@ public sealed class SignalIntegrationTests : IntegrationTestBase
     {
         var response = await Client.PostAsJsonAsync("/v1/signals/preview", new
         {
-            freeText      = "There is a large pothole on the main road blocking traffic",
-            userLatitude  = -1.2921,
+            freeText = "There is a large pothole on the main road blocking traffic",
+            userLatitude = -1.2921,
             userLongitude = 36.8219,
-            locale        = "en",
+            locale = "en",
         });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         var body = await response.Content.ReadFromJsonAsync<JsonElement>(_json);
-        Assert.Equal("roads",    body.GetProperty("category").GetString());
+        Assert.Equal("roads", body.GetProperty("category").GetString());
         Assert.Equal("potholes", body.GetProperty("subcategorySlug").GetString());
         Assert.True(body.TryGetProperty("location", out var loc));
         Assert.False(string.IsNullOrWhiteSpace(loc.GetProperty("locationLabel").GetString()));
@@ -53,23 +53,23 @@ public sealed class SignalIntegrationTests : IntegrationTestBase
 
         var response = await authClient.PostAsJsonAsync("/v1/signals/submit", new
         {
-            idempotencyKey        = Guid.NewGuid().ToString(),
-            deviceHash            = TestConstants.TestDeviceHash,
-            freeText              = "Pothole on Test Road",
-            category              = "roads",
-            subcategorySlug       = "potholes",
-            conditionSlug         = "pothole_severe",
-            conditionConfidence   = 0.92,
-            latitude              = -1.2921,
-            longitude             = 36.8219,
-            locationLabel         = "Test Road, Test Area",
+            idempotencyKey = Guid.NewGuid().ToString(),
+            deviceHash = TestConstants.TestDeviceHash,
+            freeText = "Pothole on Test Road",
+            category = "roads",
+            subcategorySlug = "potholes",
+            conditionSlug = "pothole_severe",
+            conditionConfidence = 0.92,
+            latitude = -1.2921,
+            longitude = 36.8219,
+            locationLabel = "Test Road, Test Area",
             locationPrecisionType = "road",
-            locationConfidence    = 0.85,
-            locationSource        = "nlp",
-            temporalType          = "temporary",
-            neutralSummary        = "Severe pothole on Test Road.",
-            sourceLanguage        = "en",
-            spatialCellId         = "8a390d24cbfffff",
+            locationConfidence = 0.85,
+            locationSource = "nlp",
+            temporalType = "temporary",
+            neutralSummary = "Severe pothole on Test Road.",
+            sourceLanguage = "en",
+            spatialCellId = "8a390d24cbfffff",
         });
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
@@ -88,15 +88,15 @@ public sealed class SignalIntegrationTests : IntegrationTestBase
         var idempotencyKey = Guid.NewGuid().ToString();
         var payload = new
         {
-            idempotencyKey      = idempotencyKey,
-            deviceHash          = "idem-device-01",
-            freeText            = "Water outage in my area",
-            category            = "water",
-            subcategorySlug     = "outage",
+            idempotencyKey = idempotencyKey,
+            deviceHash = "idem-device-01",
+            freeText = "Water outage in my area",
+            category = "water",
+            subcategorySlug = "outage",
             conditionConfidence = 0.80,
-            locationConfidence  = 0.70,
-            locationSource      = "user",
-            spatialCellId       = "8a390d24ccfffff",
+            locationConfidence = 0.70,
+            locationSource = "user",
+            spatialCellId = "8a390d24ccfffff",
         };
 
         var first = await authClient.PostAsJsonAsync("/v1/signals/submit", payload);

--- a/tests/Hali.Tests.Unit/Advisories/EvaluatePossibleRestorationJobTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/EvaluatePossibleRestorationJobTests.cs
@@ -52,6 +52,7 @@ public class EvaluatePossibleRestorationJobTests
         public Task<int> ComputeWrabCountAsync(Guid c, int d, CancellationToken ct) => Task.FromResult(0);
         public Task<int> ComputeActiveMassCountAsync(Guid c, int h, CancellationToken ct) => Task.FromResult(0);
         public Task<int> CountUniqueDevicesAsync(Guid c, CancellationToken ct) => Task.FromResult(0);
+        public Task<double> GetMinLocationConfidenceAsync(Guid c, CancellationToken ct) => Task.FromResult(1.0);
         public Task<IReadOnlyList<SignalCluster>> GetActiveClustersForDecayAsync(CancellationToken ct)
             => Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
         public Task UpdateCountsAsync(Guid c, int a, int o, CancellationToken ct) => Task.CompletedTask;

--- a/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
@@ -81,6 +81,7 @@ public class OfficialPostsServiceTests
         public Task<int> ComputeWrabCountAsync(Guid c, int d, CancellationToken ct) => Task.FromResult(0);
         public Task<int> ComputeActiveMassCountAsync(Guid c, int h, CancellationToken ct) => Task.FromResult(0);
         public Task<int> CountUniqueDevicesAsync(Guid c, CancellationToken ct) => Task.FromResult(0);
+        public Task<double> GetMinLocationConfidenceAsync(Guid c, CancellationToken ct) => Task.FromResult(1.0);
 
         public Task<IReadOnlyList<SignalCluster>> GetActiveClustersForDecayAsync(CancellationToken ct)
             => Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());

--- a/tests/Hali.Tests.Unit/Advisories/RestorationEvaluationTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/RestorationEvaluationTests.cs
@@ -34,6 +34,7 @@ public class RestorationEvaluationTests
         public Task<int> ComputeWrabCountAsync(Guid c, int d, CancellationToken ct) => Task.FromResult(0);
         public Task<int> ComputeActiveMassCountAsync(Guid c, int h, CancellationToken ct) => Task.FromResult(0);
         public Task<int> CountUniqueDevicesAsync(Guid c, CancellationToken ct) => Task.FromResult(0);
+        public Task<double> GetMinLocationConfidenceAsync(Guid c, CancellationToken ct) => Task.FromResult(1.0);
         public Task<IReadOnlyList<SignalCluster>> GetActiveClustersForDecayAsync(CancellationToken ct) => Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
         public Task<IReadOnlyList<SignalCluster>> GetPossibleRestorationClustersAsync(CancellationToken ct) => Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
         public Task UpdateCountsAsync(Guid c, int a, int o, CancellationToken ct) => Task.CompletedTask;

--- a/tests/Hali.Tests.Unit/Clusters/CivisCalculatorTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/CivisCalculatorTests.cs
@@ -65,6 +65,55 @@ public class CivisCalculatorTests
 	}
 
 	[Fact]
+	public void ComputeMacf_SafetyCategory_AppliesSensitivityUplift()
+	{
+		// base 2 + log2(1+1)=1 + safetyUplift 1 + 0 = 4 → ceil 4
+		CivisCategoryOptions opts = new CivisCategoryOptions
+		{
+			BaseFloor = 2,
+			MacfMin = 2,
+			MacfMax = 6
+		};
+		int nonSafety = CivisCalculator.ComputeMacf(1.0, opts, isSafetyCategory: false);
+		int safety = CivisCalculator.ComputeMacf(1.0, opts, isSafetyCategory: true);
+		Assert.Equal(3, nonSafety);
+		Assert.Equal(4, safety);
+	}
+
+	[Fact]
+	public void ComputeMacf_LowLocationConfidence_AppliesGeoUncertaintyUplift()
+	{
+		// base 2 + log2(1+1)=1 + 0 + (0.5 * 0.5)=0.25 → 3.25 → ceil 4
+		CivisCategoryOptions opts = new CivisCategoryOptions
+		{
+			BaseFloor = 2,
+			MacfMin = 2,
+			MacfMax = 6
+		};
+		int highConfidence = CivisCalculator.ComputeMacf(1.0, opts, locationConfidence: 1.0);
+		int lowConfidence = CivisCalculator.ComputeMacf(1.0, opts, locationConfidence: 0.4);
+		int boundary = CivisCalculator.ComputeMacf(1.0, opts, locationConfidence: 0.5);
+		Assert.Equal(3, highConfidence);
+		Assert.Equal(4, lowConfidence);
+		// boundary: locationConfidence == 0.5 → NOT < 0.5, so no uplift
+		Assert.Equal(3, boundary);
+	}
+
+	[Fact]
+	public void ComputeMacf_SafetyAndLowConfidence_AppliesBothUplifts()
+	{
+		// base 2 + 1 + 1 + 0.25 = 4.25 → ceil 5
+		CivisCategoryOptions opts = new CivisCategoryOptions
+		{
+			BaseFloor = 2,
+			MacfMin = 2,
+			MacfMax = 6
+		};
+		int actual = CivisCalculator.ComputeMacf(1.0, opts, isSafetyCategory: true, locationConfidence: 0.4);
+		Assert.Equal(5, actual);
+	}
+
+	[Fact]
 	public void ComputeSds_WrabBelowBaseFloor_UsesBaseFloor()
 	{
 		double actual = CivisCalculator.ComputeSds(4.0, 0.0, 2);

--- a/tests/Hali.Tests.Unit/Clusters/FakeClusterRepo.cs
+++ b/tests/Hali.Tests.Unit/Clusters/FakeClusterRepo.cs
@@ -49,6 +49,13 @@ internal sealed class FakeClusterRepo : IClusterRepository
 		return Task.FromResult(UniqueDevices);
 	}
 
+	public double MinLocationConfidence { get; set; } = 1.0;
+
+	public Task<double> GetMinLocationConfidenceAsync(Guid clusterId, CancellationToken ct)
+	{
+		return Task.FromResult(MinLocationConfidence);
+	}
+
 	public Task UpdateClusterAsync(SignalCluster cluster, CancellationToken ct)
 	{
 		Updates.Add(cluster);

--- a/tests/Hali.Tests.Unit/Clusters/OutboxRelayServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/OutboxRelayServiceTests.cs
@@ -136,6 +136,7 @@ public class OutboxRelayServiceTests
         public Task<int> ComputeWrabCountAsync(Guid c, int d, CancellationToken ct) => Task.FromResult(0);
         public Task<int> ComputeActiveMassCountAsync(Guid c, int h, CancellationToken ct) => Task.FromResult(0);
         public Task<int> CountUniqueDevicesAsync(Guid c, CancellationToken ct) => Task.FromResult(0);
+        public Task<double> GetMinLocationConfidenceAsync(Guid c, CancellationToken ct) => Task.FromResult(1.0);
         public Task<IReadOnlyList<SignalCluster>> GetActiveClustersForDecayAsync(CancellationToken ct) => Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
         public Task<IReadOnlyList<SignalCluster>> GetPossibleRestorationClustersAsync(CancellationToken ct) => Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
         public Task WriteCivisDecisionAsync(CivisDecision d, CancellationToken ct) => Task.CompletedTask;

--- a/tests/Hali.Tests.Unit/Participation/FakeClusterRepoForParticipation.cs
+++ b/tests/Hali.Tests.Unit/Participation/FakeClusterRepoForParticipation.cs
@@ -89,6 +89,11 @@ internal sealed class FakeClusterRepoForParticipation : IClusterRepository
 		return Task.FromResult(0);
 	}
 
+	public Task<double> GetMinLocationConfidenceAsync(Guid clusterId, CancellationToken ct)
+	{
+		return Task.FromResult(1.0);
+	}
+
 	public Task<IReadOnlyList<SignalCluster>> GetActiveClustersForDecayAsync(CancellationToken ct)
 	{
 		return Task.FromResult((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());


### PR DESCRIPTION
## Summary
Resolves the 4 PASS_WITH_NOTES items from Agent C Phase 1 re-validation
(docs/arch/AGENT_C_PHASE1_VALIDATION.md). All bounded fixes. No
architectural changes.

## Fixes

**1. Mobile hex cleanup**
13 hardcoded hex values in app/index.tsx, Empty.tsx, TextInput.tsx
migrated to theme tokens (Phase A–era primitives that pre-dated the
Phase B token sweep).

**2. MACF formula completion**
CivisCalculator.cs was missing the SensitivityUplift and
geoUncertainty * 0.5 terms from mvp_locked_decisions.md §9.
Added with backward-compatible default parameters; CivisEvaluationService
now passes `cluster.Category == CivicCategory.Safety`. Clamp/Ceil/MacfMin/
MacfMax logic unchanged.

**3. OpenAPI CivicCategory enum**
Added `CivicCategory` schema component with the 8-value enum. All 5
plain-string `category` fields in SignalPreviewResponse, SignalSubmitRequest,
ClusterResponse, OfficialPostRequest, and OfficialPostResponse now $ref it.

**4. Sln Release config + whitespace**
`Hali.Tests.Integration` added under Release|Any CPU in Hali.sln.
9 whitespace violations in SignalIntegrationTests.cs fixed via dotnet format.

## Test results
- Backend unit: 175/175 pass
- Release build: 0 errors
- Mobile tsc --noEmit: clean
- Zero hex remaining in the 3 fixed mobile files

## Checklist
- [x] Zero hardcoded hex in the 3 fixed files
- [x] Mobile TypeScript: zero errors
- [x] MACF formula: all 4 terms present
- [x] OpenAPI YAML: valid + CivicCategory referenced
- [x] Release build: zero MSB errors
- [x] All unit tests passing