### PR TITLE
Phase A4: align home feed response contract

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -1036,7 +1036,7 @@ components:
     ClusterPagedSection:
       type: object
       description: Paginated section containing ClusterResponse items.
-      required: [items, totalCount]
+      required: [items, nextCursor, totalCount]
       properties:
         items:
           type: array
@@ -1051,7 +1051,7 @@ components:
     OfficialPostPagedSection:
       type: object
       description: Paginated section containing OfficialPostResponse items.
-      required: [items, totalCount]
+      required: [items, nextCursor, totalCount]
       properties:
         items:
           type: array

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -596,11 +596,17 @@ paths:
           description: Opaque pagination cursor from a previous response's nextCursor
       responses:
         '200':
-          description: Home feed (all sections or single section depending on query params)
+          description: |
+            Without `section`: returns HomeResponse (all four sections).
+            With `section`: returns the matching typed PagedSection directly
+            (ClusterPagedSection or OfficialPostPagedSection).
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/HomeResponse'
+                oneOf:
+                  - $ref: '#/components/schemas/HomeResponse'
+                  - $ref: '#/components/schemas/ClusterPagedSection'
+                  - $ref: '#/components/schemas/OfficialPostPagedSection'
         '400':
           description: Unknown section name
           content:
@@ -1027,13 +1033,30 @@ components:
           $ref: '#/components/schemas/NotificationSettings'
 
     # ── Home Feed ────────────────────────────────────────────────────
-    PagedSection:
+    ClusterPagedSection:
       type: object
-      description: A paginated section of home feed items
+      description: Paginated section containing ClusterResponse items.
+      required: [items, totalCount]
       properties:
         items:
           type: array
-          items: {}
+          items:
+            $ref: '#/components/schemas/ClusterResponse'
+        nextCursor:
+          type: string
+          nullable: true
+          description: Opaque base64-encoded cursor; null means no more pages
+        totalCount:
+          type: integer
+    OfficialPostPagedSection:
+      type: object
+      description: Paginated section containing OfficialPostResponse items.
+      required: [items, totalCount]
+      properties:
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/OfficialPostResponse'
         nextCursor:
           type: string
           nullable: true
@@ -1042,20 +1065,21 @@ components:
           type: integer
     HomeResponse:
       type: object
+      required: [activeNow, officialUpdates, recurringAtThisTime, otherActiveSignals]
       properties:
         activeNow:
           allOf:
-            - $ref: '#/components/schemas/PagedSection'
+            - $ref: '#/components/schemas/ClusterPagedSection'
           description: Non-recurring active clusters in followed localities (max 20)
         officialUpdates:
           allOf:
-            - $ref: '#/components/schemas/PagedSection'
+            - $ref: '#/components/schemas/OfficialPostPagedSection'
           description: Official posts for followed localities (max 5)
         recurringAtThisTime:
           allOf:
-            - $ref: '#/components/schemas/PagedSection'
+            - $ref: '#/components/schemas/ClusterPagedSection'
           description: Recurring clusters in followed localities (max 10)
         otherActiveSignals:
           allOf:
-            - $ref: '#/components/schemas/PagedSection'
+            - $ref: '#/components/schemas/ClusterPagedSection'
           description: Active clusters outside followed localities (max 10)

--- a/apps/citizen-mobile/__tests__/api/clusters.test.ts
+++ b/apps/citizen-mobile/__tests__/api/clusters.test.ts
@@ -5,6 +5,7 @@
 
 import {
   getHome,
+  getHomeSection,
   participate,
   submitRestorationResponse,
 } from '../../src/api/clusters';
@@ -85,48 +86,13 @@ describe('getHome', () => {
     mockApiRequest.mockReset();
   });
 
