### PR TITLE
Phase A7: enable safe concurrent home section queries

### DIFF
--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -112,10 +112,10 @@ public class HomeController : ControllerBase
 
         return new HomeResponseDto
         {
-            ActiveNow = activeNowTask.Result,
-            OfficialUpdates = officialUpdatesTask.Result,
-            RecurringAtThisTime = recurringTask.Result,
-            OtherActiveSignals = otherActiveTask.Result
+            ActiveNow = await activeNowTask,
+            OfficialUpdates = await officialUpdatesTask,
+            RecurringAtThisTime = await recurringTask,
+            OtherActiveSignals = await otherActiveTask
         };
     }
 

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -6,8 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Hali.Application.Advisories;
-using Hali.Application.Clusters;
+using Hali.Application.Home;
 using Hali.Application.Notifications;
 using Hali.Contracts.Advisories;
 using Hali.Contracts.Clusters;
@@ -29,19 +28,16 @@ public class HomeController : ControllerBase
     private const int LimitOtherActive = 10;
     private static readonly TimeSpan CacheTtl = TimeSpan.FromSeconds(30);
 
-    private readonly IClusterRepository _clusters;
-    private readonly IOfficialPostsService _officialPosts;
+    private readonly IHomeFeedQueryService _feedQuery;
     private readonly IFollowService _follows;
     private readonly IDatabase _redis;
 
     public HomeController(
-        IClusterRepository clusters,
-        IOfficialPostsService officialPosts,
+        IHomeFeedQueryService feedQuery,
         IFollowService follows,
         IDatabase redis)
     {
-        _clusters = clusters;
-        _officialPosts = officialPosts;
+        _feedQuery = feedQuery;
         _follows = follows;
         _redis = redis;
     }
@@ -105,14 +101,21 @@ public class HomeController : ControllerBase
 
     private async Task<HomeResponseDto> BuildFullResponseAsync(List<Guid> localityIds, CancellationToken ct)
     {
-        // Sections run sequentially because all repository calls share a
-        // single scoped DbContext, which is not thread-safe.
+        // Each section task is safe to run concurrently because
+        // IHomeFeedQueryService creates an isolated DbContext per call.
+        var activeNowTask = BuildActiveNowSectionAsync(localityIds, null, ct);
+        var officialUpdatesTask = BuildOfficialUpdatesSectionAsync(localityIds, null, ct);
+        var recurringTask = BuildRecurringSectionAsync(localityIds, null, ct);
+        var otherActiveTask = BuildOtherActiveSectionAsync(localityIds, null, ct);
+
+        await Task.WhenAll(activeNowTask, officialUpdatesTask, recurringTask, otherActiveTask);
+
         return new HomeResponseDto
         {
-            ActiveNow = await BuildActiveNowSectionAsync(localityIds, null, ct),
-            OfficialUpdates = await BuildOfficialUpdatesSectionAsync(localityIds, null, ct),
-            RecurringAtThisTime = await BuildRecurringSectionAsync(localityIds, null, ct),
-            OtherActiveSignals = await BuildOtherActiveSectionAsync(localityIds, null, ct)
+            ActiveNow = activeNowTask.Result,
+            OfficialUpdates = officialUpdatesTask.Result,
+            RecurringAtThisTime = recurringTask.Result,
+            OtherActiveSignals = otherActiveTask.Result
         };
     }
 
@@ -122,7 +125,7 @@ public class HomeController : ControllerBase
         if (localityIds.Count == 0)
             return EmptyClusterSection();
 
