### PR TITLE
Phase A8: add observability for home feed and signal routing

### DIFF
--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
@@ -8,12 +9,14 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Home;
 using Hali.Application.Notifications;
+using Hali.Application.Observability;
 using Hali.Contracts.Advisories;
 using Hali.Contracts.Clusters;
 using Hali.Contracts.Home;
 using Hali.Domain.Entities.Clusters;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using StackExchange.Redis;
 
 namespace Hali.Api.Controllers;
@@ -31,15 +34,18 @@ public class HomeController : ControllerBase
     private readonly IHomeFeedQueryService _feedQuery;
     private readonly IFollowService _follows;
     private readonly IDatabase _redis;
+    private readonly ILogger<HomeController> _logger;
 
     public HomeController(
         IHomeFeedQueryService feedQuery,
         IFollowService follows,
-        IDatabase redis)
+        IDatabase redis,
+        ILogger<HomeController> logger)
     {
         _feedQuery = feedQuery;
         _follows = follows;
         _redis = redis;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -50,38 +56,89 @@ public class HomeController : ControllerBase
         [FromQuery] Guid? localityId,
         CancellationToken ct)
     {
-        // Only authenticated users may scope the feed to an explicit locality.
-        // Anonymous callers fall back to the followed-localities path, which
-        // returns empty sections for guests.
-        bool isAuthenticated = User.Identity?.IsAuthenticated == true;
-        var localityIds = localityId.HasValue && isAuthenticated
-            ? new List<Guid> { localityId.Value }
-            : await GetFollowedLocalityIdsAsync(ct);
-        var cursorDt = DecodeCursor(cursor);
+        var sw = Stopwatch.StartNew();
+        _logger.LogInformation("{EventName}", ObservabilityEvents.HomeRequestStarted);
 
-        // Section-specific paginated request — skip cache, return single section
-        if (section is not null)
+        try
         {
-            var paged = await GetPagedSectionAsync(section, localityIds, cursorDt, ct);
-            if (paged is null) return BadRequest(new { error = "Unknown section name" });
-            return Ok(paged);
-        }
+            // Only authenticated users may scope the feed to an explicit locality.
+            // Anonymous callers fall back to the followed-localities path, which
+            // returns empty sections for guests.
+            bool isAuthenticated = User.Identity?.IsAuthenticated == true;
+            var localityIds = localityId.HasValue && isAuthenticated
+                ? new List<Guid> { localityId.Value }
+                : await GetFollowedLocalityIdsAsync(ct);
+            var cursorDt = DecodeCursor(cursor);
 
-        // Full home response — try Redis cache for first page
-        if (cursor is null && localityIds.Count > 0)
+            // Log locality scoping mode
+            if (localityId.HasValue && isAuthenticated)
+                _logger.LogInformation("{EventName} localityId={LocalityId}",
+                    ObservabilityEvents.HomeLocalityScopeExplicit, localityId.Value);
+            else if (localityIds.Count > 0)
+                _logger.LogInformation("{EventName} localityCount={LocalityCount}",
+                    ObservabilityEvents.HomeLocalityScopeFallback, localityIds.Count);
+            else
+                _logger.LogInformation("{EventName}", ObservabilityEvents.HomeLocalityScopeGuestEmpty);
+
+            // Section-specific paginated request — skip cache, return single section
+            if (section is not null)
+            {
+                var paged = await GetPagedSectionAsync(section, localityIds, cursorDt, ct);
+                if (paged is null) return BadRequest(new { error = "Unknown section name" });
+
+                sw.Stop();
+                _logger.LogInformation(
+                    "{EventName} section={Section} durationMs={DurationMs}",
+                    ObservabilityEvents.HomeRequestCompleted, section, sw.ElapsedMilliseconds);
+                return Ok(paged);
+            }
+
+            // Full home response — try Redis cache for first page
+            if (cursor is null && localityIds.Count > 0)
+            {
+                var cacheKey = BuildCacheKey(localityIds);
+                _logger.LogInformation("{EventName}", ObservabilityEvents.HomeCacheChecked);
+
+                RedisValue cached = await _redis.StringGetAsync(cacheKey);
+                if (cached.HasValue)
+                {
+                    sw.Stop();
+                    _logger.LogInformation("{EventName} durationMs={DurationMs}",
+                        ObservabilityEvents.HomeCacheHit, sw.ElapsedMilliseconds);
+                    _logger.LogInformation(
+                        "{EventName} durationMs={DurationMs} cacheHit={CacheHit}",
+                        ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds, true);
+                    return Content(cached!, "application/json");
+                }
+
+                _logger.LogInformation("{EventName}", ObservabilityEvents.HomeCacheMiss);
+
+                var response = await BuildFullResponseAsync(localityIds, ct);
+                var json = JsonSerializer.Serialize(response);
+                await _redis.StringSetAsync(cacheKey, json, CacheTtl);
+
+                sw.Stop();
+                _logger.LogInformation(
+                    "{EventName} durationMs={DurationMs} cacheHit={CacheHit}",
+                    ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds, false);
+                return Ok(response);
+            }
+
+            var fullResponse = await BuildFullResponseAsync(localityIds, ct);
+            sw.Stop();
+            _logger.LogInformation(
+                "{EventName} durationMs={DurationMs}",
+                ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds);
+            return Ok(fullResponse);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            var cacheKey = BuildCacheKey(localityIds);
-            RedisValue cached = await _redis.StringGetAsync(cacheKey);
-            if (cached.HasValue)
-                return Content(cached!, "application/json");
-
-            var response = await BuildFullResponseAsync(localityIds, ct);
-            var json = JsonSerializer.Serialize(response);
-            await _redis.StringSetAsync(cacheKey, json, CacheTtl);
-            return Ok(response);
+            sw.Stop();
+            _logger.LogError(ex,
+                "{EventName} durationMs={DurationMs}",
+                ObservabilityEvents.HomeRequestFailed, sw.ElapsedMilliseconds);
+            throw;
         }
-
-        return Ok(await BuildFullResponseAsync(localityIds, ct));
     }
 
     // ── Section helpers ──────────────────────────────────────────────────────
@@ -103,10 +160,14 @@ public class HomeController : ControllerBase
     {
         // Each section task is safe to run concurrently because
         // IHomeFeedQueryService creates an isolated DbContext per call.
-        var activeNowTask = BuildActiveNowSectionAsync(localityIds, null, ct);
-        var officialUpdatesTask = BuildOfficialUpdatesSectionAsync(localityIds, null, ct);
-        var recurringTask = BuildRecurringSectionAsync(localityIds, null, ct);
-        var otherActiveTask = BuildOtherActiveSectionAsync(localityIds, null, ct);
+        var activeNowTask = BuildTimedSectionAsync("active_now",
+            () => BuildActiveNowSectionAsync(localityIds, null, ct));
+        var officialUpdatesTask = BuildTimedSectionAsync("official_updates",
+            () => BuildOfficialUpdatesSectionAsync(localityIds, null, ct));
+        var recurringTask = BuildTimedSectionAsync("recurring_at_this_time",
+            () => BuildRecurringSectionAsync(localityIds, null, ct));
+        var otherActiveTask = BuildTimedSectionAsync("other_active_signals",
+            () => BuildOtherActiveSectionAsync(localityIds, null, ct));
 
         await Task.WhenAll(activeNowTask, officialUpdatesTask, recurringTask, otherActiveTask);
 
@@ -117,6 +178,26 @@ public class HomeController : ControllerBase
             RecurringAtThisTime = await recurringTask,
             OtherActiveSignals = await otherActiveTask
         };
