### PR TITLE
Docs: enforce PR scope discipline and documentation hygiene

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -557,23 +557,11 @@ npx tsc --noEmit
 ```
 
 ### After addressing a Copilot review comment
-In the same commit that fixes the issue:
-1. Fix the code
-2. Append a new entry to `docs/arch/LESSONS_LEARNED.md` using the template
-3. Add or update the corresponding rule in `docs/arch/CODING_STANDARDS.md`
-
-This is mandatory — not optional. The lesson must be recorded in the same
-commit as the fix so the fix and the lesson are permanently linked in history.
+Fix the code only. Do NOT auto-write to `docs/arch/LESSONS_LEARNED.md` or
+`docs/arch/CODING_STANDARDS.md` unless the user explicitly requests a
+documentation pass. See `docs/arch/CODING_STANDARDS.md` → "PR Scope Discipline"
+for the full rule.
 
 ### At the end of every session that included a git push
-
-Before declaring a session complete, check whether the pushed PR has any
-Copilot comments not yet recorded in `docs/arch/LESSONS_LEARNED.md`.
-
-Use the end-of-session check in `docs/arch/COPILOT_RESOLUTION_SKILL.md`
-(Situation B). If unrecorded lessons exist, append them and push the
-lesson commit to the PR branch before closing the session.
-
-This applies to ALL sessions — not just sessions explicitly about Copilot
-comments. A Phase B component PR, an integration test PR, a migration fix —
-all of them get the end-of-session check.
+No automatic documentation writes. If lessons were identified, note them
+internally — they will be recorded in a separate documentation pass when requested.

--- a/agent_prompts/agent_d_mobile.md
+++ b/agent_prompts/agent_d_mobile.md
@@ -550,10 +550,10 @@ After the PR is opened, run the end-of-session check from
 `docs/arch/COPILOT_RESOLUTION_SKILL.md` (Situation B).
 
 If any Copilot comments appear after push:
-1. Fix the issue
-2. Append to `docs/arch/LESSONS_LEARNED.md`
-3. Update `docs/arch/CODING_STANDARDS.md` if a new rule is needed
-4. All in the same commit as the fix
+1. Fix the code issue only
+2. Do NOT auto-write to `docs/arch/LESSONS_LEARNED.md` or `docs/arch/CODING_STANDARDS.md`
+   — documentation updates happen in a separate pass when explicitly requested
+3. See `docs/arch/CODING_STANDARDS.md` → "PR Scope Discipline"
 
 ---
 

--- a/agent_prompts/agent_d_mobile.md
+++ b/agent_prompts/agent_d_mobile.md
@@ -544,15 +544,15 @@ The commit message must include the self-validation result.
 
 ---
 
-## Stage 5: Lessons recording
+## Stage 5: Lessons deferral
 
-After the PR is opened, run the end-of-session check from
-`docs/arch/COPILOT_RESOLUTION_SKILL.md` (Situation B).
+Do NOT auto-write reusable lessons to `docs/arch/LESSONS_LEARNED.md` or
+`docs/arch/CODING_STANDARDS.md` after opening the PR. Documentation updates
+happen only in a separate pass when explicitly requested by the user.
 
 If any Copilot comments appear after push:
 1. Fix the code issue only
-2. Do NOT auto-write to `docs/arch/LESSONS_LEARNED.md` or `docs/arch/CODING_STANDARDS.md`
-   — documentation updates happen in a separate pass when explicitly requested
+2. Do NOT modify documentation files in the same commit
 3. See `docs/arch/CODING_STANDARDS.md` → "PR Scope Discipline"
 
 ---

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -283,7 +283,7 @@ Protected files (modify only in a dedicated documentation pass):
 ### Lessons and reusable patterns
 If a reusable lesson or pattern is identified during feature work or review resolution:
 - Note it internally for future reference
-- Do NOT auto-write it to LESSONS_LEARNED.md or CODING_STANDARDS.md
+- Do NOT auto-write it to docs/arch/LESSONS_LEARNED.md or docs/arch/CODING_STANDARDS.md
 - Wait for an explicit documentation-pass instruction from the user
 - If needed, include a brief note in the PR description instead of modifying documentation files
 

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -284,7 +284,7 @@ Protected files (modify only in a dedicated documentation pass):
 If a reusable lesson or pattern is identified during feature work or review resolution:
 - Note it internally for future reference
 - Do NOT auto-write it to docs/arch/LESSONS_LEARNED.md or docs/arch/CODING_STANDARDS.md
-- Wait for an explicit documentation-pass instruction from the user
+- Wait for an explicit documentation pass instruction from the user
 - If needed, include a brief note in the PR description instead of modifying documentation files
 
 ### Review resolution discipline

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -285,6 +285,7 @@ If a reusable lesson or pattern is identified during feature work or review reso
 - Note it internally for future reference
 - Do NOT auto-write it to LESSONS_LEARNED.md or CODING_STANDARDS.md
 - Wait for an explicit documentation-pass instruction from the user
+- If needed, include a brief note in the PR description instead of modifying documentation files
 
 ### Review resolution discipline
 When resolving Copilot or PR review comments:

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -10,13 +10,11 @@ that should have been caught before the PR was opened. Every item below maps
 to a real past failure. Do not skip any item.
 
 ### CI Failures
-- [ ] If CI fails on a push you made: fix the failure AND record a lesson in
-      docs/arch/LESSONS_LEARNED.md in the same commit that fixes the CI issue
-- [ ] CI failure lesson format: same template as Copilot lessons, with
-      "What Copilot flagged" replaced by "What CI reported"
-- [ ] Never push a second time to fix CI without first checking if the root
-      cause is already covered in docs/arch/LESSONS_LEARNED.md — if it is, note
-      "Existing lesson N reinforced" rather than creating a duplicate
+- [ ] If CI fails on a push you made: fix the failure in the same branch
+- [ ] Note any reusable lesson internally — do NOT write to docs/arch/LESSONS_LEARNED.md
+      or docs/arch/CODING_STANDARDS.md unless an explicit documentation pass is requested
+- [ ] Never push a second time to fix CI without first checking if the root cause
+      is covered in docs/arch/LESSONS_LEARNED.md for context
 
 ### Self-Review (run before every commit — mandatory)
 
@@ -261,3 +259,36 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
       or `dotnet tool restore` step before invoking the tool
 - [ ] PR description is updated to reflect the actual diff scope before review is requested
 - [ ] Shell commands in Markdown fenced code blocks use literal (unescaped) shell syntax
+
+---
+
+## PR Scope Discipline
+
+### Scope purity
+- PRs must remain strictly scoped to the requested task
+- No unrelated refactors, opportunistic improvements, or formatting churn
+- No mixed concerns in a single PR
+- If a separate issue is discovered during implementation, note it — do not fix it in the same PR
+
+### Documentation hygiene
+During implementation, maintenance passes, or PR review resolution, do NOT modify
+documentation files unless the task explicitly requests documentation changes.
+
+Protected files (modify only in a dedicated documentation pass):
+- `docs/arch/CODING_STANDARDS.md`
+- `docs/arch/LESSONS_LEARNED.md`
+- Architecture docs (`docs/arch/*.md`)
+- Process docs, workflow docs, runbooks
+
+### Lessons and reusable patterns
+If a reusable lesson or pattern is identified during feature work or review resolution:
+- Note it internally for future reference
+- Do NOT auto-write it to LESSONS_LEARNED.md or CODING_STANDARDS.md
+- Wait for an explicit documentation-pass instruction from the user
+
+### Review resolution discipline
+When resolving Copilot or PR review comments:
+- Apply the smallest correct code fix
+- Do not broaden scope beyond the comment
+- Do not add documentation changes unless explicitly requested
+- Decline incorrect comments with an explanation — do not force bad changes

--- a/docs/arch/COPILOT_RESOLUTION_SKILL.md
+++ b/docs/arch/COPILOT_RESOLUTION_SKILL.md
@@ -203,72 +203,15 @@ All changes committed and pushed. Ready for re-review.
 
 ---
 
-## Mandatory: Lesson Recording Step (runs at every PR close point)
+## Lesson Recording — deferred to explicit documentation passes
 
-This step runs in TWO situations — not just when addressing Copilot comments:
+Do NOT auto-write to `docs/arch/LESSONS_LEARNED.md` or `docs/arch/CODING_STANDARDS.md`
+during review resolution or at session end. Documentation changes happen only in a
+separate, explicitly requested documentation pass.
 
-### Situation A: You just addressed Copilot comments on a PR
-After fixing code, replying to threads, and resolving conversations:
+See `docs/arch/CODING_STANDARDS.md` → "PR Scope Discipline" for the authoritative rule.
 
-1. Check if a lesson entry already exists for this PR:
-   ```bash
-   grep "## PR #<N>" docs/arch/LESSONS_LEARNED.md
-   ```
-
-2. If no entry exists, OR if this specific issue is not yet documented:
-   Append a new entry using the template in LESSONS_LEARNED.md.
-
-3. This append MUST happen in the same commit as the code fix.
-   Never commit the fix without the lesson. Never commit the lesson without the fix.
-
-### Situation B: You are finishing ANY session that pushed to a PR branch
-
-SKIP this check if Situation A already ran in this session.
-Situation A is considered to have run if the session prompt contained
-any of: "address Copilot", "fix Copilot", "resolve Copilot", or
-explicitly referenced COPILOT_RESOLUTION_SKILL.md as the primary task.
-In that case, all lessons were already captured — do not re-fetch.
-
-At the end of every session that included a `git push origin <branch>`,
-run the following before declaring the session complete:
-
-```bash
-# Get the PR number for the current branch
-BRANCH=$(git branch --show-current)
-PR_NUMBER=$(gh pr list \
-  --repo irvinesunday/Hali \
-  --head "$BRANCH" \
-  --state open \
-  --json number \
-  --jq '.[0].number // empty' 2>/dev/null)
-
-if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
-  echo "Checking PR #$PR_NUMBER for unrecorded Copilot comments..."
-
-  # Fetch all Copilot inline comments
-  gh api repos/irvinesunday/Hali/pulls/${PR_NUMBER}/comments \
-    --jq '.[] | select(.user.login | test("copilot";"i")) |
-          "COMMENT: " + .path + " | " + (.body | split("\n")[0])' \
-    2>/dev/null
-
-  # Fetch all Copilot review bodies
-  gh api repos/irvinesunday/Hali/pulls/${PR_NUMBER}/reviews \
-    --jq '.[] | select(.user.login | test("copilot";"i")) |
-          select(.body != "") |
-          "REVIEW: " + (.body | split("\n")[0])' \
-    2>/dev/null
-fi
-```
-
-If this output shows Copilot comments that are NOT yet in LESSONS_LEARNED.md:
-  - Append the lessons NOW, before the session ends
-  - Commit them to the current branch with message:
-    `docs: record Copilot lessons from PR #N`
-  - Push to the PR branch
-
-If the PR has no Copilot comments, or all are already recorded: continue normally.
-
-### What a lesson entry must contain
+### Lesson entry template (for use during documentation passes)
 
 ```markdown
 ## PR #N — [PR title]
@@ -280,15 +223,3 @@ If the PR has no Copilot comments, or all are already recorded: continue normall
 **Fix applied:** [what changed]
 **Rule added:** [text of new rule or existing rule name this reinforces]
 ```
-
-### What counts as a lesson worth recording
-
-RECORD:
-- Any Copilot inline review comment on a file
-- Any Copilot PR-level review body with a specific concern
-- Any CI failure caused by code Claude Code generated
-
-DO NOT RECORD:
-- Copilot comments that say "Looks good" or are purely positive
-- Dependabot PR activity
-- Comments on files Claude Code did not touch in this PR


### PR DESCRIPTION
## Summary

Adds a permanent repo-level rule so feature PRs, maintenance passes, and review-resolution passes stay scope-pure and do not mutate documentation unless explicitly requested.

This is a repo-behavior update only. No application code, tests, or API contracts were changed.

## Changes

**docs/arch/CODING_STANDARDS.md** — New "PR Scope Discipline" section covering:
- Scope purity (no unrelated refactors or mixed concerns)
- Documentation hygiene (no doc file writes during implementation or review resolution)
- Lessons/patterns deferred to explicit documentation passes
- Review resolution discipline (smallest correct fix, no scope broadening)

Also updated "CI Failures" checklist to remove auto-write-to-LESSONS_LEARNED requirement.

**CLAUDE.md** — Replaced mandatory lesson-recording instructions with a deferral to CODING_STANDARDS.md → "PR Scope Discipline".

**docs/arch/COPILOT_RESOLUTION_SKILL.md** — Replaced the "Mandatory: Lesson Recording Step" section with a deferral note. Preserved the lesson entry template for use during documentation passes.

**agent_prompts/agent_d_mobile.md** — Updated Copilot post-push instructions to match the new rule.

## Confirmation

- No application code changed
- No tests changed
- No API contracts changed
- Only repo guidance files were modified
- All four files now consistently defer documentation writes to explicit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)