-        var raw = await _clusters.GetActiveByLocalitiesPagedAsync(
+        var raw = await _feedQuery.GetActiveByLocalitiesPagedAsync(
             localityIds, recurringOnly: false, limit: LimitActiveNow + 1, cursorBefore, ct);
 
         return ToPagedClusterSection(raw, LimitActiveNow);
@@ -137,7 +140,7 @@ public class HomeController : ControllerBase
         var allPosts = new List<OfficialPostResponseDto>();
         foreach (var lid in localityIds)
         {
-            var posts = await _officialPosts.GetActiveByLocalityAsync(lid, ct);
+            var posts = await _feedQuery.GetOfficialPostsByLocalityAsync(lid, ct);
             allPosts.AddRange(posts);
         }
 
@@ -166,7 +169,7 @@ public class HomeController : ControllerBase
         if (localityIds.Count == 0)
             return EmptyClusterSection();
 
-        var raw = await _clusters.GetActiveByLocalitiesPagedAsync(
+        var raw = await _feedQuery.GetActiveByLocalitiesPagedAsync(
             localityIds, recurringOnly: true, limit: LimitRecurring + 1, cursorBefore, ct);
 
         return ToPagedClusterSection(raw, LimitRecurring);
@@ -175,7 +178,7 @@ public class HomeController : ControllerBase
     private async Task<PagedSection<ClusterResponseDto>> BuildOtherActiveSectionAsync(
         List<Guid> localityIds, DateTime? cursorBefore, CancellationToken ct)
     {
-        var raw = await _clusters.GetAllActivePagedAsync(localityIds, LimitOtherActive + 1, cursorBefore, ct);
+        var raw = await _feedQuery.GetAllActivePagedAsync(localityIds, LimitOtherActive + 1, cursorBefore, ct);
         return ToPagedClusterSection(raw, LimitOtherActive);
     }
 

--- a/src/Hali.Application/Home/IHomeFeedQueryService.cs
+++ b/src/Hali.Application/Home/IHomeFeedQueryService.cs
@@ -35,6 +35,6 @@ public interface IHomeFeedQueryService
     /// <summary>
     /// Returns published official posts scoped to a locality, mapped to response DTOs.
     /// </summary>
-    Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
+    Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
         Guid localityId, CancellationToken ct);
 }

--- a/src/Hali.Application/Home/IHomeFeedQueryService.cs
+++ b/src/Hali.Application/Home/IHomeFeedQueryService.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Contracts.Advisories;
+using Hali.Domain.Entities.Clusters;
+
+namespace Hali.Application.Home;
+
+/// <summary>
+/// Read-only query service for the home feed. Each method creates and
+/// disposes its own isolated DbContext so callers may run multiple
+/// methods concurrently via Task.WhenAll without DbContext thread-safety
+/// violations.
+/// </summary>
+public interface IHomeFeedQueryService
+{
+    /// <summary>
+    /// Returns active clusters for the specified localities with cursor-based pagination.
+    /// When <paramref name="recurringOnly"/> is true, only recurring; false, only non-recurring; null, all.
+    /// Caller should request limit+1 to detect whether a next page exists.
+    /// </summary>
+    Task<IReadOnlyList<SignalCluster>> GetActiveByLocalitiesPagedAsync(
+        IEnumerable<Guid> localityIds, bool? recurringOnly, int limit,
+        DateTime? cursorBefore, CancellationToken ct);
+
+    /// <summary>
+    /// Returns active clusters NOT in the specified localities with cursor-based pagination.
+    /// Caller should request limit+1 to detect whether a next page exists.
+    /// </summary>
+    Task<IReadOnlyList<SignalCluster>> GetAllActivePagedAsync(
+        IEnumerable<Guid> excludeLocalityIds, int limit,
+        DateTime? cursorBefore, CancellationToken ct);
+
+    /// <summary>
+    /// Returns published official posts scoped to a locality, mapped to response DTOs.
+    /// </summary>
+    Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
+        Guid localityId, CancellationToken ct);
+}

--- a/src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Hali.Application.Advisories;
 using Hali.Application.Auth;
 using Hali.Application.Clusters;
+using Hali.Application.Home;
 using Hali.Application.Notifications;
 using Hali.Application.Participation;
 using Hali.Application.Signals;
@@ -9,6 +10,7 @@ using Hali.Domain.Enums;
 using Hali.Infrastructure.Advisories;
 using Hali.Infrastructure.Auth;
 using Hali.Infrastructure.Clusters;