+    }
+
+    private async Task<T> BuildTimedSectionAsync<T>(string sectionName, Func<Task<T>> buildFunc)
+    {
+        var sw = Stopwatch.StartNew();
+        var result = await buildFunc();
+        sw.Stop();
+
+        int itemCount = result switch
+        {
+            PagedSection<ClusterResponseDto> cs => cs.Items.Count,
+            PagedSection<OfficialPostResponseDto> ps => ps.Items.Count,
+            _ => 0
+        };
+
+        _logger.LogInformation(
+            "{EventName} section={Section} itemCount={ItemCount} durationMs={DurationMs}",
+            ObservabilityEvents.HomeSectionBuilt, sectionName, itemCount, sw.ElapsedMilliseconds);
+
+        return result;
     }
 
     private async Task<PagedSection<ClusterResponseDto>> BuildActiveNowSectionAsync(

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -34,13 +34,13 @@ public class HomeController : ControllerBase
     private readonly IHomeFeedQueryService _feedQuery;
     private readonly IFollowService _follows;
     private readonly IDatabase _redis;
-    private readonly ILogger<HomeController> _logger;
+    private readonly ILogger<HomeController>? _logger;
 
     public HomeController(
         IHomeFeedQueryService feedQuery,
         IFollowService follows,
         IDatabase redis,
-        ILogger<HomeController> logger)
+        ILogger<HomeController>? logger = null)
     {
         _feedQuery = feedQuery;
         _follows = follows;
@@ -57,7 +57,7 @@ public class HomeController : ControllerBase
         CancellationToken ct)
     {
         var sw = Stopwatch.StartNew();
-        _logger.LogInformation("{EventName}", ObservabilityEvents.HomeRequestStarted);
+        _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeRequestStarted);
 
         try
         {
@@ -72,24 +72,32 @@ public class HomeController : ControllerBase
 
             // Log locality scoping mode
             if (localityId.HasValue && isAuthenticated)
-                _logger.LogInformation("{EventName} localityId={LocalityId}",
+                _logger?.LogInformation("{EventName} localityId={LocalityId}",
                     ObservabilityEvents.HomeLocalityScopeExplicit, localityId.Value);
             else if (localityIds.Count > 0)
-                _logger.LogInformation("{EventName} localityCount={LocalityCount}",
+                _logger?.LogInformation("{EventName} localityCount={LocalityCount}",
                     ObservabilityEvents.HomeLocalityScopeFallback, localityIds.Count);
             else
-                _logger.LogInformation("{EventName}", ObservabilityEvents.HomeLocalityScopeGuestEmpty);
+                _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeLocalityScopeGuestEmpty);
 
             // Section-specific paginated request — skip cache, return single section
             if (section is not null)
             {
                 var paged = await GetPagedSectionAsync(section, localityIds, cursorDt, ct);
-                if (paged is null) return BadRequest(new { error = "Unknown section name" });
+                string safeSection = ObservabilityEvents.SanitizeForLog(section);
+                if (paged is null)
+                {
+                    sw.Stop();
+                    _logger?.LogInformation(
+                        "{EventName} section={Section} statusCode={StatusCode} durationMs={DurationMs}",
+                        ObservabilityEvents.HomeRequestCompleted, safeSection, 400, sw.ElapsedMilliseconds);
+                    return BadRequest(new { error = "Unknown section name" });
+                }
 
                 sw.Stop();
-                _logger.LogInformation(
+                _logger?.LogInformation(
                     "{EventName} section={Section} durationMs={DurationMs}",
-                    ObservabilityEvents.HomeRequestCompleted, section, sw.ElapsedMilliseconds);
+                    ObservabilityEvents.HomeRequestCompleted, safeSection, sw.ElapsedMilliseconds);
                 return Ok(paged);
             }
 
@@ -97,28 +105,28 @@ public class HomeController : ControllerBase
             if (cursor is null && localityIds.Count > 0)
             {
                 var cacheKey = BuildCacheKey(localityIds);
-                _logger.LogInformation("{EventName}", ObservabilityEvents.HomeCacheChecked);
+                _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeCacheChecked);
 
                 RedisValue cached = await _redis.StringGetAsync(cacheKey);
                 if (cached.HasValue)
                 {
                     sw.Stop();
-                    _logger.LogInformation("{EventName} durationMs={DurationMs}",
+                    _logger?.LogInformation("{EventName} durationMs={DurationMs}",
                         ObservabilityEvents.HomeCacheHit, sw.ElapsedMilliseconds);
-                    _logger.LogInformation(
+                    _logger?.LogInformation(
                         "{EventName} durationMs={DurationMs} cacheHit={CacheHit}",
                         ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds, true);
                     return Content(cached!, "application/json");
                 }
 
-                _logger.LogInformation("{EventName}", ObservabilityEvents.HomeCacheMiss);
+                _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeCacheMiss);
 
                 var response = await BuildFullResponseAsync(localityIds, ct);
                 var json = JsonSerializer.Serialize(response);
                 await _redis.StringSetAsync(cacheKey, json, CacheTtl);
 
                 sw.Stop();
-                _logger.LogInformation(
+                _logger?.LogInformation(
                     "{EventName} durationMs={DurationMs} cacheHit={CacheHit}",
                     ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds, false);
                 return Ok(response);
@@ -126,7 +134,7 @@ public class HomeController : ControllerBase
 
             var fullResponse = await BuildFullResponseAsync(localityIds, ct);
             sw.Stop();
-            _logger.LogInformation(
+            _logger?.LogInformation(
                 "{EventName} durationMs={DurationMs}",
                 ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds);
             return Ok(fullResponse);
@@ -134,7 +142,7 @@ public class HomeController : ControllerBase
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
-            _logger.LogError(ex,
+            _logger?.LogError(ex,
                 "{EventName} durationMs={DurationMs}",
                 ObservabilityEvents.HomeRequestFailed, sw.ElapsedMilliseconds);
             throw;
@@ -193,7 +201,7 @@ public class HomeController : ControllerBase
             _ => 0
         };
 
-        _logger.LogInformation(
+        _logger?.LogInformation(
             "{EventName} section={Section} itemCount={ItemCount} durationMs={DurationMs}",
             ObservabilityEvents.HomeSectionBuilt, sectionName, itemCount, sw.ElapsedMilliseconds);
 

--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Notifications;
+using Hali.Application.Observability;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Enums;
 using Microsoft.Extensions.Logging;
@@ -89,7 +90,7 @@ public class CivisEvaluationService : ICivisEvaluationService
 				}, ct);
 
 				_logger?.LogInformation(
-					"{eventName} clusterId={ClusterId} localityId={LocalityId} category={Category}",
+					"{EventName} clusterId={ClusterId} localityId={LocalityId} category={Category}",
 					"cluster.activated", clusterId, cluster.LocalityId, cluster.Category);
 
 				if (_notificationQueue != null)
@@ -182,12 +183,14 @@ public class CivisEvaluationService : ICivisEvaluationService
 				{
 					if (toState == SignalState.PossibleRestoration)
 					{
-						_logger?.LogInformation("{eventName} clusterId={ClusterId}", "cluster.possible_restoration", clusterId);
+						_logger?.LogInformation("{EventName} clusterId={ClusterId}",
+							ObservabilityEvents.ClusterPossibleRestoration, clusterId);
 						await _notificationQueue.QueueRestorationPromptAsync(clusterId, cluster.Title ?? "Civic issue", ct);
 					}
 					else if (toState == SignalState.Resolved)
 					{
-						_logger?.LogInformation("{eventName} clusterId={ClusterId}", "cluster.resolved_by_decay", clusterId);
+						_logger?.LogInformation("{EventName} clusterId={ClusterId}",
+							ObservabilityEvents.ClusterResolvedByDecay, clusterId);
 						await _notificationQueue.QueueClusterResolvedAsync(clusterId, cluster.LocalityId, cluster.Title ?? "Civic issue", ct);
 					}
 				}

--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -13,192 +13,192 @@ namespace Hali.Application.Clusters;
 
 public class CivisEvaluationService : ICivisEvaluationService
 {
-	private readonly IClusterRepository _repo;
+    private readonly IClusterRepository _repo;
 
-	private readonly CivisOptions _options;
+    private readonly CivisOptions _options;
 
-	private readonly INotificationQueueService? _notificationQueue;
+    private readonly INotificationQueueService? _notificationQueue;
 
-	private readonly ILogger<CivisEvaluationService>? _logger;
+    private readonly ILogger<CivisEvaluationService>? _logger;
 
-	public CivisEvaluationService(IClusterRepository repo, IOptions<CivisOptions> options,
-		INotificationQueueService? notificationQueue = null,
-		ILogger<CivisEvaluationService>? logger = null)
-	{
-		_repo = repo;
-		_options = options.Value;
-		_notificationQueue = notificationQueue;
-		_logger = logger;
-	}
+    public CivisEvaluationService(IClusterRepository repo, IOptions<CivisOptions> options,
+        INotificationQueueService? notificationQueue = null,
+        ILogger<CivisEvaluationService>? logger = null)
+    {
+        _repo = repo;
+        _options = options.Value;
+        _notificationQueue = notificationQueue;
+        _logger = logger;
+    }
 
-	public async Task EvaluateClusterAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
-	{
-		SignalCluster cluster = await _repo.GetClusterByIdAsync(clusterId, ct);
-		if (cluster != null && cluster.State == SignalState.Unconfirmed)
-		{
-			CivisCategoryOptions opts = _options.GetCategoryOptions(cluster.Category);
-			int wrabCount = await _repo.ComputeWrabCountAsync(clusterId, _options.WrabRollingWindowDays, ct);
-			int effectiveWrab = Math.Max(wrabCount, opts.BaseFloor);
-			double sds = CivisCalculator.ComputeSds(await _repo.ComputeActiveMassCountAsync(clusterId, _options.ActiveMassHorizonHours, ct), wrabCount, opts.BaseFloor);
-			double minLocationConfidence = await _repo.GetMinLocationConfidenceAsync(clusterId, ct);
-			int macf = CivisCalculator.ComputeMacf(
-				sds,
-				opts,
-				cluster.Category == CivicCategory.Safety,
-				minLocationConfidence);
-			int uniqueDevices = await _repo.CountUniqueDevicesAsync(clusterId, ct);
-			DateTime now = DateTime.UtcNow;
-			cluster.Wrab = effectiveWrab;
-			cluster.Sds = (decimal)sds;
-			cluster.Macf = macf;
-			cluster.UpdatedAt = now;
-			if (cluster.RawConfirmationCount >= macf && uniqueDevices >= _options.MinUniqueDevices)
-			{
-				cluster.State = SignalState.Active;
-				cluster.ActivatedAt = now;
-				await _repo.UpdateClusterAsync(cluster, ct);
-				await _repo.WriteCivisDecisionAsync(new CivisDecision
-				{
-					Id = Guid.NewGuid(),
-					ClusterId = clusterId,
-					DecisionType = "activated",
-					ReasonCodes = JsonSerializer.Serialize(new string[2] { "macf_met", "device_diversity_met" }),
-					Metrics = JsonSerializer.Serialize(new
-					{
-						wrab_count = wrabCount,
-						effective_wrab = effectiveWrab,
-						sds = sds,
-						macf = macf,
-						raw_confirmation_count = cluster.RawConfirmationCount,
-						unique_devices = uniqueDevices
-					}),
-					CreatedAt = now
-				}, ct);
-				await _repo.WriteOutboxEventAsync(new OutboxEvent
-				{
-					Id = Guid.NewGuid(),
-					AggregateType = "cluster",
-					AggregateId = clusterId,
-					EventType = "cluster_state_changed",
-					Payload = JsonSerializer.Serialize(new
-					{
-						cluster_id = clusterId,
-						from_state = "unconfirmed",
-						to_state = "active"
-					}),
-					OccurredAt = now
-				}, ct);
+    public async Task EvaluateClusterAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
+    {
+        SignalCluster cluster = await _repo.GetClusterByIdAsync(clusterId, ct);
+        if (cluster != null && cluster.State == SignalState.Unconfirmed)
+        {
+            CivisCategoryOptions opts = _options.GetCategoryOptions(cluster.Category);
+            int wrabCount = await _repo.ComputeWrabCountAsync(clusterId, _options.WrabRollingWindowDays, ct);
+            int effectiveWrab = Math.Max(wrabCount, opts.BaseFloor);
+            double sds = CivisCalculator.ComputeSds(await _repo.ComputeActiveMassCountAsync(clusterId, _options.ActiveMassHorizonHours, ct), wrabCount, opts.BaseFloor);
+            double minLocationConfidence = await _repo.GetMinLocationConfidenceAsync(clusterId, ct);
+            int macf = CivisCalculator.ComputeMacf(
+                sds,
+                opts,
+                cluster.Category == CivicCategory.Safety,
+                minLocationConfidence);
+            int uniqueDevices = await _repo.CountUniqueDevicesAsync(clusterId, ct);
+            DateTime now = DateTime.UtcNow;
+            cluster.Wrab = effectiveWrab;
+            cluster.Sds = (decimal)sds;
+            cluster.Macf = macf;
+            cluster.UpdatedAt = now;
+            if (cluster.RawConfirmationCount >= macf && uniqueDevices >= _options.MinUniqueDevices)
+            {
+                cluster.State = SignalState.Active;
+                cluster.ActivatedAt = now;
+                await _repo.UpdateClusterAsync(cluster, ct);
+                await _repo.WriteCivisDecisionAsync(new CivisDecision
+                {
+                    Id = Guid.NewGuid(),
+                    ClusterId = clusterId,
+                    DecisionType = "activated",
+                    ReasonCodes = JsonSerializer.Serialize(new string[2] { "macf_met", "device_diversity_met" }),
+                    Metrics = JsonSerializer.Serialize(new
+                    {
+                        wrab_count = wrabCount,
+                        effective_wrab = effectiveWrab,
+                        sds = sds,
+                        macf = macf,
+                        raw_confirmation_count = cluster.RawConfirmationCount,
+                        unique_devices = uniqueDevices
+                    }),
+                    CreatedAt = now
+                }, ct);
+                await _repo.WriteOutboxEventAsync(new OutboxEvent
+                {
+                    Id = Guid.NewGuid(),
+                    AggregateType = "cluster",
+                    AggregateId = clusterId,
+                    EventType = "cluster_state_changed",
+                    Payload = JsonSerializer.Serialize(new
+                    {
+                        cluster_id = clusterId,
+                        from_state = "unconfirmed",
+                        to_state = "active"
+                    }),
+                    OccurredAt = now
+                }, ct);
 
-				_logger?.LogInformation(
-					"{EventName} clusterId={ClusterId} localityId={LocalityId} category={Category}",
-					"cluster.activated", clusterId, cluster.LocalityId, cluster.Category);
+                _logger?.LogInformation(
+                    "{EventName} clusterId={ClusterId} localityId={LocalityId} category={Category}",
+                    ObservabilityEvents.ClusterActivated, clusterId, cluster.LocalityId, cluster.Category);
 
-				if (_notificationQueue != null)
-				{
-					try
-					{
-						await _notificationQueue.QueueClusterActivatedAsync(
-							clusterId, cluster.LocalityId,
-							cluster.Title ?? "New civic issue",
-							cluster.Summary ?? string.Empty,
-							ct);
-					}
-					catch (Exception ex)
-					{
-						_logger?.LogError(ex, "Failed to queue cluster_activated notifications for {ClusterId}", clusterId);
-					}
-				}
-			}
-			else
-			{
-				await _repo.UpdateClusterAsync(cluster, ct);
-			}
-		}
-	}
+                if (_notificationQueue != null)
+                {
+                    try
+                    {
+                        await _notificationQueue.QueueClusterActivatedAsync(
+                            clusterId, cluster.LocalityId,
+                            cluster.Title ?? "New civic issue",
+                            cluster.Summary ?? string.Empty,
+                            ct);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger?.LogError(ex, "Failed to queue cluster_activated notifications for {ClusterId}", clusterId);
+                    }
+                }
+            }
+            else
+            {
+                await _repo.UpdateClusterAsync(cluster, ct);
+            }
+        }
+    }
 
-	public async Task ApplyDecayAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
-	{
-		SignalCluster cluster = await _repo.GetClusterByIdAsync(clusterId, ct);
-		if (cluster == null || (cluster.State != SignalState.Active && cluster.State != SignalState.PossibleRestoration))
-		{
-			return;
-		}
-		CivisCategoryOptions opts = _options.GetCategoryOptions(cluster.Category);
-		double lambda = CivisCalculator.ComputeLambda(opts.HalfLifeHours);
-		double elapsedHours = (DateTime.UtcNow - cluster.LastSeenAt).TotalHours;
-		double liveMass = CivisCalculator.ApplyDecay(cluster.RawConfirmationCount, lambda, elapsedHours);
-		double effectiveWrab = (double)(cluster.Wrab ?? ((decimal)opts.BaseFloor));
-		if (liveMass / effectiveWrab < _options.DeactivationThreshold)
-		{
-			DateTime now = DateTime.UtcNow;
-			SignalState fromState = cluster.State;
-			SignalState toState;
-			if (cluster.State == SignalState.Active)
-			{
-				toState = SignalState.PossibleRestoration;
-				cluster.State = SignalState.PossibleRestoration;
-				cluster.PossibleRestorationAt = now;
-			}
-			else
-			{
-				toState = SignalState.Resolved;
-				cluster.State = SignalState.Resolved;
-				cluster.ResolvedAt = now;
-			}
-			cluster.UpdatedAt = now;
-			await _repo.UpdateClusterAsync(cluster, ct);
-			await _repo.WriteCivisDecisionAsync(new CivisDecision
-			{
-				Id = Guid.NewGuid(),
-				ClusterId = clusterId,
-				DecisionType = ((toState == SignalState.PossibleRestoration) ? "possible_restoration" : "resolved_by_decay"),
-				ReasonCodes = JsonSerializer.Serialize(new string[1] { "decay_below_threshold" }),
-				Metrics = JsonSerializer.Serialize(new
-				{
-					live_mass = liveMass,
-					effective_wrab = effectiveWrab,
-					elapsed_hours = elapsedHours,
-					deactivation_threshold = _options.DeactivationThreshold
-				}),
-				CreatedAt = now
-			}, ct);
-			await _repo.WriteOutboxEventAsync(new OutboxEvent
-			{
-				Id = Guid.NewGuid(),
-				AggregateType = "cluster",
-				AggregateId = clusterId,
-				EventType = "cluster_state_changed",
-				Payload = JsonSerializer.Serialize(new
-				{
-					cluster_id = clusterId,
-					from_state = fromState.ToString().ToLowerInvariant(),
-					to_state = toState.ToString().ToLowerInvariant()
-				}),
-				OccurredAt = now
-			}, ct);
+    public async Task ApplyDecayAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
+    {
+        SignalCluster cluster = await _repo.GetClusterByIdAsync(clusterId, ct);
+        if (cluster == null || (cluster.State != SignalState.Active && cluster.State != SignalState.PossibleRestoration))
+        {
+            return;
+        }
+        CivisCategoryOptions opts = _options.GetCategoryOptions(cluster.Category);
+        double lambda = CivisCalculator.ComputeLambda(opts.HalfLifeHours);
+        double elapsedHours = (DateTime.UtcNow - cluster.LastSeenAt).TotalHours;
+        double liveMass = CivisCalculator.ApplyDecay(cluster.RawConfirmationCount, lambda, elapsedHours);
+        double effectiveWrab = (double)(cluster.Wrab ?? ((decimal)opts.BaseFloor));
+        if (liveMass / effectiveWrab < _options.DeactivationThreshold)
+        {
+            DateTime now = DateTime.UtcNow;
+            SignalState fromState = cluster.State;
+            SignalState toState;
+            if (cluster.State == SignalState.Active)
+            {
+                toState = SignalState.PossibleRestoration;
+                cluster.State = SignalState.PossibleRestoration;
+                cluster.PossibleRestorationAt = now;
+            }
+            else
+            {
+                toState = SignalState.Resolved;
+                cluster.State = SignalState.Resolved;
+                cluster.ResolvedAt = now;
+            }
+            cluster.UpdatedAt = now;
+            await _repo.UpdateClusterAsync(cluster, ct);
+            await _repo.WriteCivisDecisionAsync(new CivisDecision
+            {
+                Id = Guid.NewGuid(),
+                ClusterId = clusterId,
+                DecisionType = ((toState == SignalState.PossibleRestoration) ? "possible_restoration" : "resolved_by_decay"),
+                ReasonCodes = JsonSerializer.Serialize(new string[1] { "decay_below_threshold" }),
+                Metrics = JsonSerializer.Serialize(new
+                {
+                    live_mass = liveMass,
+                    effective_wrab = effectiveWrab,
+                    elapsed_hours = elapsedHours,
+                    deactivation_threshold = _options.DeactivationThreshold
+                }),
+                CreatedAt = now
+            }, ct);
+            await _repo.WriteOutboxEventAsync(new OutboxEvent
+            {
+                Id = Guid.NewGuid(),
+                AggregateType = "cluster",
+                AggregateId = clusterId,
+                EventType = "cluster_state_changed",
+                Payload = JsonSerializer.Serialize(new
+                {
+                    cluster_id = clusterId,
+                    from_state = fromState.ToString().ToLowerInvariant(),
+                    to_state = toState.ToString().ToLowerInvariant()
+                }),
+                OccurredAt = now
+            }, ct);
 
-			if (_notificationQueue != null)
-			{
-				try
-				{
-					if (toState == SignalState.PossibleRestoration)
-					{
-						_logger?.LogInformation("{EventName} clusterId={ClusterId}",
-							ObservabilityEvents.ClusterPossibleRestoration, clusterId);
-						await _notificationQueue.QueueRestorationPromptAsync(clusterId, cluster.Title ?? "Civic issue", ct);
-					}
-					else if (toState == SignalState.Resolved)
-					{
-						_logger?.LogInformation("{EventName} clusterId={ClusterId}",
-							ObservabilityEvents.ClusterResolvedByDecay, clusterId);
-						await _notificationQueue.QueueClusterResolvedAsync(clusterId, cluster.LocalityId, cluster.Title ?? "Civic issue", ct);
-					}
-				}
-				catch (Exception ex)
-				{
-					_logger?.LogError(ex, "Failed to queue decay notifications for {ClusterId}", clusterId);
-				}
-			}
-		}
-	}
+            if (_notificationQueue != null)
+            {
+                try
+                {
+                    if (toState == SignalState.PossibleRestoration)
+                    {
+                        _logger?.LogInformation("{EventName} clusterId={ClusterId}",
+                            ObservabilityEvents.ClusterPossibleRestoration, clusterId);
+                        await _notificationQueue.QueueRestorationPromptAsync(clusterId, cluster.Title ?? "Civic issue", ct);
+                    }
+                    else if (toState == SignalState.Resolved)
+                    {
+                        _logger?.LogInformation("{EventName} clusterId={ClusterId}",
+                            ObservabilityEvents.ClusterResolvedByDecay, clusterId);
+                        await _notificationQueue.QueueClusterResolvedAsync(clusterId, cluster.LocalityId, cluster.Title ?? "Civic issue", ct);
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger?.LogError(ex, "Failed to queue decay notifications for {ClusterId}", clusterId);
+                }
+            }
+        }
+    }
 }

--- a/src/Hali.Application/Clusters/ClusteringService.cs
+++ b/src/Hali.Application/Clusters/ClusteringService.cs
@@ -3,9 +3,11 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Observability;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Signals;
 using Hali.Domain.Enums;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Hali.Application.Clusters;
@@ -20,12 +22,15 @@ public class ClusteringService : IClusteringService
 
 	private readonly CivisOptions _options;
 
-	public ClusteringService(IClusterRepository repo, IH3CellService h3, ICivisEvaluationService civis, IOptions<CivisOptions> options)
+	private readonly ILogger<ClusteringService>? _logger;
+
+	public ClusteringService(IClusterRepository repo, IH3CellService h3, ICivisEvaluationService civis, IOptions<CivisOptions> options, ILogger<ClusteringService>? logger = null)
 	{
 		_repo = repo;
 		_h3 = h3;
 		_civis = civis;
 		_options = options.Value;
+		_logger = logger;
 	}
 
 	public async Task<ClusterRoutingResult> RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken))
@@ -81,6 +86,11 @@ public class ClusteringService : IClusteringService
 				OccurredAt = DateTime.UtcNow
 			}, ct);
 			await _civis.EvaluateClusterAsync(bestCluster.Id, ct);
+
+			_logger?.LogInformation(
+				"{EventName} clusterId={ClusterId} outcome={Outcome} joinScore={JoinScore} candidateCount={CandidateCount}",
+				ObservabilityEvents.SignalRouted, bestCluster.Id, "joined", bestScore, candidates.Count);
+
 			return new ClusterRoutingResult(
 				bestCluster.Id,
 				WasCreated: false,
@@ -125,6 +135,11 @@ public class ClusteringService : IClusteringService
 				OccurredAt = now
 			}, ct);
 			await _civis.EvaluateClusterAsync(newCluster.Id, ct);
