### PR TITLE
Phase A3: return cluster outcome in submit response

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -863,9 +863,13 @@ components:
         sourceLanguage: { type: string, nullable: true }
     SignalSubmitResponse:
       type: object
-      required: [signalEventId, createdAt]
+      required: [signalEventId, clusterId, isNewCluster, clusterState, createdAt]
       properties:
         signalEventId: { type: string, format: uuid }
+        clusterId: { type: string, format: uuid }
+        isNewCluster: { type: boolean }
+        clusterState: { type: string, enum: [unconfirmed, active, possible_restoration, resolved] }
+        localityId: { type: string, format: uuid, nullable: true }
         createdAt: { type: string, format: date-time }
 
     # ── Clusters / Participation ─────────────────────────────────────

--- a/apps/citizen-mobile/app/(app)/compose/submit.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/submit.tsx
@@ -24,14 +24,21 @@ export default function ComposerSubmitScreen(): React.ReactElement {
   return (
     <SubmitScreenContent
       freeText={freeText} preview={preview} deviceHash={deviceHash}
-      onSuccess={() => { reset(); router.replace('/(app)/home'); }}
+      onSuccess={(clusterId?: string) => {
+        reset();
+        if (clusterId) {
+          router.replace(`/(app)/clusters/${clusterId}`);
+        } else {
+          router.replace('/(app)/home');
+        }
+      }}
     />
   );
 }
 
 function SubmitScreenContent({
   freeText, preview, deviceHash, onSuccess,
-}: { freeText: string; preview: SignalPreviewResponse; deviceHash: string; onSuccess: () => void }): React.ReactElement {
+}: { freeText: string; preview: SignalPreviewResponse; deviceHash: string; onSuccess: (clusterId?: string) => void }): React.ReactElement {
   const router = useRouter();
   const [screenState, setScreenState] = useState<ScreenState>('idle');
   const [errorMessage, setErrorMessage] = useState('');
@@ -75,9 +82,9 @@ function SubmitScreenContent({
       neutralSummary: preview.neutralSummary ?? undefined,
     };
     const result = await submitSignal(body);
-    if (result.ok) { onSuccess(); return; }
+    if (result.ok) { onSuccess(result.value.clusterId); return; }
     setScreenState('error');
-    if (result.error.status === 409) { onSuccess(); return; }
+    if (result.error.status === 409) { onSuccess(undefined); return; }
     if (result.error.status === 429) {
       setErrorMessage('Too many signals submitted. Please wait a moment and try again.');
     } else if (result.error.status === 422) {

--- a/apps/citizen-mobile/src/api/signals.ts
+++ b/apps/citizen-mobile/src/api/signals.ts
@@ -6,7 +6,7 @@
 //
 // Endpoints:
 //   POST /v1/signals/preview  → single-candidate extraction + shouldSuggestJoin
-//   POST /v1/signals/submit   → { signalEventId, createdAt } (async clustering)
+//   POST /v1/signals/submit   → { signalEventId, clusterId, isNewCluster, clusterState, localityId, createdAt }
 
 import { apiRequest } from './client';
 import type {
@@ -46,11 +46,9 @@ export async function previewSignal(
  * [Authorize] — access token is required. If the token has expired the
  * client's 401 interceptor will silently refresh and retry once.
  *
- * The response is { signalEventId, createdAt } — there is NO clusterId.
- * Clustering happens asynchronously on the server side via a background
- * worker. On success, the mobile screen should navigate to the home feed;
- * the new cluster will appear after the worker runs (typical latency <
- * a few seconds).
+ * The response includes the cluster routing outcome (clusterId, isNewCluster,
+ * clusterState, localityId). On success, the mobile screen navigates to the
+ * cluster detail screen using the returned clusterId.
  */
 export async function submitSignal(
   body: SignalSubmitRequest,

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -258,13 +258,15 @@ export interface SignalSubmitRequest {
  * Shape of the /v1/signals/submit success response.
  * Matches Hali.Contracts.Signals.SignalSubmitResponseDto exactly.
  *
- * Note: the backend does NOT return a clusterId here. Clustering happens
- * asynchronously via a background worker (outbox pattern). The mobile
- * client should navigate to the home feed on success, where the new
- * cluster will appear after the worker runs.
+ * Clustering is synchronous — the response includes the routing outcome
+ * so the client can navigate directly to the cluster detail screen.
  */
 export interface SignalSubmitResponse {
   signalEventId: string;
+  clusterId: string;
+  isNewCluster: boolean;
+  clusterState: string;
+  localityId: string | null;
   createdAt: string;
 }
 

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -247,6 +247,13 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
   spans auth transitions; derive readiness from React Query `isSuccess`/`isError` instead so the
   flag resets when auth state changes
 
+## Enum serialization rules
+
+- Never use `.ToString().ToLowerInvariant()` on multi-word PascalCase enums for wire output — it
+  produces `possiblerestoration` instead of `possible_restoration`. Use a PascalCase→snake_case
+  helper (see `ClusteringService.ToSnakeCase`, `ClustersController.ToSnakeCase`)
+- Wire-format enum values must match the OpenAPI `enum` array exactly (e.g. `possible_restoration`)
+
 ## GitHub Actions rules
 
 - [ ] All CI workflows reference the .NET SDK version via a shared `env.DOTNET_VERSION` variable

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -1126,3 +1126,12 @@ a CLI silently ignore a user-supplied option."
 **Root cause:** Helper was written with a deterministic-ID intent that was never wired through; the lambda already mirrors the input signal's properties.
 **Fix applied:** Removed the unused parameter and dead locals.
 **Rule added:** Tests → "After writing a test helper, verify every parameter and local is actually consumed. Unused parameters signal an incomplete implementation or a copy-paste artifact."
+
+## PR #94 — Phase A3: return cluster outcome in submit response
+
+### Lesson 1: Enum.ToString().ToLowerInvariant() breaks multi-word enum wire values
+**File:** `src/Hali.Application/Clusters/ClusteringService.cs`
+**What Copilot flagged:** `bestCluster.State.ToString().ToLowerInvariant()` serializes `SignalState.PossibleRestoration` as `"possiblerestoration"` instead of the documented wire value `"possible_restoration"`. This mismatches the OpenAPI enum and breaks clients.
+**Root cause:** Used `.ToString().ToLowerInvariant()` as a shortcut for enum-to-wire conversion. This works for single-word values (`Unconfirmed` → `"unconfirmed"`) but silently fails for multi-word PascalCase values (`PossibleRestoration` → `"possiblerestoration"` instead of `"possible_restoration"`).
+**Fix applied:** Added a private `ToSnakeCase(SignalState)` helper (matching the existing pattern in `ClustersController` and `OfficialPostsService`) and used it in both the join and create return paths. Added a regression test asserting `PossibleRestoration` maps to `"possible_restoration"`.
+**Rule added:** Enum serialization → "Never use `.ToString().ToLowerInvariant()` on multi-word PascalCase enums for wire output. Use a PascalCase→snake_case helper."

--- a/src/Hali.Application/Clusters/ClusterRoutingResult.cs
+++ b/src/Hali.Application/Clusters/ClusterRoutingResult.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Hali.Application.Clusters;
+
+/// <summary>
+/// Structured outcome of routing a signal to a cluster.
+/// Returned by <see cref="IClusteringService.RouteSignalAsync"/> so callers
+/// know whether a new cluster was created or an existing one was joined.
+/// </summary>
+public record ClusterRoutingResult(
+    Guid ClusterId,
+    bool WasCreated,
+    bool WasJoined,
+    string ClusterState,
+    Guid? LocalityId);

--- a/src/Hali.Application/Clusters/ClusteringService.cs
+++ b/src/Hali.Application/Clusters/ClusteringService.cs
@@ -85,7 +85,7 @@ public class ClusteringService : IClusteringService
 				bestCluster.Id,
 				WasCreated: false,
 				WasJoined: true,
-				bestCluster.State.ToString().ToLowerInvariant(),
+				ToSnakeCase(bestCluster.State),
 				bestCluster.LocalityId);
 		}
 		else
@@ -129,7 +129,7 @@ public class ClusteringService : IClusteringService
 				newCluster.Id,
 				WasCreated: true,
 				WasJoined: false,
-				newCluster.State.ToString().ToLowerInvariant(),
+				ToSnakeCase(newCluster.State),
 				newCluster.LocalityId);
 		}
 	}
@@ -141,6 +141,19 @@ public class ClusteringService : IClusteringService
 		double num2 = Math.Max(0.0, 1.0 - totalHours / _options.TimeScoreMaxAgeHours);
 		double num3 = ((!string.IsNullOrEmpty(signal.ConditionSlug) && signal.ConditionSlug == cluster.DominantConditionSlug) ? 1.0 : 0.0);
 		return 0.4 + 0.25 * num + 0.2 * num2 + 0.15 * num3;
+	}
+
+	private static string ToSnakeCase(SignalState state)
+	{
+		string pascal = state.ToString();
+		var sb = new System.Text.StringBuilder(pascal.Length + 4);
+		for (int i = 0; i < pascal.Length; i++)
+		{
+			char c = pascal[i];
+			if (i > 0 && char.IsUpper(c)) sb.Append('_');
+			sb.Append(char.ToLowerInvariant(c));
+		}
+		return sb.ToString();
 	}
 
 	private static string BuildClusterTitle(SignalEvent signal)

--- a/src/Hali.Application/Clusters/ClusteringService.cs
+++ b/src/Hali.Application/Clusters/ClusteringService.cs
@@ -28,11 +28,11 @@ public class ClusteringService : IClusteringService
 		_options = options.Value;
 	}
 