+using Hali.Infrastructure.Home;
 using Hali.Infrastructure.Data;
 using Hali.Infrastructure.Data.Advisories;
 using Hali.Infrastructure.Data.Auth;
@@ -114,6 +116,26 @@ public static class ServiceCollectionExtensions
 				npgsql.MapEnum<OfficialPostType>("official_post_type", null, Snake);
 			}));
 		services.AddScoped<IOfficialPostRepository, OfficialPostRepository>();
+
+		// DbContext factories for concurrent read queries (home feed).
+		// AddDbContextFactory coexists with AddDbContext — the scoped context
+		// remains available for write paths while the factory creates isolated
+		// instances for parallel reads.
+		services.AddDbContextFactory<ClustersDbContext>((sp, opts) =>
+			opts.UseNpgsql(sp.GetRequiredService<HaliDataSources>().Clusters, npgsql =>
+			{
+				npgsql.UseNetTopologySuite();
+				npgsql.MapEnum<CivicCategory>("civic_category", null, Snake);
+				npgsql.MapEnum<SignalState>("signal_state", null, Snake);
+			}));
+		services.AddDbContextFactory<AdvisoriesDbContext>((sp, opts) =>
+			opts.UseNpgsql(sp.GetRequiredService<HaliDataSources>().Advisories, npgsql =>
+			{
+				npgsql.UseNetTopologySuite();
+				npgsql.MapEnum<CivicCategory>("civic_category", null, Snake);
+				npgsql.MapEnum<OfficialPostType>("official_post_type", null, Snake);
+			}));
+		services.AddSingleton<IHomeFeedQueryService, HomeFeedQueryService>();
 
 		// Notifications
 		services.AddDbContext<NotificationsDbContext>((sp, opts) =>

--- a/src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -117,24 +117,8 @@ public static class ServiceCollectionExtensions
 			}));
 		services.AddScoped<IOfficialPostRepository, OfficialPostRepository>();
 
-		// DbContext factories for concurrent read queries (home feed).
-		// AddDbContextFactory coexists with AddDbContext — the scoped context
-		// remains available for write paths while the factory creates isolated
-		// instances for parallel reads.
-		services.AddDbContextFactory<ClustersDbContext>((sp, opts) =>
-			opts.UseNpgsql(sp.GetRequiredService<HaliDataSources>().Clusters, npgsql =>
-			{
-				npgsql.UseNetTopologySuite();
-				npgsql.MapEnum<CivicCategory>("civic_category", null, Snake);
-				npgsql.MapEnum<SignalState>("signal_state", null, Snake);
-			}));
-		services.AddDbContextFactory<AdvisoriesDbContext>((sp, opts) =>
-			opts.UseNpgsql(sp.GetRequiredService<HaliDataSources>().Advisories, npgsql =>
-			{
-				npgsql.UseNetTopologySuite();
-				npgsql.MapEnum<CivicCategory>("civic_category", null, Snake);
-				npgsql.MapEnum<OfficialPostType>("official_post_type", null, Snake);
-			}));
+		// Home feed read-query service — creates isolated DbContext instances
+		// per query via IServiceScopeFactory to enable safe concurrent reads.
 		services.AddSingleton<IHomeFeedQueryService, HomeFeedQueryService>();
 
 		// Notifications

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -71,7 +71,7 @@ public class HomeFeedQueryService : IHomeFeedQueryService
         return await q.OrderByDescending(c => c.ActivatedAt).Take(limit).ToListAsync(ct);
     }
 
-    public async Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
+    public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
         Guid localityId, CancellationToken ct)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Home;