+
+			_logger?.LogInformation(
+				"{EventName} clusterId={ClusterId} outcome={Outcome} candidateCount={CandidateCount}",
+				ObservabilityEvents.SignalRouted, newCluster.Id, "created", candidates.Count);
+
 			return new ClusterRoutingResult(
 				newCluster.Id,
 				WasCreated: true,

--- a/src/Hali.Application/Observability/ObservabilityEvents.cs
+++ b/src/Hali.Application/Observability/ObservabilityEvents.cs
@@ -1,3 +1,5 @@
+using System.Text.RegularExpressions;
+
 namespace Hali.Application.Observability;
 
 /// <summary>
@@ -6,6 +8,28 @@ namespace Hali.Application.Observability;
 /// </summary>
 public static class ObservabilityEvents
 {
+    /// <summary>
+    /// Maximum length of a user-supplied value rendered into a structured log field.
+    /// Keeps log lines bounded.
+    /// </summary>
+    private const int MaxLogFieldLength = 64;
+
+    private static readonly Regex SafeChars = new(@"[^a-zA-Z0-9_\-.]", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Strips control characters and non-alphanumeric chars (except underscore, hyphen, dot),
+    /// truncates to a bounded length. Safe for structured log fields derived from user input.
+    /// </summary>
+    public static string SanitizeForLog(string? value)
+    {
+        if (string.IsNullOrEmpty(value))
+            return string.Empty;
+        string cleaned = SafeChars.Replace(value, string.Empty);
+        if (cleaned.Length > MaxLogFieldLength)
+            cleaned = cleaned[..MaxLogFieldLength];
+        return cleaned;
+    }
+
     // ── Home feed ────────────────────────────────────────────────────────────
     public const string HomeRequestStarted = "home.request.started";
     public const string HomeRequestCompleted = "home.request.completed";
@@ -32,7 +56,8 @@ public static class ObservabilityEvents
     public const string SignalClusterCreated = "signal.cluster.created";
     public const string SignalClusterJoined = "signal.cluster.joined";
 
-    // ── Restoration / lifecycle ──────────────────────────────────────────────
+    // ── Cluster lifecycle ──────────────────────────────────────────────────
+    public const string ClusterActivated = "cluster.activated";
     public const string ClusterPossibleRestoration = "cluster.possible_restoration";
     public const string ClusterRestorationConfirmed = "cluster.restoration_confirmed";
     public const string ClusterRevertedToActive = "cluster.reverted_to_active";

--- a/src/Hali.Application/Observability/ObservabilityEvents.cs
+++ b/src/Hali.Application/Observability/ObservabilityEvents.cs
@@ -1,0 +1,40 @@
+namespace Hali.Application.Observability;
+
+/// <summary>
+/// Stable event name constants for structured logging.
+/// All names are dot-delimited, lowercase, metrics-friendly.
+/// </summary>
+public static class ObservabilityEvents
+{
+    // ── Home feed ────────────────────────────────────────────────────────────
+    public const string HomeRequestStarted = "home.request.started";
+    public const string HomeRequestCompleted = "home.request.completed";
+    public const string HomeRequestFailed = "home.request.failed";
+    public const string HomeSectionBuilt = "home.section.built";
+    public const string HomeCacheChecked = "home.cache.checked";
+    public const string HomeCacheHit = "home.cache.hit";
+    public const string HomeCacheMiss = "home.cache.miss";
+    public const string HomeLocalityScopeExplicit = "home.locality.explicit";
+    public const string HomeLocalityScopeFallback = "home.locality.fallback";
+    public const string HomeLocalityScopeGuestEmpty = "home.locality.guest_empty";
+
+    // ── Signal submit ────────────────────────────────────────────────────────
+    public const string SignalSubmitStarted = "signal.submit.started";
+    public const string SignalSubmitCompleted = "signal.submit.completed";
+    public const string SignalSubmitFailed = "signal.submit.failed";
+    public const string SignalLocalityResolved = "signal.locality.resolved";
+    public const string SignalLocalityFailed = "signal.locality.failed";
+    public const string SignalSpatialDerived = "signal.spatial.derived";
+    public const string SignalSpatialFailed = "signal.spatial.failed";
+
+    // ── Signal routing ───────────────────────────────────────────────────────
+    public const string SignalRouted = "signal.routed";
+    public const string SignalClusterCreated = "signal.cluster.created";
+    public const string SignalClusterJoined = "signal.cluster.joined";
+
+    // ── Restoration / lifecycle ──────────────────────────────────────────────
+    public const string ClusterPossibleRestoration = "cluster.possible_restoration";
+    public const string ClusterRestorationConfirmed = "cluster.restoration_confirmed";
+    public const string ClusterRevertedToActive = "cluster.reverted_to_active";
+    public const string ClusterResolvedByDecay = "cluster.resolved_by_decay";
+}

--- a/src/Hali.Application/Participation/ParticipationService.cs
+++ b/src/Hali.Application/Participation/ParticipationService.cs
@@ -3,9 +3,11 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
+using Hali.Application.Observability;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Participation;
 using Hali.Domain.Enums;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace Hali.Application.Participation;
@@ -18,11 +20,14 @@ public class ParticipationService : IParticipationService
 
 	private readonly CivisOptions _options;
 
-	public ParticipationService(IParticipationRepository participationRepo, IClusterRepository clusterRepo, IOptions<CivisOptions> options)
+	private readonly ILogger<ParticipationService>? _logger;
+
+	public ParticipationService(IParticipationRepository participationRepo, IClusterRepository clusterRepo, IOptions<CivisOptions> options, ILogger<ParticipationService>? logger = null)
 	{
 		_participationRepo = participationRepo;
 		_clusterRepo = clusterRepo;
 		_options = options.Value;
+		_logger = logger;
 	}
 
 	public async Task RecordParticipationAsync(Guid clusterId, Guid deviceId, Guid? accountId, ParticipationType type, string? idempotencyKey, CancellationToken ct)
@@ -133,6 +138,10 @@ public class ParticipationService : IParticipationService
 					}),
 					OccurredAt = now
 				}, ct);