-	public async Task RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken))
+	public async Task<ClusterRoutingResult> RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken))
 	{
 		if (signal.SpatialCellId is null)
 		{
-			return;
+			throw new InvalidOperationException("CLUSTERING_NO_SPATIAL_CELL");
 		}
 		string[] searchCells = _h3.GetKRingCells(signal.SpatialCellId, 1);
 		IReadOnlyList<SignalCluster> candidates = await _repo.FindCandidateClustersAsync(searchCells, signal.Category, ct);
@@ -81,6 +81,12 @@ public class ClusteringService : IClusteringService
 				OccurredAt = DateTime.UtcNow
 			}, ct);
 			await _civis.EvaluateClusterAsync(bestCluster.Id, ct);
+			return new ClusterRoutingResult(
+				bestCluster.Id,
+				WasCreated: false,
+				WasJoined: true,
+				bestCluster.State.ToString().ToLowerInvariant(),
+				bestCluster.LocalityId);
 		}
 		else
 		{
@@ -119,6 +125,12 @@ public class ClusteringService : IClusteringService
 				OccurredAt = now
 			}, ct);
 			await _civis.EvaluateClusterAsync(newCluster.Id, ct);
+			return new ClusterRoutingResult(
+				newCluster.Id,
+				WasCreated: true,
+				WasJoined: false,
+				newCluster.State.ToString().ToLowerInvariant(),
+				newCluster.LocalityId);
 		}
 	}
 