+using Hali.Contracts.Advisories;
+using Hali.Domain.Entities.Advisories;
+using Hali.Domain.Entities.Clusters;
+using Hali.Infrastructure.Data.Advisories;
+using Hali.Infrastructure.Data.Clusters;
+using Microsoft.EntityFrameworkCore;
+
+namespace Hali.Infrastructure.Home;
+
+/// <summary>
+/// Read-only home feed query service. Each method creates and disposes
+/// its own DbContext via IDbContextFactory, making concurrent calls safe.
+/// All queries use AsNoTracking — this service never mutates data.
+/// </summary>
+public class HomeFeedQueryService : IHomeFeedQueryService
+{
+    private readonly IDbContextFactory<ClustersDbContext> _clustersFactory;
+    private readonly IDbContextFactory<AdvisoriesDbContext> _advisoriesFactory;
+
+    public HomeFeedQueryService(
+        IDbContextFactory<ClustersDbContext> clustersFactory,
+        IDbContextFactory<AdvisoriesDbContext> advisoriesFactory)
+    {
+        _clustersFactory = clustersFactory;
+        _advisoriesFactory = advisoriesFactory;
+    }
+
+    public async Task<IReadOnlyList<SignalCluster>> GetActiveByLocalitiesPagedAsync(
+        IEnumerable<Guid> localityIds, bool? recurringOnly, int limit,
+        DateTime? cursorBefore, CancellationToken ct)
+    {
+        await using var db = await _clustersFactory.CreateDbContextAsync(ct);
+
+        var ids = localityIds.ToList();
+        var q = db.SignalClusters
+            .AsNoTracking()
+            .Where(c => c.LocalityId != null && ids.Contains(c.LocalityId.Value) && (int)c.State == 1);
+
+        if (recurringOnly == true)
+            q = q.Where(c => c.TemporalType == "recurring");
+        else if (recurringOnly == false)
+            q = q.Where(c => c.TemporalType != "recurring");
+
+        if (cursorBefore.HasValue)
+            q = q.Where(c => c.ActivatedAt < cursorBefore.Value);
+
+        return await q.OrderByDescending(c => c.ActivatedAt).Take(limit).ToListAsync(ct);
+    }
+
+    public async Task<IReadOnlyList<SignalCluster>> GetAllActivePagedAsync(
+        IEnumerable<Guid> excludeLocalityIds, int limit,
+        DateTime? cursorBefore, CancellationToken ct)
+    {
+        await using var db = await _clustersFactory.CreateDbContextAsync(ct);
+
+        var excludeIds = excludeLocalityIds.ToList();
+        var q = db.SignalClusters
+            .AsNoTracking()
+            .Where(c => (int)c.State == 1 &&
+                        (c.LocalityId == null || !excludeIds.Contains(c.LocalityId.Value)));
+
+        if (cursorBefore.HasValue)
+            q = q.Where(c => c.ActivatedAt < cursorBefore.Value);
+
+        return await q.OrderByDescending(c => c.ActivatedAt).Take(limit).ToListAsync(ct);
+    }
+
+    public async Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
+        Guid localityId, CancellationToken ct)
+    {
+        await using var db = await _advisoriesFactory.CreateDbContextAsync(ct);
+
+        var postIds = await db.OfficialPostScopes
+            .AsNoTracking()
+            .Where(s => s.LocalityId == localityId)
+            .Select(s => s.OfficialPostId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        var posts = await db.OfficialPosts
+            .AsNoTracking()
+            .Where(p => postIds.Contains(p.Id) && p.Status == "published")
+            .OrderByDescending(p => p.CreatedAt)
+            .ToListAsync(ct);
+
+        return posts.Select(MapToDto).ToList();
+    }
+
+    // ── DTO mapping (mirrors OfficialPostsService.MapToDto exactly) ─────────
+
+    private static string EnumToSnakeCase(string name) =>
+        Regex.Replace(name, "(?<=[a-z])([A-Z])", "_$1").ToLowerInvariant();
+
+    private static OfficialPostResponseDto MapToDto(OfficialPost p) => new(
+        p.Id,
+        p.InstitutionId,
+        EnumToSnakeCase(p.Type.ToString()),
+        EnumToSnakeCase(p.Category.ToString()),
+        p.Title,
+        p.Body,
+        p.StartsAt,
+        p.EndsAt,
+        p.Status,
+        p.RelatedClusterId,
+        p.IsRestorationClaim,
+        p.CreatedAt);
+}

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -11,32 +11,30 @@ using Hali.Domain.Entities.Clusters;
 using Hali.Infrastructure.Data.Advisories;
 using Hali.Infrastructure.Data.Clusters;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Hali.Infrastructure.Home;
 
 /// <summary>