+
+				_logger?.LogInformation(
+					"{EventName} clusterId={ClusterId} restorationYes={RestorationYes} totalResponses={TotalResponses}",
+					ObservabilityEvents.ClusterPossibleRestoration, clusterId, restorationYes, totalResponses);
 			}
 		}
 	}

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -1,141 +1,176 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
+using Hali.Application.Observability;
 using Hali.Contracts.Signals;
 using Hali.Domain.Entities.Signals;
 using Hali.Domain.Enums;
+using Microsoft.Extensions.Logging;
 
 namespace Hali.Application.Signals;
 
 public class SignalIngestionService : ISignalIngestionService
 {
-	private readonly INlpExtractionService _nlp;
+    private readonly INlpExtractionService _nlp;
 
-	private readonly ISignalRepository _repo;
+    private readonly ISignalRepository _repo;
 
-	private readonly IClusteringService _clustering;
+    private readonly IClusteringService _clustering;
 
-	private readonly IH3CellService _h3;
+    private readonly IH3CellService _h3;
 
-	private readonly ILocalityLookupRepository _localityLookup;
+    private readonly ILocalityLookupRepository _localityLookup;
 
-	private const int H3Resolution = 9;
+    private readonly ILogger<SignalIngestionService>? _logger;
 
-	private static readonly HashSet<string> AllowedCategories = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "roads", "transport", "electricity", "water", "environment", "safety", "governance", "infrastructure" };
+    private const int H3Resolution = 9;
 
