### PR TITLE
chore: gitignore Claude worktrees and Expo expo-env.d.ts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,3 +119,9 @@ build_state.json
 agent_outputs/session_*_prompt.txt
 agent_outputs/session_*_claude_output.txt
 agent_outputs/master_orchestrator.log
+
+# ── Claude Code agent worktrees (local only) ────────────────────────────────
+.claude/worktrees/
+
+# ── Expo generated type declarations ────────────────────────────────────────
+expo-env.d.ts


### PR DESCRIPTION
## Summary
- Adds `.claude/worktrees/` to `.gitignore` — ephemeral Claude Code agent workspaces (local-only, 152 MB cleaned locally)
- Adds `expo-env.d.ts` to `.gitignore` — Expo-generated type declaration file explicitly marked "should be in your git ignore" by Expo itself

## Rationale
Both paths were showing as untracked in `git status`. Neither belongs in source control:
- `.claude/worktrees/` contains full repo clones from agent isolation runs — accidental staging would add 152 MB of duplicates
- `expo-env.d.ts` is auto-generated by Expo CLI and creates unnecessary churn across Expo version bumps

## Test plan
- [x] `git status` returns clean after the change
- [x] `expo-env.d.ts` remains on disk for TypeScript compilation
- [x] No tracked files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)