-/// Read-only home feed query service. Each method creates and disposes
-/// its own DbContext via IDbContextFactory, making concurrent calls safe.
-/// All queries use AsNoTracking — this service never mutates data.
+/// Read-only home feed query service. Each method creates a new DI scope
+/// and resolves a fresh DbContext, making concurrent calls safe — no two
+/// tasks share a DbContext instance. All queries use AsNoTracking.
 /// </summary>
 public class HomeFeedQueryService : IHomeFeedQueryService
 {
-    private readonly IDbContextFactory<ClustersDbContext> _clustersFactory;
-    private readonly IDbContextFactory<AdvisoriesDbContext> _advisoriesFactory;
+    private readonly IServiceScopeFactory _scopeFactory;
 
-    public HomeFeedQueryService(
-        IDbContextFactory<ClustersDbContext> clustersFactory,
-        IDbContextFactory<AdvisoriesDbContext> advisoriesFactory)
+    public HomeFeedQueryService(IServiceScopeFactory scopeFactory)
     {
-        _clustersFactory = clustersFactory;
-        _advisoriesFactory = advisoriesFactory;
+        _scopeFactory = scopeFactory;
     }
 
     public async Task<IReadOnlyList<SignalCluster>> GetActiveByLocalitiesPagedAsync(
         IEnumerable<Guid> localityIds, bool? recurringOnly, int limit,
         DateTime? cursorBefore, CancellationToken ct)
     {
-        await using var db = await _clustersFactory.CreateDbContextAsync(ct);
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClustersDbContext>();
 
         var ids = localityIds.ToList();
         var q = db.SignalClusters
@@ -58,7 +56,8 @@ public class HomeFeedQueryService : IHomeFeedQueryService
         IEnumerable<Guid> excludeLocalityIds, int limit,
         DateTime? cursorBefore, CancellationToken ct)
     {
-        await using var db = await _clustersFactory.CreateDbContextAsync(ct);
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<ClustersDbContext>();
 
         var excludeIds = excludeLocalityIds.ToList();
         var q = db.SignalClusters
@@ -75,7 +74,8 @@ public class HomeFeedQueryService : IHomeFeedQueryService
     public async Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
         Guid localityId, CancellationToken ct)
     {
-        await using var db = await _advisoriesFactory.CreateDbContextAsync(ct);
+        await using var scope = _scopeFactory.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<AdvisoriesDbContext>();
 
         var postIds = await db.OfficialPostScopes
             .AsNoTracking()

--- a/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
@@ -77,7 +77,7 @@ public class HomeFeedConcurrencyTests
             finally { Exit(); }
         }
 
-        public async Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
+        public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
             Guid localityId, CancellationToken ct)
         {
             Enter();

--- a/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Home;
+using Hali.Contracts.Advisories;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Enums;
+using Xunit;
+
+namespace Hali.Tests.Unit.Home;
+
+/// <summary>
+/// A7: Tests proving that the home feed can safely run concurrent section
+/// queries via IHomeFeedQueryService without shared-state violations.
+/// Each test simulates the concurrent execution pattern used by
+/// BuildFullResponseAsync — multiple section tasks in Task.WhenAll.
+/// </summary>
+public class HomeFeedConcurrencyTests
+{
+    // ── Fake IHomeFeedQueryService that tracks concurrent calls ──────────────
+
+    private sealed class TrackingFeedQueryService : IHomeFeedQueryService
+    {
+        private int _activeCalls;
+        private int _peakConcurrency;
+        private readonly object _lock = new();
+
+        public int PeakConcurrency => _peakConcurrency;
+
+        private void Enter()
+        {
+            lock (_lock)
+            {
+                _activeCalls++;
+                if (_activeCalls > _peakConcurrency)
+                    _peakConcurrency = _activeCalls;
+            }
+        }
+
+        private void Exit()
+        {
+            lock (_lock) { _activeCalls--; }
+        }
+
+        public async Task<IReadOnlyList<SignalCluster>> GetActiveByLocalitiesPagedAsync(
+            IEnumerable<Guid> localityIds, bool? recurringOnly, int limit,
+            DateTime? cursorBefore, CancellationToken ct)
+        {
+            Enter();
+            try
+            {
+                await Task.Delay(10, ct); // simulate DB latency
+                var ids = localityIds.ToList();
+                if (ids.Count == 0)
+                    return new List<SignalCluster>();
+                return new List<SignalCluster>
+                {
+                    MakeCluster(ids[0], recurringOnly == true ? "recurring" : null)
+                };
+            }
+            finally { Exit(); }
+        }
+
+        public async Task<IReadOnlyList<SignalCluster>> GetAllActivePagedAsync(
+            IEnumerable<Guid> excludeLocalityIds, int limit,
+            DateTime? cursorBefore, CancellationToken ct)
+        {
+            Enter();
+            try
+            {
+                await Task.Delay(10, ct);
+                return new List<SignalCluster> { MakeCluster(Guid.NewGuid()) };
+            }
+            finally { Exit(); }
+        }
+
+        public async Task<List<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
+            Guid localityId, CancellationToken ct)
+        {
+            Enter();
+            try
+            {
+                await Task.Delay(10, ct);
+                return new List<OfficialPostResponseDto>();
+            }
+            finally { Exit(); }
+        }
+
+        private static SignalCluster MakeCluster(Guid localityId, string? temporalType = null) => new()
+        {
+            Id = Guid.NewGuid(),
+            State = SignalState.Active,
+            Category = CivicCategory.Roads,
+            LocalityId = localityId,
+            TemporalType = temporalType,
+            ActivatedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow
+        };
+    }
+
+    // ── Test 1: concurrent section queries execute in parallel ────────────────
+
+    [Fact]
+    public async Task ConcurrentSections_ExecuteInParallel()
+    {
+        var svc = new TrackingFeedQueryService();
+        var localityIds = new List<Guid> { Guid.NewGuid() };
+
+        // Mirror BuildFullResponseAsync pattern
+        var t1 = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);
+        var t2 = svc.GetOfficialPostsByLocalityAsync(localityIds[0], CancellationToken.None);
+        var t3 = svc.GetActiveByLocalitiesPagedAsync(localityIds, true, 11, null, CancellationToken.None);
+        var t4 = svc.GetAllActivePagedAsync(localityIds, 11, null, CancellationToken.None);
+
+        await Task.WhenAll(t1, t2, t3, t4);
+
+        // At least 2 of the 4 tasks should have overlapped
+        Assert.True(svc.PeakConcurrency >= 2,
+            $"Expected concurrent execution but peak was {svc.PeakConcurrency}");
+    }
+
+    // ── Test 2: all four sections return results under concurrency ────────────
+
+    [Fact]
+    public async Task ConcurrentSections_AllReturnResults()
+    {
+        var svc = new TrackingFeedQueryService();
+        var localityIds = new List<Guid> { Guid.NewGuid() };
+
+        var t1 = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);
+        var t2 = svc.GetOfficialPostsByLocalityAsync(localityIds[0], CancellationToken.None);
+        var t3 = svc.GetActiveByLocalitiesPagedAsync(localityIds, true, 11, null, CancellationToken.None);
+        var t4 = svc.GetAllActivePagedAsync(localityIds, 11, null, CancellationToken.None);
+
+        await Task.WhenAll(t1, t2, t3, t4);
+
+        Assert.NotEmpty(t1.Result);
+        Assert.NotNull(t2.Result);
+        Assert.NotEmpty(t3.Result);
+        Assert.NotEmpty(t4.Result);
+    }
+
+    // ── Test 3: single-section fetch is also safe (no concurrency needed) ────
+
+    [Fact]
+    public async Task SingleSectionFetch_WorksIndependently()
+    {
+        var svc = new TrackingFeedQueryService();
+        var localityIds = new List<Guid> { Guid.NewGuid() };
+
+        var result = await svc.GetActiveByLocalitiesPagedAsync(
+            localityIds, false, 21, null, CancellationToken.None);
+
+        Assert.NotEmpty(result);
+        Assert.Equal(1, svc.PeakConcurrency);
+    }
+
+    // ── Test 4: empty locality list returns empty without calling DB ─────────
+
+    [Fact]
+    public async Task EmptyLocalityIds_ReturnsEmptyResults()
+    {
+        var svc = new TrackingFeedQueryService();
+        var empty = new List<Guid>();
+
+        // The controller guards against empty locality IDs before calling
+        // the service, so this tests the contract boundary
+        var result = await svc.GetActiveByLocalitiesPagedAsync(
+            empty, false, 21, null, CancellationToken.None);
+
+        // The fake returns a cluster even for empty — the real guard is in the controller
+        Assert.NotNull(result);
+    }
+
+    // ── Test 5: concurrent execution preserves section-specific filtering ────
+
+    [Fact]
+    public async Task ConcurrentExecution_PreservesSectionFiltering()
+    {
+        var svc = new TrackingFeedQueryService();
+        var localityIds = new List<Guid> { Guid.NewGuid() };
+
+        var activeNowTask = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);
+        var recurringTask = svc.GetActiveByLocalitiesPagedAsync(localityIds, true, 11, null, CancellationToken.None);
+
+        await Task.WhenAll(activeNowTask, recurringTask);
+
+        // activeNow should have non-recurring cluster
+        Assert.All(activeNowTask.Result, c => Assert.NotEqual("recurring", c.TemporalType));
+
+        // recurring should have recurring cluster
+        Assert.All(recurringTask.Result, c => Assert.Equal("recurring", c.TemporalType));
+    }
+}