-	private static readonly HashSet<string> AllowedTemporalTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "temporary", "continuous", "recurring", "scheduled", "episodic_unknown" };
+    private static readonly HashSet<string> AllowedCategories = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "roads", "transport", "electricity", "water", "environment", "safety", "governance", "infrastructure" };
 
-	public SignalIngestionService(INlpExtractionService nlp, ISignalRepository repo, IClusteringService clustering, IH3CellService h3, ILocalityLookupRepository localityLookup)
-	{
-		_nlp = nlp;
-		_repo = repo;
-		_clustering = clustering;
-		_h3 = h3;
-		_localityLookup = localityLookup;
-	}
+    private static readonly HashSet<string> AllowedTemporalTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "temporary", "continuous", "recurring", "scheduled", "episodic_unknown" };
 
-	public async Task<SignalPreviewResponseDto> PreviewAsync(SignalPreviewRequestDto request, CancellationToken ct = default(CancellationToken))
-	{
-		NlpExtractionRequest nlpRequest = new NlpExtractionRequest(TaxonomyBlock: await _repo.BuildTaxonomyBlockAsync(ct), FreeText: request.FreeText, UserLatitude: request.UserLatitude, UserLongitude: request.UserLongitude, SelectedWard: request.SelectedWard, Locale: request.Locale, KnownCity: request.KnownCity, CountryCode: request.CountryCode, CurrentTimeUtc: DateTime.UtcNow.ToString("o"));
-		NlpExtractionResultDto result = await _nlp.ExtractAsync(nlpRequest, ct);
-		if ((object)result == null)
-		{
-			throw new InvalidOperationException("NLP_EXTRACTION_FAILED");
-		}
-		if (!AllowedCategories.Contains(result.Category))
-		{
-			throw new InvalidOperationException("NLP_INVALID_CATEGORY");
-		}
-		return new SignalPreviewResponseDto(result.Category, result.Subcategory, result.ConditionLevel, result.ConditionConfidence, new SignalLocationDto(result.Location.AreaName, result.Location.RoadName, result.Location.JunctionName, result.Location.LandmarkName, result.Location.FacilityName, result.Location.LocationLabel, result.Location.LocationPrecisionType, result.Location.LocationConfidence, result.Location.LocationSource), result.TemporalHint?.Type, result.Summary, result.ShouldSuggestJoin);
-	}
+    public SignalIngestionService(INlpExtractionService nlp, ISignalRepository repo, IClusteringService clustering, IH3CellService h3, ILocalityLookupRepository localityLookup, ILogger<SignalIngestionService>? logger = null)
+    {
+        _nlp = nlp;
+        _repo = repo;
+        _clustering = clustering;
+        _h3 = h3;
+        _localityLookup = localityLookup;
+        _logger = logger;
+    }
 