-  it('calls GET /v1/home with no query params by default', async () => {
+  it('calls GET /v1/home with no query params', async () => {
     mockApiRequest.mockResolvedValueOnce(okResult(emptyHome()));
 
     await getHome();
 
     expect(mockApiRequest).toHaveBeenCalledTimes(1);
     expect(mockApiRequest).toHaveBeenCalledWith('/v1/home', { method: 'GET' });
-  });
-
-  it('appends a section query param when provided', async () => {
-    mockApiRequest.mockResolvedValueOnce(okResult(emptyHome()));
-
-    await getHome({ section: 'active_now' });
-
-    expect(mockApiRequest).toHaveBeenCalledWith('/v1/home?section=active_now', {
-      method: 'GET',
-    });
-  });
-
-  it('appends both section and cursor when provided', async () => {
-    mockApiRequest.mockResolvedValueOnce(okResult(emptyHome()));
-
-    await getHome({
-      section: 'other_active_signals',
-      cursor: 'opaque-cursor-value',
-    });
-
-    expect(mockApiRequest).toHaveBeenCalledWith(
-      '/v1/home?section=other_active_signals&cursor=opaque-cursor-value',
-      { method: 'GET' },
-    );
-  });
-
-  it('url-encodes the cursor value', async () => {
-    mockApiRequest.mockResolvedValueOnce(okResult(emptyHome()));
-
-    await getHome({ section: 'active_now', cursor: 'a+b/c=' });
-
-    expect(mockApiRequest).toHaveBeenCalledWith(
-      '/v1/home?section=active_now&cursor=a%2Bb%2Fc%3D',
-      { method: 'GET' },
-    );
   });
 
   it('returns the full four-section PagedSection response on success', async () => {
@@ -179,6 +145,68 @@ describe('getHome', () => {
     if (result.ok) return;
     expect(result.error.status).toBe(500);
     expect(result.error.code).toBe('unknown_error');
+  });
+});
+
+// ─── getHomeSection ─────────────────────────────────────────────────────────
+
+describe('getHomeSection', () => {
+  beforeEach(() => {
+    mockApiRequest.mockReset();
+  });
+
+  it('builds the correct URL for a section request', async () => {
+    mockApiRequest.mockResolvedValueOnce(
+      okResult(makeSection<ClusterResponse>([])),
+    );
+
+    await getHomeSection('active_now');
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/v1/home?section=active_now',
+      { method: 'GET' },
+    );
+  });
+
+  it('appends both section and cursor when provided', async () => {
+    mockApiRequest.mockResolvedValueOnce(
+      okResult(makeSection<ClusterResponse>([])),
+    );
+
+    await getHomeSection('other_active_signals', 'opaque-cursor-value');
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/v1/home?section=other_active_signals&cursor=opaque-cursor-value',
+      { method: 'GET' },
+    );
+  });
+
+  it('url-encodes the cursor value', async () => {
+    mockApiRequest.mockResolvedValueOnce(
+      okResult(makeSection<ClusterResponse>([])),
+    );
+
+    await getHomeSection('active_now', 'a+b/c=');
+
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      '/v1/home?section=active_now&cursor=a%2Bb%2Fc%3D',
+      { method: 'GET' },
+    );
+  });
+
+  it('returns a PagedSection with items and nextCursor', async () => {
+    const cluster = makeCluster({ id: 'c1' });
+    const section = { items: [cluster], nextCursor: 'abc', totalCount: 5 };
+    mockApiRequest.mockResolvedValueOnce(okResult(section));
+
+    const result = await getHomeSection('active_now');
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.items).toHaveLength(1);
+    expect(result.value.items[0]?.id).toBe('c1');
+    expect(result.value.nextCursor).toBe('abc');
+    expect(result.value.totalCount).toBe(5);
   });
 });
 