--- a/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
@@ -12,10 +12,11 @@ using Xunit;
 namespace Hali.Tests.Unit.Home;
 
 /// <summary>
-/// A7: Tests proving that the home feed can safely run concurrent section
-/// queries via IHomeFeedQueryService without shared-state violations.
-/// Each test simulates the concurrent execution pattern used by
-/// BuildFullResponseAsync — multiple section tasks in Task.WhenAll.
+/// A7: Tests validating the concurrent execution pattern used for home feed
+/// section queries with a fake <see cref="IHomeFeedQueryService" />.
+/// These tests verify that multiple section tasks can overlap and complete
+/// under <see cref="Task.WhenAll(System.Collections.Generic.IEnumerable{System.Threading.Tasks.Task})" />,
+/// but they do not exercise real EF Core or DbContext thread-safety behavior.
 /// </summary>
 public class HomeFeedConcurrencyTests
 {
@@ -103,7 +104,7 @@ public class HomeFeedConcurrencyTests
         };
     }
 
-    // ── Test 1: concurrent section queries execute in parallel ────────────────
+    // ── Test 1: fire-then-await pattern achieves concurrent execution ──────────
 
     [Fact]
     public async Task ConcurrentSections_ExecuteInParallel()

--- a/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
@@ -139,10 +139,10 @@ public class HomeFeedConcurrencyTests
 
         await Task.WhenAll(t1, t2, t3, t4);
 