--- a/src/Hali.Application/Clusters/IClusteringService.cs
+++ b/src/Hali.Application/Clusters/IClusteringService.cs
@@ -6,5 +6,5 @@ namespace Hali.Application.Clusters;
 
 public interface IClusteringService
 {
-	Task RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken));
+	Task<ClusterRoutingResult> RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken));
 }

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -129,7 +129,13 @@ public class SignalIngestionService : ISignalIngestionService
 		};
 		SignalEvent saved = await _repo.PersistSignalAsync(signal, ct);
 		await _repo.SetIdempotencyKeyAsync(idemKey, TimeSpan.FromHours(24), ct);
-		await _clustering.RouteSignalAsync(saved, ct);
-		return new SignalSubmitResponseDto(saved.Id, saved.CreatedAt);
+		var routing = await _clustering.RouteSignalAsync(saved, ct);
+		return new SignalSubmitResponseDto(
+			saved.Id,
+			routing.ClusterId,
+			routing.WasCreated,
+			routing.ClusterState,
+			routing.LocalityId,
+			saved.CreatedAt);
 	}
 }

--- a/src/Hali.Contracts/Signals/SignalSubmitResponseDto.cs
+++ b/src/Hali.Contracts/Signals/SignalSubmitResponseDto.cs
@@ -2,4 +2,10 @@ using System;
 
 namespace Hali.Contracts.Signals;
 
-public record SignalSubmitResponseDto(Guid SignalEventId, DateTime CreatedAt);
+public record SignalSubmitResponseDto(
+    Guid SignalEventId,
+    Guid ClusterId,
+    bool IsNewCluster,
+    string ClusterState,
+    Guid? LocalityId,
+    DateTime CreatedAt);

--- a/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
@@ -387,4 +387,25 @@ public class ClusteringServiceTests
         await repo.Received(1).AttachToClusterAsync(
             nullLocalityCluster.Id, signal.Id, signal.DeviceId, "join", Arg.Any<CancellationToken>());
     }