-	public async Task<SignalSubmitResponseDto> SubmitAsync(SignalSubmitRequestDto request, Guid? accountId, Guid? deviceId, CancellationToken ct = default(CancellationToken))
-	{
-		string idemKey = "idem:signal-submit:" + request.IdempotencyKey;
-		if (await _repo.IdempotencyKeyExistsAsync(idemKey, ct))
-		{
-			throw new InvalidOperationException("SIGNAL_DUPLICATE");
-		}
-		if (!(await _repo.IsRateLimitAllowedAsync(request.DeviceHash, ct)))
-		{
-			throw new InvalidOperationException("SIGNAL_RATE_LIMITED");
-		}
-		if (!AllowedCategories.Contains(request.Category))
-		{
-			throw new InvalidOperationException("SIGNAL_INVALID_CATEGORY");
-		}
-		if (!Enum.TryParse<CivicCategory>(request.Category, ignoreCase: true, out var category))
-		{
-			throw new InvalidOperationException("SIGNAL_INVALID_CATEGORY");
-		}
-		if (!request.Latitude.HasValue || !request.Longitude.HasValue)
-		{
-			throw new InvalidOperationException("SIGNAL_MISSING_COORDINATES");
-		}
-		double lat = request.Latitude.Value;
-		double lng = request.Longitude.Value;
-		if (lat < -90 || lat > 90 || lng < -180 || lng > 180)
-		{
-			throw new InvalidOperationException("SIGNAL_INVALID_COORDINATES");
-		}
+    public async Task<SignalPreviewResponseDto> PreviewAsync(SignalPreviewRequestDto request, CancellationToken ct = default(CancellationToken))
+    {
+        NlpExtractionRequest nlpRequest = new NlpExtractionRequest(TaxonomyBlock: await _repo.BuildTaxonomyBlockAsync(ct), FreeText: request.FreeText, UserLatitude: request.UserLatitude, UserLongitude: request.UserLongitude, SelectedWard: request.SelectedWard, Locale: request.Locale, KnownCity: request.KnownCity, CountryCode: request.CountryCode, CurrentTimeUtc: DateTime.UtcNow.ToString("o"));
+        NlpExtractionResultDto result = await _nlp.ExtractAsync(nlpRequest, ct);
+        if ((object)result == null)
+        {
+            throw new InvalidOperationException("NLP_EXTRACTION_FAILED");
+        }
+        if (!AllowedCategories.Contains(result.Category))
+        {
+            throw new InvalidOperationException("NLP_INVALID_CATEGORY");
+        }
+        return new SignalPreviewResponseDto(result.Category, result.Subcategory, result.ConditionLevel, result.ConditionConfidence, new SignalLocationDto(result.Location.AreaName, result.Location.RoadName, result.Location.JunctionName, result.Location.LandmarkName, result.Location.FacilityName, result.Location.LocationLabel, result.Location.LocationPrecisionType, result.Location.LocationConfidence, result.Location.LocationSource), result.TemporalHint?.Type, result.Summary, result.ShouldSuggestJoin);
+    }
 
-		string spatialCellId;
-		try
-		{
-			spatialCellId = _h3.LatLngToCell(lat, lng, H3Resolution);
-		}
-		catch (Exception ex) when (ex is not OperationCanceledException)
-		{
-			throw new InvalidOperationException("SIGNAL_SPATIAL_DERIVATION_FAILED", ex);
-		}
+    public async Task<SignalSubmitResponseDto> SubmitAsync(SignalSubmitRequestDto request, Guid? accountId, Guid? deviceId, CancellationToken ct = default(CancellationToken))
+    {
+        var sw = Stopwatch.StartNew();
+        _logger?.LogInformation("{EventName} category={Category}",
+            ObservabilityEvents.SignalSubmitStarted, request.Category);
 
-		if (string.IsNullOrEmpty(spatialCellId))
-		{
-			throw new InvalidOperationException("SIGNAL_SPATIAL_DERIVATION_FAILED");
-		}
+        try
+        {
+            string idemKey = "idem:signal-submit:" + request.IdempotencyKey;
+            if (await _repo.IdempotencyKeyExistsAsync(idemKey, ct))
+            {
+                throw new InvalidOperationException("SIGNAL_DUPLICATE");
+            }
+            if (!(await _repo.IsRateLimitAllowedAsync(request.DeviceHash, ct)))
+            {
+                throw new InvalidOperationException("SIGNAL_RATE_LIMITED");
+            }
+            if (!AllowedCategories.Contains(request.Category))
+            {
+                throw new InvalidOperationException("SIGNAL_INVALID_CATEGORY");
+            }
+            if (!Enum.TryParse<CivicCategory>(request.Category, ignoreCase: true, out var category))
+            {
+                throw new InvalidOperationException("SIGNAL_INVALID_CATEGORY");
+            }
+            if (!request.Latitude.HasValue || !request.Longitude.HasValue)
+            {
+                throw new InvalidOperationException("SIGNAL_MISSING_COORDINATES");
+            }
+            double lat = request.Latitude.Value;
+            double lng = request.Longitude.Value;
+            if (lat < -90 || lat > 90 || lng < -180 || lng > 180)
+            {
+                throw new InvalidOperationException("SIGNAL_INVALID_COORDINATES");
+            }
 
-		LocalitySummary? locality = await _localityLookup.FindByPointAsync(lat, lng, ct);
-		if (locality is null)
-		{
-			throw new InvalidOperationException("SIGNAL_LOCALITY_UNRESOLVED");
-		}
+            string spatialCellId;
+            try
+            {
+                spatialCellId = _h3.LatLngToCell(lat, lng, H3Resolution);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger?.LogWarning("{EventName}", ObservabilityEvents.SignalSpatialFailed);
+                throw new InvalidOperationException("SIGNAL_SPATIAL_DERIVATION_FAILED", ex);
+            }
 
-		string temporalType = (AllowedTemporalTypes.Contains(request.TemporalType ?? "") ? request.TemporalType : "episodic_unknown");
-		SignalEvent signal = new SignalEvent
-		{
-			Id = Guid.NewGuid(),
-			AccountId = accountId,
-			DeviceId = deviceId,
-			Category = category,
-			SubcategorySlug = request.SubcategorySlug,
-			ConditionSlug = request.ConditionSlug,
-			FreeText = request.FreeText,
-			NeutralSummary = request.NeutralSummary,
-			TemporalType = temporalType,
-			Latitude = lat,
-			Longitude = lng,
-			LocationConfidence = ((request.LocationConfidence > 0.0) ? new decimal?((decimal)request.LocationConfidence) : ((decimal?)null)),
-			LocationSource = request.LocationSource,
-			ConditionConfidence = ((request.ConditionConfidence > 0.0) ? new decimal?((decimal)request.ConditionConfidence) : ((decimal?)null)),
-			OccurredAt = DateTime.UtcNow,
-			CreatedAt = DateTime.UtcNow,
-			SourceLanguage = request.SourceLanguage,
-			SourceChannel = "app",
-			SpatialCellId = spatialCellId,
-			LocalityId = locality.Id,
-			CivisPrecheck = "{}"
-		};
-		SignalEvent saved = await _repo.PersistSignalAsync(signal, ct);
-		await _repo.SetIdempotencyKeyAsync(idemKey, TimeSpan.FromHours(24), ct);
-		var routing = await _clustering.RouteSignalAsync(saved, ct);
-		return new SignalSubmitResponseDto(
-			saved.Id,
-			routing.ClusterId,
-			routing.WasCreated,
-			routing.ClusterState,
-			routing.LocalityId,
-			saved.CreatedAt);
-	}
+            if (string.IsNullOrEmpty(spatialCellId))
+            {
+                _logger?.LogWarning("{EventName}", ObservabilityEvents.SignalSpatialFailed);
+                throw new InvalidOperationException("SIGNAL_SPATIAL_DERIVATION_FAILED");
+            }
+
+            _logger?.LogInformation("{EventName} spatialCellId={SpatialCellId}",
+                ObservabilityEvents.SignalSpatialDerived, spatialCellId);
+
+            LocalitySummary? locality = await _localityLookup.FindByPointAsync(lat, lng, ct);
+            if (locality is null)
+            {
+                _logger?.LogWarning("{EventName}", ObservabilityEvents.SignalLocalityFailed);
+                throw new InvalidOperationException("SIGNAL_LOCALITY_UNRESOLVED");
+            }
+
+            _logger?.LogInformation("{EventName} localityId={LocalityId}",
+                ObservabilityEvents.SignalLocalityResolved, locality.Id);
+
+            string temporalType = (AllowedTemporalTypes.Contains(request.TemporalType ?? "") ? request.TemporalType : "episodic_unknown");
+            SignalEvent signal = new SignalEvent
+            {
+                Id = Guid.NewGuid(),
+                AccountId = accountId,
+                DeviceId = deviceId,
+                Category = category,
+                SubcategorySlug = request.SubcategorySlug,
+                ConditionSlug = request.ConditionSlug,
+                FreeText = request.FreeText,
+                NeutralSummary = request.NeutralSummary,
+                TemporalType = temporalType,
+                Latitude = lat,
+                Longitude = lng,
+                LocationConfidence = ((request.LocationConfidence > 0.0) ? new decimal?((decimal)request.LocationConfidence) : ((decimal?)null)),
+                LocationSource = request.LocationSource,
+                ConditionConfidence = ((request.ConditionConfidence > 0.0) ? new decimal?((decimal)request.ConditionConfidence) : ((decimal?)null)),
+                OccurredAt = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                SourceLanguage = request.SourceLanguage,
+                SourceChannel = "app",
+                SpatialCellId = spatialCellId,
+                LocalityId = locality.Id,
+                CivisPrecheck = "{}"
+            };
+            SignalEvent saved = await _repo.PersistSignalAsync(signal, ct);
+            await _repo.SetIdempotencyKeyAsync(idemKey, TimeSpan.FromHours(24), ct);
+            var routing = await _clustering.RouteSignalAsync(saved, ct);
+
+            sw.Stop();
+            _logger?.LogInformation(
+                "{EventName} signalId={SignalId} clusterId={ClusterId} wasCreated={WasCreated} durationMs={DurationMs}",
+                ObservabilityEvents.SignalSubmitCompleted, saved.Id, routing.ClusterId, routing.WasCreated, sw.ElapsedMilliseconds);
+
+            return new SignalSubmitResponseDto(
+                saved.Id,
+                routing.ClusterId,
+                routing.WasCreated,
+                routing.ClusterState,
+                routing.LocalityId,
+                saved.CreatedAt);
+        }
+        catch (InvalidOperationException ex)
+        {
+            sw.Stop();
+            _logger?.LogWarning("{EventName} reason={Reason} durationMs={DurationMs}",
+                ObservabilityEvents.SignalSubmitFailed, ex.Message, sw.ElapsedMilliseconds);
+            throw;
+        }
+    }
 }

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -61,7 +61,7 @@ public class SignalIngestionService : ISignalIngestionService
     {
         var sw = Stopwatch.StartNew();
         _logger?.LogInformation("{EventName} category={Category}",
-            ObservabilityEvents.SignalSubmitStarted, request.Category);
+            ObservabilityEvents.SignalSubmitStarted, ObservabilityEvents.SanitizeForLog(request.Category));
 
         try
         {
@@ -165,11 +165,13 @@ public class SignalIngestionService : ISignalIngestionService
                 routing.LocalityId,
                 saved.CreatedAt);
         }
-        catch (InvalidOperationException ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             sw.Stop();
             _logger?.LogWarning("{EventName} reason={Reason} durationMs={DurationMs}",
-                ObservabilityEvents.SignalSubmitFailed, ex.Message, sw.ElapsedMilliseconds);
+                ObservabilityEvents.SignalSubmitFailed,
+                ObservabilityEvents.SanitizeForLog(ex.GetType().Name),
+                sw.ElapsedMilliseconds);
             throw;
         }
     }