-        Assert.NotEmpty(t1.Result);
-        Assert.NotNull(t2.Result);
-        Assert.NotEmpty(t3.Result);
-        Assert.NotEmpty(t4.Result);
+        Assert.NotEmpty(await t1);
+        Assert.NotNull(await t2);
+        Assert.NotEmpty(await t3);
+        Assert.NotEmpty(await t4);
     }
 
     // ── Test 3: single-section fetch is also safe (no concurrency needed) ────
@@ -173,8 +173,7 @@ public class HomeFeedConcurrencyTests
         var result = await svc.GetActiveByLocalitiesPagedAsync(
             empty, false, 21, null, CancellationToken.None);
 
-        // The fake returns a cluster even for empty — the real guard is in the controller
-        Assert.NotNull(result);
+        Assert.Empty(result);
     }
 
     // ── Test 5: concurrent execution preserves section-specific filtering ────
@@ -191,9 +190,9 @@ public class HomeFeedConcurrencyTests
         await Task.WhenAll(activeNowTask, recurringTask);
 
         // activeNow should have non-recurring cluster
-        Assert.All(activeNowTask.Result, c => Assert.NotEqual("recurring", c.TemporalType));
+        Assert.All(await activeNowTask, c => Assert.NotEqual("recurring", c.TemporalType));
 
         // recurring should have recurring cluster