+
+    // -----------------------------------------------------------------------
+    // Phase A3: ClusterState wire format (snake_case)
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task RouteSignal_JoinToClusterInPossibleRestoration_ReturnsSnakeCaseState()
+    {
+        var (svc, repo, h3, civis) = Build();
+        var signal = MakeSignal();
+        var cluster = MakeCluster(lastSeenAgoHours: 0.1);
+        cluster.State = SignalState.PossibleRestoration;
+
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster> { cluster });
+
+        var result = await svc.RouteSignalAsync(signal);
+
+        Assert.Equal("possible_restoration", result.ClusterState);
+    }
 }

--- a/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
@@ -78,12 +78,13 @@ public class ClusteringServiceTests
     // -----------------------------------------------------------------------
 
     [Fact]
-    public async Task RouteSignal_WhenSpatialCellIdIsNull_ReturnsImmediately()
+    public async Task RouteSignal_WhenSpatialCellIdIsNull_Throws()
     {
         var (svc, repo, h3, civis) = Build();
         var signal = MakeSignal(spatialCellId: null);
 
-        await svc.RouteSignalAsync(signal);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.RouteSignalAsync(signal));
+        Assert.Equal("CLUSTERING_NO_SPATIAL_CELL", ex.Message);
 
         h3.DidNotReceive().GetKRingCells(Arg.Any<string>(), Arg.Any<int>());
         await repo.DidNotReceive().FindCandidateClustersAsync(
@@ -106,9 +107,12 @@ public class ClusteringServiceTests
         repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
             .Returns(new List<SignalCluster> { existingCluster });
 
-        await svc.RouteSignalAsync(signal);
+        var result = await svc.RouteSignalAsync(signal);
 
         await repo.Received(1).AttachToClusterAsync(existingCluster.Id, signal.Id, signal.DeviceId, "join", Arg.Any<CancellationToken>());
+        Assert.Equal(existingCluster.Id, result.ClusterId);
+        Assert.True(result.WasJoined);
+        Assert.False(result.WasCreated);
     }
 
     [Fact]
@@ -184,7 +188,7 @@ public class ClusteringServiceTests
         repo.CreateClusterAsync(Arg.Do<SignalCluster>(c => created = c), signal.Id, signal.DeviceId, Arg.Any<CancellationToken>())
             .Returns(callInfo => Task.FromResult(callInfo.Arg<SignalCluster>()));
 
-        await svc.RouteSignalAsync(signal);
+        var result = await svc.RouteSignalAsync(signal);
 
         await repo.Received(1).CreateClusterAsync(
             Arg.Any<SignalCluster>(), signal.Id, signal.DeviceId, Arg.Any<CancellationToken>());
@@ -192,6 +196,10 @@ public class ClusteringServiceTests
         Assert.Equal(SignalState.Unconfirmed, created!.State);
         Assert.Equal(signal.Category, created.Category);
         Assert.Equal(1, created.RawConfirmationCount);
+        Assert.Equal(created.Id, result.ClusterId);
+        Assert.True(result.WasCreated);
+        Assert.False(result.WasJoined);
+        Assert.Equal("unconfirmed", result.ClusterState);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
@@ -52,6 +52,8 @@ public class SignalIngestionServiceTests
 			.Returns(new LocalitySummary(DefaultLocalityId, "Nairobi West", "Nairobi", "Nairobi"));
 	}
 
+	private static readonly Guid DefaultClusterId = Guid.Parse("cccccccc-dddd-eeee-ffff-000000000000");
+
 	private void SetupDefaultRepo()
 	{
 		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
@@ -69,6 +71,8 @@ public class SignalIngestionServiceTests
 				LocalityId = s.LocalityId
 			};
 		});
+		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+			.Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
 	}
 
 	[Fact]
@@ -127,6 +131,8 @@ public class SignalIngestionServiceTests
 			SpatialCellId = "892a1008003ffff",
 			LocalityId = DefaultLocalityId
 		});
+		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+			.Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
 		SignalIngestionService svc = CreateService();
 		Assert.NotNull(await svc.SubmitAsync(MakeSubmitRequest("key-dup"), null, null));
 		Assert.Equal("SIGNAL_DUPLICATE", (await Assert.ThrowsAsync<InvalidOperationException>(() => svc.SubmitAsync(MakeSubmitRequest("key-dup"), null, null))).Message);