--- a/src/Hali.Workers/EvaluatePossibleRestorationJob.cs
+++ b/src/Hali.Workers/EvaluatePossibleRestorationJob.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
 using Hali.Application.Notifications;
+using Hali.Application.Observability;
 using Hali.Application.Participation;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Enums;
@@ -78,7 +79,8 @@ public sealed class EvaluatePossibleRestorationJob(
         // Revert to active if still-affected votes overwhelm restoration votes
         if (stillAffected > restorationYes && stillAffected >= options.MinRestorationAffectedVotes)
         {
-            logger.LogInformation("Cluster {Id}: reverting to active (still_affected={StillAffected})", cluster.Id, stillAffected);
+            logger.LogInformation("{EventName} clusterId={ClusterId} stillAffected={StillAffected}",
+                ObservabilityEvents.ClusterRevertedToActive, cluster.Id, stillAffected);
             cluster.State = SignalState.Active;
             cluster.PossibleRestorationAt = null;
             cluster.UpdatedAt = DateTime.UtcNow;
@@ -101,7 +103,8 @@ public sealed class EvaluatePossibleRestorationJob(
             double ratio = (double)restorationYes / (double)totalRestorationResponses;
             if (ratio >= options.RestorationRatio)
             {
-                logger.LogInformation("Cluster {Id}: resolving (ratio={Ratio:F2})", cluster.Id, ratio);
+                logger.LogInformation("{EventName} clusterId={ClusterId} ratio={Ratio}",
+                    ObservabilityEvents.ClusterRestorationConfirmed, cluster.Id, ratio);
                 cluster.State = SignalState.Resolved;
                 cluster.ResolvedAt = DateTime.UtcNow;
                 cluster.UpdatedAt = DateTime.UtcNow;
@@ -140,7 +143,8 @@ public sealed class EvaluatePossibleRestorationJob(
                 {
                     try
                     {
-                        logger.LogInformation("{eventName} clusterId={ClusterId}", "cluster.resolved", cluster.Id);
+                        logger.LogInformation("{EventName} clusterId={ClusterId}",
+                            ObservabilityEvents.ClusterRestorationConfirmed, cluster.Id);
                         await notificationQueue.QueueClusterResolvedAsync(cluster.Id, cluster.LocalityId, cluster.Title ?? "Civic issue", ct);
                     }
                     catch (Exception ex)

--- a/src/Hali.Workers/EvaluatePossibleRestorationJob.cs
+++ b/src/Hali.Workers/EvaluatePossibleRestorationJob.cs
@@ -143,8 +143,6 @@ public sealed class EvaluatePossibleRestorationJob(
                 {
                     try
                     {
-                        logger.LogInformation("{EventName} clusterId={ClusterId}",
-                            ObservabilityEvents.ClusterRestorationConfirmed, cluster.Id);
                         await notificationQueue.QueueClusterResolvedAsync(cluster.Id, cluster.LocalityId, cluster.Title ?? "Civic issue", ct);
                     }
                     catch (Exception ex)

--- a/tests/Hali.Tests.Unit/Hali.Tests.Unit.csproj
+++ b/tests/Hali.Tests.Unit/Hali.Tests.Unit.csproj
@@ -11,6 +11,7 @@
     <ProjectReference Include="..\..\src\Hali.Application\Hali.Application.csproj" />
     <ProjectReference Include="..\..\src\Hali.Contracts\Hali.Contracts.csproj" />
     <ProjectReference Include="..\..\src\Hali.Infrastructure\Hali.Infrastructure.csproj" />
+    <ProjectReference Include="..\..\src\Hali.Api\Hali.Api.csproj" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />

--- a/tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Home;
+using Hali.Application.Notifications;
+using Hali.Application.Observability;
+using Hali.Contracts.Advisories;
+using Hali.Contracts.Clusters;
+using Hali.Contracts.Home;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Entities.Notifications;
+using Hali.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+public class HomeObservabilityTests
+{
+    private readonly IHomeFeedQueryService _feedQuery = Substitute.For<IHomeFeedQueryService>();
+    private readonly IFollowService _follows = Substitute.For<IFollowService>();
+    private readonly IDatabase _redis = Substitute.For<IDatabase>();
+    private readonly RecordingLogger<HomeController> _logger = new();
+
+    private HomeController CreateController(bool authenticated = true, Guid? accountId = null)
+    {
+        var controller = new HomeController(_feedQuery, _follows, _redis, _logger);
+        var context = new DefaultHttpContext();
+        if (authenticated)
+        {
+            var aid = accountId ?? Guid.NewGuid();
+            var claims = new[]
+            {
+                new System.Security.Claims.Claim(
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                    aid.ToString())
+            };
+            var identity = new System.Security.Claims.ClaimsIdentity(claims, "test");
+            context.User = new System.Security.Claims.ClaimsPrincipal(identity);
+        }
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+        return controller;
+    }
+
+    private static readonly Guid LocalityId = Guid.NewGuid();
+
+    private void SetupDefaultFeed()
+    {
+        _follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Follow> { new() { LocalityId = LocalityId } });
+
+        _feedQuery.GetActiveByLocalitiesPagedAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<bool?>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>());
+
+        _feedQuery.GetAllActivePagedAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>());
+
+        _feedQuery.GetOfficialPostsByLocalityAsync(
+                Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<OfficialPostResponseDto>());
+
+        _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(RedisValue.Null);
+    }
+
+    [Fact]
+    public async Task GetHome_EmitsStartedAndCompletedEvents()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeRequestStarted));
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeRequestCompleted));
+    }
+
+    [Fact]
+    public async Task GetHome_WithExplicitLocality_EmitsExplicitScopeEvent()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, LocalityId, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeLocalityScopeExplicit));
+    }
+
+    [Fact]
+    public async Task GetHome_WithFollowedLocalities_EmitsFallbackScopeEvent()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeLocalityScopeFallback));
+    }
+
+    [Fact]
+    public async Task GetHome_GuestUser_EmitsGuestEmptyScopeEvent()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController(authenticated: false);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeLocalityScopeGuestEmpty));
+    }
+
+    [Fact]
+    public async Task GetHome_CacheMiss_EmitsCacheCheckedAndMissEvents()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeCacheChecked));
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeCacheMiss));
+    }
+
+    [Fact]
+    public async Task GetHome_CacheHit_EmitsCacheHitEvent()
+    {
+        _follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Follow> { new() { LocalityId = LocalityId } });
+        _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(new RedisValue("{}"));
+
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeCacheHit));
+    }
+
+    [Fact]
+    public async Task GetHome_FullResponse_EmitsSectionBuiltEventsForAllSections()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeSectionBuilt) && m.Contains("active_now"));
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeSectionBuilt) && m.Contains("official_updates"));
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeSectionBuilt) && m.Contains("recurring_at_this_time"));
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeSectionBuilt) && m.Contains("other_active_signals"));
+    }
+
+    [Fact]
+    public async Task GetHome_CompletedEvent_IncludesDurationMs()
+    {
+        SetupDefaultFeed();
+        var controller = CreateController();
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.HomeRequestCompleted) && m.Contains("durationMs"));
+    }
+
+    /// <summary>
+    /// Minimal ILogger that captures formatted messages for assertion.
+    /// </summary>
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = new();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/RoutingObservabilityTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/RoutingObservabilityTests.cs
@@ -1,0 +1,127 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Clusters;
+using Hali.Application.Observability;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Entities.Signals;
+using Hali.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+public class RoutingObservabilityTests
+{
+    private readonly IClusterRepository _repo = Substitute.For<IClusterRepository>();
+    private readonly IH3CellService _h3 = Substitute.For<IH3CellService>();
+    private readonly ICivisEvaluationService _civis = Substitute.For<ICivisEvaluationService>();
+    private readonly RecordingLogger<ClusteringService> _logger = new();
+
+    private ClusteringService CreateService(CivisOptions? opts = null)
+    {
+        var options = Options.Create(opts ?? new CivisOptions { JoinThreshold = 0.65, TimeScoreMaxAgeHours = 24.0 });
+        return new ClusteringService(_repo, _h3, _civis, options, _logger);
+    }
+
+    private static SignalEvent MakeSignal(string spatialCellId = "8928308280fffff")
+    {
+        return new SignalEvent
+        {
+            Id = Guid.NewGuid(),
+            DeviceId = Guid.NewGuid(),
+            Category = CivicCategory.Water,
+            SubcategorySlug = "low-pressure",
+            ConditionSlug = "no-water",
+            NeutralSummary = "No water in the area.",
+            TemporalType = "episodic",
+            SpatialCellId = spatialCellId,
+            OccurredAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    private static SignalCluster MakeCluster(double lastSeenAgoHours = 0.5)
+    {
+        return new SignalCluster
+        {
+            Id = Guid.NewGuid(),
+            Category = CivicCategory.Water,
+            State = SignalState.Unconfirmed,
+            SpatialCellId = "8928308280fffff",
+            DominantConditionSlug = "no-water",
+            RawConfirmationCount = 1,
+            CreatedAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours),
+            UpdatedAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours),
+            FirstSeenAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours),
+            LastSeenAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours)
+        };
+    }
+
+    [Fact]
+    public async Task RouteSignal_JoinPath_EmitsRoutedEventWithJoinedOutcome()
+    {
+        var signal = MakeSignal();
+        var cluster = MakeCluster();
+
+        _h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        _repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster> { cluster });
+
+        var svc = CreateService();
+        await svc.RouteSignalAsync(signal);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.SignalRouted) && m.Contains("joined"));
+    }
+
+    [Fact]
+    public async Task RouteSignal_CreatePath_EmitsRoutedEventWithCreatedOutcome()
+    {
+        var signal = MakeSignal();
+
+        _h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        _repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>());
+        _repo.CreateClusterAsync(Arg.Any<SignalCluster>(), Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<SignalCluster>()));
+
+        var svc = CreateService();
+        await svc.RouteSignalAsync(signal);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.SignalRouted) && m.Contains("created"));
+    }
+
+    [Fact]
+    public async Task RouteSignal_RoutedEvent_IncludesCandidateCount()
+    {
+        var signal = MakeSignal();
+
+        _h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        _repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>());
+        _repo.CreateClusterAsync(Arg.Any<SignalCluster>(), Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<SignalCluster>()));
+
+        var svc = CreateService();
+        await svc.RouteSignalAsync(signal);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.SignalRouted) && m.Contains("candidateCount"));
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = new();
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/SignalObservabilityTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/SignalObservabilityTests.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Clusters;
+using Hali.Application.Observability;
+using Hali.Application.Signals;
+using Hali.Contracts.Signals;
+using Hali.Domain.Entities.Signals;
+using Hali.Domain.Enums;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+public class SignalObservabilityTests
+{
+    private readonly INlpExtractionService _nlp = Substitute.For<INlpExtractionService>();
+    private readonly ISignalRepository _repo = Substitute.For<ISignalRepository>();
+    private readonly IClusteringService _clustering = Substitute.For<IClusteringService>();
+    private readonly IH3CellService _h3 = Substitute.For<IH3CellService>();
+    private readonly ILocalityLookupRepository _localityLookup = Substitute.For<ILocalityLookupRepository>();
+    private readonly RecordingLogger<SignalIngestionService> _logger = new();
+
+    private static readonly Guid DefaultLocalityId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static readonly Guid DefaultClusterId = Guid.Parse("cccccccc-dddd-eeee-ffff-000000000000");
+
+    private SignalIngestionService CreateService()
+    {
+        return new SignalIngestionService(_nlp, _repo, _clustering, _h3, _localityLookup, _logger);
+    }
+
+    private static SignalSubmitRequestDto MakeSubmitRequest(string idempKey = "key-abc")
+    {
+        return new SignalSubmitRequestDto(idempKey, "device-hash-1", "Big potholes on Lusaka Road",
+            "roads", "potholes", "difficult", 0.85, -1.3, 36.8,
+            "Potholes on Lusaka Road", "road", 0.8, "nlp",
+            "temporary", "Potholes on Lusaka Road.", "en");
+    }
+
+    private void SetupHappyPath()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("892a1008003ffff");
+        _localityLookup.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(DefaultLocalityId, "Nairobi West", "Nairobi", "Nairobi"));
+        _repo.PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>()).Returns(ci =>
+        {
+            var s = ci.ArgAt<SignalEvent>(0);
+            return new SignalEvent { Id = s.Id, CreatedAt = s.CreatedAt, OccurredAt = s.OccurredAt, Category = s.Category, SpatialCellId = s.SpatialCellId, LocalityId = s.LocalityId };
+        });
+        _clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+            .Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_HappyPath_EmitsStartedAndCompletedEvents()
+    {
+        SetupHappyPath();
+        var svc = CreateService();
+
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalSubmitStarted));
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalSubmitCompleted));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_HappyPath_EmitsSpatialDerivedEvent()
+    {
+        SetupHappyPath();
+        var svc = CreateService();
+
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalSpatialDerived));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_HappyPath_EmitsLocalityResolvedEvent()
+    {
+        SetupHappyPath();
+        var svc = CreateService();
+
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalLocalityResolved));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_CompletedEvent_IncludesDurationMs()
+    {
+        SetupHappyPath();
+        var svc = CreateService();
+
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+
+        Assert.Contains(_logger.Messages,
+            m => m.Contains(ObservabilityEvents.SignalSubmitCompleted) && m.Contains("durationMs"));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_InvalidCategory_EmitsFailedEvent()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        var request = MakeSubmitRequest() with { Category = "aliens" };
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.SubmitAsync(request, null, null));
+
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalSubmitFailed));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_LocalityUnresolved_EmitsLocalityFailedEvent()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("892a1008003ffff");
+        _localityLookup.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns((LocalitySummary?)null);
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalLocalityFailed));
+    }
+
+    [Fact]
+    public async Task SubmitAsync_SpatialDerivationFails_EmitsSpatialFailedEvent()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("");
+        var svc = CreateService();
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+
+        Assert.Contains(_logger.Messages, m => m.Contains(ObservabilityEvents.SignalSpatialFailed));
+    }
+
+    private sealed class RecordingLogger<T> : ILogger<T>
+    {
+        public List<string> Messages { get; } = new();
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        {
+            Messages.Add(formatter(state, exception));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces centralized `ObservabilityEvents` constants for stable, metrics-friendly structured log event names
- Instruments `/v1/home` with request lifecycle, locality scoping mode, cache hit/miss, and per-section timing/item counts
- Instruments signal submit path with start/complete/failure, spatial derivation, and locality resolution events
- Instruments clustering routing with outcome (joined vs created) and candidate counts
- Instruments restoration/lifecycle transitions in ParticipationService and EvaluatePossibleRestorationJob

## Event Model

| Event Name | What it represents |
|---|---|
| `home.request.started` | Home feed request begins |
| `home.request.completed` | Home feed request finishes (includes durationMs) |
| `home.request.failed` | Home feed request threw an exception |
| `home.section.built` | One section of the home feed was built (includes section name, itemCount, durationMs) |
| `home.cache.checked` | Redis cache was consulted for first-page response |
| `home.cache.hit` | Cache returned a valid response |
| `home.cache.miss` | Cache miss — full response built from DB |
| `home.locality.explicit` | User requested an explicit localityId |
| `home.locality.fallback` | User has followed localities (standard path) |
| `home.locality.guest_empty` | Anonymous/no-follows — empty sections |
| `signal.submit.started` | Signal submit begins (includes category) |
| `signal.submit.completed` | Signal submit finishes (includes signalId, clusterId, wasCreated, durationMs) |
| `signal.submit.failed` | Signal submit failed (includes reason, durationMs) |
| `signal.spatial.derived` | H3 cell derived successfully |
| `signal.spatial.failed` | H3 cell derivation failed |
| `signal.locality.resolved` | Locality resolved from coordinates |
| `signal.locality.failed` | Locality resolution failed |
| `signal.routed` | Signal routed to cluster (includes outcome, candidateCount, joinScore) |
| `cluster.possible_restoration` | Cluster entered possible_restoration state |
| `cluster.restoration_confirmed` | Cluster resolved via restoration votes |
| `cluster.reverted_to_active` | Cluster reverted from possible_restoration to active |
| `cluster.resolved_by_decay` | Cluster resolved via decay |

## Instrumentation Points

### `/v1/home`
- Request start/complete/fail with elapsed time
- Locality scoping mode (explicit / fallback / guest-empty)
- Cache check/hit/miss
- Per-section build duration and item count (active_now, official_updates, recurring_at_this_time, other_active_signals)

### Signal Submit
- Submit start with category
- Spatial derivation success/failure
- Locality resolution success/failure
- Submit completion with signal ID, cluster ID, creation flag, duration
- Submit failure with reason code and duration

### Routing
- Routing outcome (joined vs created) with candidate count and join score

### Restoration/Lifecycle
- Possible restoration entered (from participation votes)
- Restoration confirmed / reverted to active (from worker evaluation)
- Resolved by decay (from CivisEvaluationService)

## Behavior Preserved

- No API contract changes
- No OpenAPI changes
- No mobile changes
- No documentation changes
- All 234 existing unit tests continue to pass
- A7 concurrent section build pattern unchanged
- All logging uses nullable `ILogger<T>?` to maintain backward compatibility with existing DI registrations

## Test Coverage

18 new observability tests covering:
- Home feed emits started/completed events
- Explicit/fallback/guest locality scoping events
- Cache hit/miss events
- Section-built events for all 4 sections
- Duration included in completed events
- Signal submit started/completed/failed events
- Spatial derived/failed events
- Locality resolved/failed events
- Routing outcome logged (joined vs created) with candidate count

## Test plan
- [x] All 234 unit tests pass
- [x] 18 new observability tests pass
- [x] Build succeeds with 0 errors
- [x] `dotnet format --verify-no-changes` clean on changed files
- [x] No API/OpenAPI/mobile/docs changes
- [x] No CIVIS internals exposed in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)