-        Assert.All(recurringTask.Result, c => Assert.Equal("recurring", c.TemporalType));
+        Assert.All(await recurringTask, c => Assert.Equal("recurring", c.TemporalType));
     }
 }


### PR DESCRIPTION
## Summary

Solves the DbContext thread-safety constraint that blocked concurrent home feed section building in A6. Copilot correctly identified that `Task.WhenAll` over repository calls sharing a single scoped `DbContext` throws at runtime. A7 introduces `IServiceScopeFactory`-based scope isolation for safe concurrent reads.

## Architecture change

### New: `IHomeFeedQueryService` (Application layer)
Read-only query service interface with methods for each home section's data needs:
- `GetActiveByLocalitiesPagedAsync` — active/recurring cluster queries
- `GetAllActivePagedAsync` — other-active cluster queries
- `GetOfficialPostsByLocalityAsync` — official posts per locality

### New: `HomeFeedQueryService` (Infrastructure layer)
Implementation using `IServiceScopeFactory` to create isolated DI scopes per query:
- Each method call creates a new `AsyncServiceScope` and resolves a fresh DbContext
- Context is disposed after the query completes (`await using`)
- All queries use `AsNoTracking()` — read-only, no change tracking
- Exact same query logic as the existing repositories

### DI registration
- `IHomeFeedQueryService` registered as singleton (holds only `IServiceScopeFactory`, no mutable state)
- Scoped DbContexts remain available for write paths; per-scope resolution provides isolated instances for parallel reads

### HomeController
- Now injects `IHomeFeedQueryService` instead of `IClusterRepository` + `IOfficialPostsService`
- `BuildFullResponseAsync` re-enabled with `Task.WhenAll` — safe because each section task creates its own DI scope with an isolated DbContext

## Behavior preserved

| Scenario | Before A7 | After A7 |
|---|---|---|
| `/v1/home` | Sequential sections, scoped DbContext | Concurrent sections, scope-isolated DbContext |
| `/v1/home?localityId=...` | Same | Same |
| `/v1/home?section=...` | Sequential, scoped DbContext | Sequential, scope-isolated DbContext |
| Unauthenticated | Empty sections | Empty sections |
| Pagination | DB-level cursor + limit | Identical |
| Caching | Redis 30s TTL, locality-keyed | Identical |

## Test coverage (5 new tests)

1. `ConcurrentSections_ExecuteInParallel` — fire-then-await pattern achieves overlapping execution
2. `ConcurrentSections_AllReturnResults` — all 4 sections return data under concurrency
3. `SingleSectionFetch_WorksIndependently` — section fetch works without concurrency
4. `EmptyLocalityIds_ReturnsEmptyResults` — empty input handled correctly
5. `ConcurrentExecution_PreservesSectionFiltering` — recurring/non-recurring partitioning preserved under concurrency

## Files changed

| File | Why |
|---|---|
| `src/Hali.Application/Home/IHomeFeedQueryService.cs` | New interface for concurrent-safe home feed reads |
| `src/Hali.Infrastructure/Home/HomeFeedQueryService.cs` | Implementation using IServiceScopeFactory |
| `src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs` | Register service as singleton |
| `src/Hali.Api/Controllers/HomeController.cs` | Use new service, re-enable Task.WhenAll |
| `tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs` | 5 new concurrency tests |

## Scope boundaries

- No API contract changes (no OpenAPI modifications)

## Note on duplicate MapToDto

`HomeFeedQueryService.MapToDto` mirrors `OfficialPostsService.MapToDto`. This is intentional — extracting a shared mapper is a refactoring concern for a separate PR. The comment on line 96 documents the duplication.