### PR TITLE
docs(arch): Copilot/CodeQL lessons audit — quality gates, coding standards hardening

### DIFF
--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -189,7 +189,7 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
   `Request.QueryString`, raw header values) into structured log templates.
   Use `context.GetEndpoint()?.DisplayName` for route identification.
   For any user-supplied value that must be logged, use
-  `ObservabilityEvents.SanitizeForLog()`.
+  `ObservabilityEvents.SanitizeForLog(value)`.
 - The existing header-sanitization rule (Security section) covers response
   headers; this rule covers the structured-logging path explicitly.
 

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -117,6 +117,11 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
 - [ ] No `Animated` (old API) for new animations — use `react-native-reanimated`
 - [ ] All new components export from their module's barrel index file
 - [ ] Every new shared component has an accessibilityLabel and accessibilityRole
+- [ ] When replacing an inline element with a shared component, diff the old element's
+      accessibility attributes (`accessibilityLabel`, `accessibilityState`, `accessibilityRole`,
+      `accessibilityHint`, `accessibilityLiveRegion`) and ensure all are preserved
+- [ ] Every `setTimeout`, `setInterval`, and Reanimated animation started in a `useEffect`
+      is cancelled in the cleanup function — stale callbacks cause ghost navigation and leaks
 
 ### Security
 - [ ] No secrets, tokens, or API keys in any committed file
@@ -133,6 +138,9 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
 - [ ] Never modify an existing migration's Up() or Down() method
 - [ ] Every new migration has a meaningful name (not Migration1, Migration2)
 - [ ] Migration can be reversed — verify Down() is correct
+- [ ] Any Down() that reverts an enum column to integer must use raw SQL with
+      `USING` and `CASE` mapping — a bare `AlterColumn` will throw a type cast error
+- [ ] Down() must never drop shared tables (e.g., `outbox_events`) used by other modules
 - [ ] If a spec or arch doc references a DB table/column that does not exist in the
       current schema, mark it explicitly as a planned schema change before implementation
 
@@ -168,6 +176,23 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
 - Services return domain results, not HTTP responses
 - Every service method that mutates state writes an audit log entry
 
+### Exception handling
+- Middleware and service-layer catch-all blocks must handle
+  `OperationCanceledException` before the general `Exception` catch.
+  In middleware: `catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)`
+  — return without writing a response or logging an error.
+  In services: `catch (Exception ex) when (ex is not OperationCanceledException)`.
+  Client disconnects are not server errors.
+
+### Logging safety
+- Never pass raw request-derived values (`Request.Path`, `Request.Method`,
+  `Request.QueryString`, raw header values) into structured log templates.
+  Use `context.GetEndpoint()?.DisplayName` for route identification.
+  For any user-supplied value that must be logged, use
+  `ObservabilityEvents.SanitizeForLog()`.
+- The existing header-sanitization rule (Security section) covers response
+  headers; this rule covers the structured-logging path explicitly.
+
 ### Nullable reference types
 - All new C# files have nullable enabled (#nullable enable or via csproj)
 - Use `??` and `?.` where appropriate; prefer `is null` / `is not null` for explicit null
@@ -178,6 +203,13 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
   its content stream are disposed after reading
 - Any `IDisposable`/`IAsyncDisposable` infrastructure object (NpgsqlDataSource, HttpClient, etc.)
   must be registered in the DI container — not captured in a closure — to ensure proper disposal
+
+### XML documentation
+- `cref` attributes must use fully qualified type names
+  (`<exception cref="Hali.Application.Errors.ValidationException">`),
+  not short names that may not resolve in the target namespace (CS1574).
+- When a service implementation changes which exception it throws, update the
+  interface's XML `<exception>` doc in the same commit.
 
 ### String formatting
 - Always use `CultureInfo.InvariantCulture` when converting numeric types to strings for
@@ -191,6 +223,9 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
   → prefer: `g.FirstOrDefault(e => !string.IsNullOrWhiteSpace(e.Field)) ?? g.First()`
 
 ### EF Core
+- `DbContext` is not thread-safe. Never wrap multiple queries in `Task.WhenAll`
+  on a shared context. Use sequential queries on a single context, or resolve
+  separate scoped contexts via `IServiceScopeFactory` for genuinely parallel work.
 - When a `dotnet build` step precedes a `dotnet ef` step in the same CI job,
   always pass `--no-build` to the EF command to avoid redundant builds
 