--- a/apps/citizen-mobile/__tests__/api/homeContract.test.ts
+++ b/apps/citizen-mobile/__tests__/api/homeContract.test.ts
@@ -1,0 +1,152 @@
+// apps/citizen-mobile/__tests__/api/homeContract.test.ts
+//
+// Contract shape tests verifying that the mobile HomeResponse type
+// exactly matches the backend PagedSection<T> structure returned by
+// GET /v1/home.
+//
+// These tests guard against contract drift between backend and mobile.
+
+import type {
+  ClusterResponse,
+  HomeResponse,
+  OfficialPostResponse,
+  PagedSection,
+} from '../../src/types/api';
+
+// ─── Fixtures ────────────────────────────────────────────────────────────────
+
+/** Minimal wire-format cluster matching ClusterResponseDto. */
+function wireCluster(): ClusterResponse {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    state: 'active',
+    category: 'water',
+    subcategorySlug: 'water_outage',
+    title: 'Water outage on Ngong Road',
+    summary: 'No water since 6am',
+    affectedCount: 12,
+    observingCount: 3,
+    createdAt: '2026-04-11T06:00:00Z',
+    updatedAt: '2026-04-11T06:30:00Z',
+    activatedAt: '2026-04-11T06:15:00Z',
+    possibleRestorationAt: null,
+    resolvedAt: null,
+    officialPosts: [],
+    myParticipation: null,
+  };
+}
+
+/** Minimal wire-format official post matching OfficialPostResponseDto. */
+function wireOfficialPost(): OfficialPostResponse {
+  return {
+    id: '00000000-0000-0000-0000-000000000002',
+    institutionId: '00000000-0000-0000-0000-000000000099',
+    type: 'live_update',
+    category: 'water',
+    title: 'Repair crew dispatched',
+    body: 'A repair crew has been dispatched to the area.',
+    startsAt: null,
+    endsAt: null,
+    status: 'active',
+    relatedClusterId: null,
+    isRestorationClaim: false,
+    createdAt: '2026-04-11T07:00:00Z',
+  };
+}
+
+function makePagedSection<T>(items: T[], nextCursor: string | null = null): PagedSection<T> {
+  return { items, nextCursor, totalCount: items.length };
+}
+
+// ─── HomeResponse shape ──────────────────────────────────────────────────────
+
+describe('HomeResponse contract shape', () => {
+  it('has exactly four required PagedSection properties', () => {
+    const response: HomeResponse = {
+      activeNow: makePagedSection<ClusterResponse>([]),
+      officialUpdates: makePagedSection<OfficialPostResponse>([]),
+      recurringAtThisTime: makePagedSection<ClusterResponse>([]),
+      otherActiveSignals: makePagedSection<ClusterResponse>([]),
+    };
+
+    // All four keys present
+    expect(Object.keys(response).sort()).toEqual([
+      'activeNow',
+      'officialUpdates',
+      'otherActiveSignals',
+      'recurringAtThisTime',
+    ]);
+  });
+
+  it('each section has items, nextCursor, and totalCount', () => {
+    const section = makePagedSection([wireCluster()]);
+
+    expect(section).toHaveProperty('items');
+    expect(section).toHaveProperty('nextCursor');
+    expect(section).toHaveProperty('totalCount');
+    expect(Array.isArray(section.items)).toBe(true);
+  });
+
+  it('activeNow items are ClusterResponse', () => {
+    const cluster = wireCluster();
+    const section = makePagedSection([cluster]);
+
+    const item = section.items[0]!;
+    expect(item).toHaveProperty('id');
+    expect(item).toHaveProperty('state');
+    expect(item).toHaveProperty('category');
+    expect(item).toHaveProperty('affectedCount');
+    expect(item).toHaveProperty('observingCount');
+    expect(item).toHaveProperty('officialPosts');
+    expect(item).toHaveProperty('myParticipation');
+  });
+
+  it('officialUpdates items are OfficialPostResponse', () => {
+    const post = wireOfficialPost();
+    const section = makePagedSection([post]);
+
+    const item = section.items[0]!;
+    expect(item).toHaveProperty('id');
+    expect(item).toHaveProperty('institutionId');
+    expect(item).toHaveProperty('type');
+    expect(item).toHaveProperty('title');
+    expect(item).toHaveProperty('body');
+    expect(item).toHaveProperty('isRestorationClaim');
+  });
+
+  it('populated response round-trips correctly', () => {
+    const response: HomeResponse = {
+      activeNow: makePagedSection([wireCluster()], 'cursor-1'),
+      officialUpdates: makePagedSection([wireOfficialPost()]),
+      recurringAtThisTime: makePagedSection<ClusterResponse>([]),
+      otherActiveSignals: makePagedSection([wireCluster(), wireCluster()]),
+    };
+
+    // Simulate JSON round-trip (as if received from backend)
+    const parsed: HomeResponse = JSON.parse(JSON.stringify(response));
+
+    expect(parsed.activeNow.items).toHaveLength(1);
+    expect(parsed.activeNow.nextCursor).toBe('cursor-1');
+    expect(parsed.officialUpdates.items).toHaveLength(1);
+    expect(parsed.recurringAtThisTime.items).toHaveLength(0);
+    expect(parsed.otherActiveSignals.items).toHaveLength(2);
+    expect(parsed.otherActiveSignals.totalCount).toBe(2);
+  });
+
+  it('calm state is computed from empty items arrays', () => {
+    const response: HomeResponse = {
+      activeNow: makePagedSection<ClusterResponse>([]),
+      officialUpdates: makePagedSection<OfficialPostResponse>([]),
+      recurringAtThisTime: makePagedSection<ClusterResponse>([]),
+      otherActiveSignals: makePagedSection<ClusterResponse>([]),
+    };
+
+    const isCalmState =
+      response.activeNow.items.length === 0 &&
+      response.officialUpdates.items.length === 0 &&
+      response.recurringAtThisTime.items.length === 0 &&
+      response.otherActiveSignals.items.length === 0;
+
+    expect(isCalmState).toBe(true);
+  });
+});