@@ -320,5 +326,59 @@ public class SignalIngestionServiceTests
 		await _clustering.Received(1).RouteSignalAsync(
 			Arg.Is<SignalEvent>(s => s.LocalityId == DefaultLocalityId),
 			Arg.Any<CancellationToken>());
+	}
+
+	// --- Phase A3: Cluster routing result in submit response ---
+
+	[Fact]
+	public async Task SubmitAsync_NewClusterCreated_ResponseIncludesClusterIdAndIsNewCluster()
+	{
+		SetupDefaultRepo();
+		SetupDefaultH3();
+		SetupDefaultLocality();
+		var clusterId = Guid.NewGuid();
+		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+			.Returns(new ClusterRoutingResult(clusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
+		SignalIngestionService svc = CreateService();
+
+		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+		Assert.Equal(clusterId, result.ClusterId);
+		Assert.True(result.IsNewCluster);
+		Assert.Equal("unconfirmed", result.ClusterState);
+		Assert.Equal(DefaultLocalityId, result.LocalityId);
+	}
+
+	[Fact]
+	public async Task SubmitAsync_JoinedExistingCluster_ResponseIncludesClusterIdAndIsNotNew()
+	{
+		SetupDefaultRepo();
+		SetupDefaultH3();
+		SetupDefaultLocality();
+		var clusterId = Guid.NewGuid();
+		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+			.Returns(new ClusterRoutingResult(clusterId, WasCreated: false, WasJoined: true, "active", DefaultLocalityId));
+		SignalIngestionService svc = CreateService();
+
+		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+		Assert.Equal(clusterId, result.ClusterId);
+		Assert.False(result.IsNewCluster);
+		Assert.Equal("active", result.ClusterState);
+	}
+
+	[Fact]
+	public async Task SubmitAsync_ResponseAlwaysIncludesSignalEventIdAndCreatedAt()
+	{
+		SetupDefaultRepo();
+		SetupDefaultH3();
+		SetupDefaultLocality();
+		SignalIngestionService svc = CreateService();
+
+		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+		Assert.NotEqual(Guid.Empty, result.SignalEventId);
+		Assert.NotEqual(Guid.Empty, result.ClusterId);
+		Assert.NotEqual(default, result.CreatedAt);
 	}
 }


### PR DESCRIPTION
## Summary
- **Add `ClusterRoutingResult`** — structured record returned by `ClusteringService.RouteSignalAsync()` containing `ClusterId`, `WasCreated`, `WasJoined`, `ClusterState`, `LocalityId`
- **Expand `SignalSubmitResponseDto`** with cluster routing fields (`clusterId`, `isNewCluster`, `clusterState`, `localityId`) so the client receives the full routing outcome
- **Update mobile submit flow** to navigate directly to `/(app)/clusters/{clusterId}` using the backend-returned cluster ID instead of falling back to the home feed
- **Align OpenAPI spec and mobile TypeScript types** with the new response shape

## Key behavior changes
- **New cluster created:** response includes `isNewCluster: true`, `clusterState: "unconfirmed"`, and the new cluster's ID → mobile navigates to cluster detail
- **Joined existing cluster:** response includes `isNewCluster: false`, current cluster state, and the joined cluster's ID → mobile navigates to that cluster's detail
- **409 idempotent retry:** falls back to home feed (no cluster ID available from dedup path)

## Test coverage
| Test | What it proves |
|---|---|
| `RouteSignal_WhenSpatialCellIdIsNull_Throws` | Guard: null spatial cell throws instead of silent no-op |
| `RouteSignal_WhenMatchingClusterFound_AttachesSignalToCluster` | Join path returns correct `ClusterId`, `WasJoined=true` |
| `RouteSignal_WhenNoCandidateCluster_CreatesNewUnconfirmedCluster` | Create path returns correct `ClusterId`, `WasCreated=true`, `ClusterState="unconfirmed"` |
| `SubmitAsync_NewClusterCreated_ResponseIncludesClusterIdAndIsNewCluster` | Submit response contains cluster routing fields for creation |
| `SubmitAsync_JoinedExistingCluster_ResponseIncludesClusterIdAndIsNotNew` | Submit response contains cluster routing fields for join |
| `SubmitAsync_ResponseAlwaysIncludesSignalEventIdAndCreatedAt` | Existing fields still present alongside new fields |

All 197 unit tests pass. TypeScript compiles cleanly.

## Scope
This is **Phase A3 only** — submit outcome. No feed changes, no restoration changes, no unrelated DTO cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)