--- a/docs/arch/COPILOT_LESSONS.md
+++ b/docs/arch/COPILOT_LESSONS.md
@@ -1,0 +1,50 @@
+# Copilot Lessons — High-Signal Recurring Patterns
+
+> Patterns Copilot has flagged multiple times across PRs.
+> Read before opening any PR. Each entry names the standing rule
+> where the fix is encoded — go there for the full requirement.
+>
+> This file is intentionally short. Do not duplicate rules already
+> explained in `docs/arch/CODING_STANDARDS.md`.
+
+---
+
+## 1. Log-forging via request-derived values
+Copilot and CodeQL flag `Request.Path`, `Request.Method`, headers, and
+correlation IDs flowing into structured logs. This was the single most
+common finding (12+ CodeQL alerts, 5 PRs). The fix is always the same:
+use `GetEndpoint()?.DisplayName` or `SanitizeForLog()`.
+-> CODING_STANDARDS: C# Conventions > Logging safety
+
+## 2. OperationCanceledException swallowed by catch-all
+Exception middleware and service catch blocks that catch `Exception`
+without excluding `OperationCanceledException` turn client disconnects
+into 500s. Flagged in PRs #92, #104, #106.
+-> CODING_STANDARDS: C# Conventions > Exception handling
+
+## 3. Accessibility props dropped on component extraction
+When an inline element is replaced with a shared component, accessibility
+attributes silently disappear. Flagged 15+ times across 5 mobile PRs
+(#74, #78, #79, #81, #82). Diff the old element before deleting it.
+-> CODING_STANDARDS: React Native / TypeScript checklist
+
+## 4. Tests lost during merge conflict resolution
+Merge resolution in test files can silently delete test methods or weaken
+assertions. Two tests lost in PR #106. Always diff `tests/` against the
+base branch after conflict resolution.
+-> PR_QUALITY_GATES: G3
+
+## 5. Enum serialization with ToLowerInvariant()
+`.ToString().ToLowerInvariant()` on PascalCase enums produces wrong wire
+values (e.g., `possiblerestoration`). Flagged in PR #94.
+-> CODING_STANDARDS: Enum serialization rules
+
+## 6. DbContext used in Task.WhenAll
+EF Core DbContext is not thread-safe. Parallel queries on a shared context
+corrupt state silently. Caught in PR #98, immediately reverted.
+-> CODING_STANDARDS: C# Conventions > EF Core
+
+## 7. Interface docs diverge from implementation
+When a service changes which exception it throws, the interface XML docs
+stay stale. Copilot catches the mismatch. Update docs in the same commit.
+-> CODING_STANDARDS: C# Conventions > XML documentation

--- a/docs/arch/COPILOT_LESSONS.md
+++ b/docs/arch/COPILOT_LESSONS.md
@@ -11,37 +11,39 @@
 
 ## 1. Log-forging via request-derived values
 Copilot and CodeQL flag `Request.Path`, `Request.Method`, headers, and
-correlation IDs flowing into structured logs. This was the single most
-common finding (12+ CodeQL alerts, 5 PRs). The fix is always the same:
-use `GetEndpoint()?.DisplayName` or `SanitizeForLog()`.
+correlation IDs flowing into structured logs. This is the single most
+common finding (12+ CodeQL alerts across multiple PRs). The fix is always
+the same: use `context.GetEndpoint()?.DisplayName` or
+`ObservabilityEvents.SanitizeForLog(...)`.
 -> CODING_STANDARDS: C# Conventions > Logging safety
 
 ## 2. OperationCanceledException swallowed by catch-all
 Exception middleware and service catch blocks that catch `Exception`
 without excluding `OperationCanceledException` turn client disconnects
-into 500s. Flagged in PRs #92, #104, #106.
+into 500s. Flagged repeatedly across multiple PRs.
 -> CODING_STANDARDS: C# Conventions > Exception handling
 
 ## 3. Accessibility props dropped on component extraction
 When an inline element is replaced with a shared component, accessibility
-attributes silently disappear. Flagged 15+ times across 5 mobile PRs
-(#74, #78, #79, #81, #82). Diff the old element before deleting it.
+attributes silently disappear. Flagged 15+ times across multiple mobile
+PRs. Diff the old element before deleting it.
 -> CODING_STANDARDS: React Native / TypeScript checklist
 
 ## 4. Tests lost during merge conflict resolution
 Merge resolution in test files can silently delete test methods or weaken
-assertions. Two tests lost in PR #106. Always diff `tests/` against the
-base branch after conflict resolution.
+assertions. This has caused test loss before. Always diff `tests/` against
+the base branch after conflict resolution.
 -> PR_QUALITY_GATES: G3
 
 ## 5. Enum serialization with ToLowerInvariant()
 `.ToString().ToLowerInvariant()` on PascalCase enums produces wrong wire
-values (e.g., `possiblerestoration`). Flagged in PR #94.
+values (e.g., `possiblerestoration`). This pattern has recurred.
 -> CODING_STANDARDS: Enum serialization rules
 
 ## 6. DbContext used in Task.WhenAll
 EF Core DbContext is not thread-safe. Parallel queries on a shared context
-corrupt state silently. Caught in PR #98, immediately reverted.
+corrupt state silently. This pattern has been caught before and should be
+treated as a blocking issue.
 -> CODING_STANDARDS: C# Conventions > EF Core
 
 ## 7. Interface docs diverge from implementation

--- a/docs/arch/COPILOT_LESSONS.md
+++ b/docs/arch/COPILOT_LESSONS.md
@@ -27,7 +27,7 @@ into 500s. Flagged repeatedly across multiple PRs.
 When an inline element is replaced with a shared component, accessibility
 attributes silently disappear. Flagged 15+ times across multiple mobile
 PRs. Diff the old element before deleting it.
--> CODING_STANDARDS: React Native / TypeScript checklist
+-> CODING_STANDARDS: Pre-commit checklist > React Native / TypeScript (citizen-mobile)
 
 ## 4. Tests lost during merge conflict resolution
 Merge resolution in test files can silently delete test methods or weaken

--- a/docs/arch/PR_QUALITY_GATES.md
+++ b/docs/arch/PR_QUALITY_GATES.md
@@ -1,0 +1,47 @@
+# PR Quality Gates
+
+> Mandatory checks before requesting review on any PR.
+> Each gate maps to a recurring class of review failure.
+> Run these after all commits are done, before requesting review.
+
+---
+
+## G1 — Build clean
+- [ ] `dotnet build` zero warnings (C# changes)
+- [ ] `dotnet format --verify-no-changes` passes (C# changes)
+- [ ] `npx tsc --noEmit` zero errors (TypeScript changes)
+- [ ] `dotnet test` zero failures
+
+## G2 — API contract integrity
+- [ ] Every new/changed endpoint reflected in `02_openapi.yaml`
+- [ ] Every `[ProducesResponseType]` has a code path that returns it
+- [ ] Error codes follow `<category>.<reason>` naming (e.g., `validation.locality_unresolved`)
+- [ ] Enum wire values match OpenAPI `enum` arrays exactly
+
+## G3 — Test integrity
+- [ ] No test methods removed vs. base branch: `git diff <base-branch>...HEAD -- tests/`
+- [ ] New domain logic has unit tests
+- [ ] Assertions match test names (`Assert.Empty` not `Assert.NotNull` for emptiness)
+
+## G4 — Security surface
+- [ ] No request-derived values in structured log templates
+- [ ] No hardcoded credentials in design-time factories or configuration
+- [ ] `[AllowAnonymous]` endpoints do not accept user-controlled filter
+  params that should require authentication
+
+## G5 — Accessibility (mobile PRs)
+- [ ] All accessibility props preserved when migrating to shared components
+- [ ] `React.memo` comparators include every rendered field
+
+## G6 — Documentation alignment
+- [ ] Interface XML docs match implementation (exception types, return types)
+- [ ] PR description accurately describes the diff scope
+
+## G7 — Review findings resolved
+- [ ] All Copilot review comments are fixed, replied to with rationale,
+  or explicitly deferred
+- [ ] All CodeQL / code-scanning alerts introduced by the PR are resolved
+  or have a documented suppression rationale in the PR thread
+- [ ] Intentionally deferred findings that represent real work are logged
+  as GitHub issues (with a link in the PR thread) before merge —
+  do not let deferred items disappear without a tracking artifact

--- a/docs/arch/PR_QUALITY_GATES.md
+++ b/docs/arch/PR_QUALITY_GATES.md
@@ -7,7 +7,7 @@
 ---
 
 ## G1 — Build clean
-- [ ] `dotnet build` zero warnings (C# changes)
+- [ ] `dotnet build` no new warnings vs. the current baseline (C# changes)
 - [ ] `dotnet format --verify-no-changes` passes (C# changes)
 - [ ] `npx tsc --noEmit` zero errors (TypeScript changes)
 - [ ] `dotnet test` zero failures


### PR DESCRIPTION
## Summary

- Extract recurring lessons from historical Copilot/CodeQL review feedback (48 PRs, 29 CodeQL alerts) into durable repo documentation
- Add 8 new rules to `docs/arch/CODING_STANDARDS.md` covering exception handling, logging safety, XML docs, EF Core concurrency, migration rollback, and React Native cleanup/accessibility
- Create `docs/arch/PR_QUALITY_GATES.md` with 7 mandatory pre-review gates including a review-findings-resolved gate (G7) requiring deferred items to be tracked as GitHub issues
- Create `docs/arch/COPILOT_LESSONS.md` with 7 high-signal recurring patterns cross-referencing standing rules

## Test plan

- [ ] Verify no existing CODING_STANDARDS rules were removed or weakened
- [ ] Verify PR_QUALITY_GATES gates are base-branch-aware (no hardcoded `main`)
- [ ] Verify COPILOT_LESSONS entries cross-reference standing rules without duplicating them
- [ ] Verify all three files render correctly in GitHub Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)