--- a/apps/citizen-mobile/src/api/clusters.ts
+++ b/apps/citizen-mobile/src/api/clusters.ts
@@ -26,36 +26,30 @@ import type {
  * parameter. Calling this with no follows (or unauthenticated) returns all
  * sections with items: [].
  *
- * Pass a `section` name to fetch only that section (paginated via cursor).
+ * For single-section pagination, use {@link getHomeSection} instead.
  */
-export async function getHome(
-  options: { section?: HomeSectionName; cursor?: string } = {},
-): Promise<Result<HomeResponse, ApiError>> {
-  const query: string[] = [];
-  if (options.section) {
-    query.push(`section=${encodeURIComponent(options.section)}`);
-  }
-  if (options.cursor) {
-    query.push(`cursor=${encodeURIComponent(options.cursor)}`);
-  }
-  const path = query.length > 0 ? `/v1/home?${query.join('&')}` : '/v1/home';
-  return apiRequest<HomeResponse>(path, { method: 'GET' });
+export async function getHome(): Promise<Result<HomeResponse, ApiError>> {
+  return apiRequest<HomeResponse>('/v1/home', { method: 'GET' });
 }
 
 /**
  * GET /v1/home?section=...&cursor=... — fetch a single paginated section.
  * Use this when paging "Load more" inside a specific section.
- * The backend returns a PagedSection<T> wrapper directly (not a HomeResponse).
+ * The backend returns a PagedSection<T> directly (not a HomeResponse).
+ *
+ * Callers should specify the item type explicitly when fetching
+ * official_updates: `getHomeSection<OfficialPostResponse>(...)`.
+ * Defaults to ClusterResponse for the three cluster sections.
  */
-export async function getHomeSection(
+export async function getHomeSection<T = ClusterResponse>(
   section: HomeSectionName,
   cursor?: string,
-): Promise<Result<PagedSection<ClusterResponse>, ApiError>> {
+): Promise<Result<PagedSection<T>, ApiError>> {
   const query: string[] = [`section=${encodeURIComponent(section)}`];
   if (cursor) {
     query.push(`cursor=${encodeURIComponent(cursor)}`);
   }
-  return apiRequest<PagedSection<ClusterResponse>>(
+  return apiRequest<PagedSection<T>>(
     `/v1/home?${query.join('&')}`,
     { method: 'GET' },
   );

--- a/apps/citizen-mobile/src/api/clusters.ts
+++ b/apps/citizen-mobile/src/api/clusters.ts
@@ -10,6 +10,7 @@ import type {
   ApiError,
   Result,
   ClusterResponse,
+  OfficialPostResponse,
   HomeResponse,
   HomeSectionName,
   PagedSection,
@@ -17,6 +18,10 @@ import type {
   ContextRequest,
   RestorationResponseRequest,
 } from '../types/api';
+
+/** Maps each home section name to its item type on the wire. */
+type SectionItemType<S extends HomeSectionName> =
+  S extends 'official_updates' ? OfficialPostResponse : ClusterResponse;
 
 /**
  * GET /v1/home
@@ -37,19 +42,19 @@ export async function getHome(): Promise<Result<HomeResponse, ApiError>> {
  * Use this when paging "Load more" inside a specific section.
  * The backend returns a PagedSection<T> directly (not a HomeResponse).
  *
- * Callers should specify the item type explicitly when fetching
- * official_updates: `getHomeSection<OfficialPostResponse>(...)`.
- * Defaults to ClusterResponse for the three cluster sections.
+ * The item type is inferred from the section name:
+ *   - 'official_updates' → OfficialPostResponse
+ *   - all others → ClusterResponse
  */
-export async function getHomeSection<T = ClusterResponse>(
-  section: HomeSectionName,
+export async function getHomeSection<S extends HomeSectionName>(
+  section: S,
   cursor?: string,
-): Promise<Result<PagedSection<T>, ApiError>> {
+): Promise<Result<PagedSection<SectionItemType<S>>, ApiError>> {
   const query: string[] = [`section=${encodeURIComponent(section)}`];
   if (cursor) {
     query.push(`cursor=${encodeURIComponent(cursor)}`);
   }
-  return apiRequest<PagedSection<T>>(
+  return apiRequest<PagedSection<SectionItemType<S>>>(
     `/v1/home?${query.join('&')}`,
     { method: 'GET' },
   );

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -247,6 +247,17 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
   spans auth transitions; derive readiness from React Query `isSuccess`/`isError` instead so the
   flag resets when auth state changes
 
+## OpenAPI rules
+
+- In OpenAPI 3.1, always list fields the backend unconditionally serialises in `required`, even
+  when they are `nullable: true`. `required` means present-on-wire, not non-null.
+
+## TypeScript API rules
+
+- When an API function returns different types based on a discriminant argument (e.g. section name),
+  use conditional types or overloads to infer the correct return type — never rely on generic
+  defaults (`T = SomeType`) that the caller might forget to override.
+
 ## Enum serialization rules
 
 - Never use `.ToString().ToLowerInvariant()` on multi-word PascalCase enums for wire output — it

--- a/docs/arch/LESSONS_LEARNED.md
+++ b/docs/arch/LESSONS_LEARNED.md
@@ -1135,3 +1135,19 @@ a CLI silently ignore a user-supplied option."
 **Root cause:** Used `.ToString().ToLowerInvariant()` as a shortcut for enum-to-wire conversion. This works for single-word values (`Unconfirmed` → `"unconfirmed"`) but silently fails for multi-word PascalCase values (`PossibleRestoration` → `"possiblerestoration"` instead of `"possible_restoration"`).
 **Fix applied:** Added a private `ToSnakeCase(SignalState)` helper (matching the existing pattern in `ClustersController` and `OfficialPostsService`) and used it in both the join and create return paths. Added a regression test asserting `PossibleRestoration` maps to `"possible_restoration"`.
 **Rule added:** Enum serialization → "Never use `.ToString().ToLowerInvariant()` on multi-word PascalCase enums for wire output. Use a PascalCase→snake_case helper."
+
+## PR #95 — Phase A4: align home feed response contract
+
+### Lesson 1: OpenAPI nullable fields must still be listed in `required`
+**File:** `02_openapi.yaml`
+**What Copilot flagged:** `ClusterPagedSection` and `OfficialPostPagedSection` omitted `nextCursor` from `required`, but the backend always includes it (as null or a string). Generated clients would treat it as optional/undefined instead of required-but-nullable.
+**Root cause:** Assumed `required` and `nullable` were mutually exclusive in OpenAPI 3.1. They are not — `required` means "always present in the JSON", `nullable: true` means "may be null". A field can be both.
+**Fix applied:** Added `nextCursor` to the `required` list on both paged section schemas (keeping `nullable: true`).
+**Rule added:** OpenAPI → "In OpenAPI 3.1, always list fields the backend unconditionally serialises in `required`, even when they are `nullable: true`. `required` means present-on-wire, not non-null."
+
+### Lesson 2: Generic default types silently mis-type discriminated API responses
+**File:** `apps/citizen-mobile/src/api/clusters.ts`
+**What Copilot flagged:** `getHomeSection<T = ClusterResponse>` defaults `T` to `ClusterResponse`, but calling with `'official_updates'` silently types the response as `PagedSection<ClusterResponse>` when the backend returns `OfficialPostResponse` items.
+**Root cause:** Used a generic default (`T = ClusterResponse`) as a convenience shortcut. The caller could override it, but nothing prevented the mis-typed default from being used silently.
+**Fix applied:** Replaced the default generic with a conditional type map (`SectionItemType<S>`) that infers the correct item type from the section name argument. `'official_updates'` now automatically resolves to `OfficialPostResponse`.
+**Rule added:** TypeScript API → "When an API function returns different types based on a discriminant argument (e.g. section name), use conditional types or overloads to infer the correct return type — never rely on generic defaults that the caller might forget to override."


### PR DESCRIPTION
## Summary

- Replaced untyped OpenAPI `PagedSection` (`items: {}`) with typed `ClusterPagedSection` and `OfficialPostPagedSection` schemas — items are now explicitly typed per section
- Added `required` fields to `HomeResponse` and both paged section schemas
- Documented single-section response variant (`?section=X` returns `PagedSection<T>` directly, not `HomeResponse`) via `oneOf` in OpenAPI
- Removed `section`/`cursor` params from `getHome()` — it now only returns the full `HomeResponse`; single-section fetching uses `getHomeSection<T>()` which is now generic for correct typing of `official_updates`
- Added contract shape test suite

## Behavior changes

- **Backend `/v1/home`**: No change — already returns the correct `PagedSection<T>` structure
- **OpenAPI**: Now truthfully documents item types per section and the two response shapes (full vs single-section)
- **Mobile `getHome()`**: No longer accepts `section`/`cursor` overloads that would silently mistype the response
- **Mobile `getHomeSection<T>()`**: Now generic — callers can specify `OfficialPostResponse` for `official_updates` section

## Stale assumptions removed

- OpenAPI `items: {}` (untyped) → now typed per section
- `getHome({ section })` returning `HomeResponse` when backend returns `PagedSection<T>` → removed, use `getHomeSection()` instead
- `getHomeSection()` hardcoded to `ClusterResponse` → now generic

## Test coverage

- **homeContract.test.ts** (6 tests): Verifies all 4 sections present, items/nextCursor/totalCount on each, correct item types, JSON round-trip, calm state computation
- **clusters.test.ts**: Updated `getHome` tests (no section params), added `getHomeSection` tests for URL construction, cursor encoding, and response shape

## Scope boundaries

- No locality filtering changes
- No feed UI redesign
- No restoration changes
- No pagination UI (cursor infra preserved)
- No backend code changes (already correct)

🤖 Generated with [Claude Code](https://claude.com/claude-code)