### PR TITLE
feat(b8): anonymous browse — public read, auth-gated writes

### DIFF
--- a/apps/citizen-mobile/app/(app)/clusters/[id].tsx
+++ b/apps/citizen-mobile/app/(app)/clusters/[id].tsx
@@ -38,6 +38,7 @@ import { ParticipationBar } from '../../../src/components/cluster/ParticipationB
 import { Loading } from '../../../src/components/common/Loading';
 import { Button } from '../../../src/components/common/Button';
 import {
+  AuthPrompt,
   CategoryIconCircle,
   SectionHeader,
   OfficialUpdateRow,
@@ -279,55 +280,62 @@ export default function ClusterDetailScreen(): React.ReactElement {
         )}
 
         {/* ── Participation actions ─────────────────────────────── */}
-        <View style={styles.actionsBlock}>
-          <Text style={styles.actionsLabel}>How does this affect you?</Text>
-          <View style={styles.actionRow}>
-            <Button
-              label="I'm Affected"
-              variant={localParticipation === 'affected' ? 'primary' : 'secondary'}
-              size="sm"
-              loading={
-                participationMutation.isPending &&
-                participationMutation.variables?.type === 'affected'
-              }
-              disabled={participationMutation.isPending}
-              onPress={() => void handleParticipate('affected')}
-              style={styles.actionBtn}
-            />
-            {!isExperiential && (
+        {authState.status !== 'authenticated' ? (
+          <AuthPrompt
+            message="Sign in to report how this affects you and contribute to this signal."
+            onSignIn={() => router.push('/(auth)/phone')}
+          />
+        ) : (
+          <View style={styles.actionsBlock}>
+            <Text style={styles.actionsLabel}>How does this affect you?</Text>
+            <View style={styles.actionRow}>
               <Button
-                label="I'm Observing"
-                variant={localParticipation === 'observing' ? 'primary' : 'secondary'}
+                label="I'm Affected"
+                variant={localParticipation === 'affected' ? 'primary' : 'secondary'}
                 size="sm"
                 loading={
                   participationMutation.isPending &&
-                  participationMutation.variables?.type === 'observing'
+                  participationMutation.variables?.type === 'affected'
                 }
                 disabled={participationMutation.isPending}
-                onPress={() => void handleParticipate('observing')}
+                onPress={() => void handleParticipate('affected')}
                 style={styles.actionBtn}
               />
+              {!isExperiential && (
+                <Button
+                  label="I'm Observing"
+                  variant={localParticipation === 'observing' ? 'primary' : 'secondary'}
+                  size="sm"
+                  loading={
+                    participationMutation.isPending &&
+                    participationMutation.variables?.type === 'observing'
+                  }
+                  disabled={participationMutation.isPending}
+                  onPress={() => void handleParticipate('observing')}
+                  style={styles.actionBtn}
+                />
+              )}
+            </View>
+
+            {localParticipation !== null && (
+              <TouchableOpacity
+                onPress={() => void handleParticipate('no_longer_affected')}
+                disabled={participationMutation.isPending}
+                style={styles.ghostCta}
+                accessibilityRole="button"
+                accessibilityLabel="No longer affected"
+              >
+                <Text style={styles.ghostCtaText}>No longer affected</Text>
+              </TouchableOpacity>
+            )}
+
+            {participationError !== null && (
+              <Text style={styles.errorText} accessibilityRole="alert">
+                {participationError}
+              </Text>
             )}
           </View>
-
-          {localParticipation !== null && (
-            <TouchableOpacity
-              onPress={() => void handleParticipate('no_longer_affected')}
-              disabled={participationMutation.isPending}
-              style={styles.ghostCta}
-              accessibilityRole="button"
-              accessibilityLabel="No longer affected"
-            >
-              <Text style={styles.ghostCtaText}>No longer affected</Text>
-            </TouchableOpacity>
-          )}
-
-          {participationError !== null && (
-            <Text style={styles.errorText} accessibilityRole="alert">
-              {participationError}
-            </Text>
-          )}
-        </View>
+        )}
 
         {/* ── Add Further Context ───────────────────────────────── */}
         {showContextBlock && (

--- a/apps/citizen-mobile/app/(app)/clusters/[id].tsx
+++ b/apps/citizen-mobile/app/(app)/clusters/[id].tsx
@@ -283,7 +283,9 @@ export default function ClusterDetailScreen(): React.ReactElement {
         {authState.status !== 'authenticated' ? (
           <AuthPrompt
             message="Sign in to report how this affects you and contribute to this signal."
-            onSignIn={() => router.push('/(auth)/phone')}
+            onSignIn={() => {
+              void requireAuth();
+            }}
           />
         ) : (
           <View style={styles.actionsBlock}>

--- a/apps/citizen-mobile/app/(app)/home.tsx
+++ b/apps/citizen-mobile/app/(app)/home.tsx
@@ -544,7 +544,7 @@ function LocalitySelectorSheet({
         <FlatList
           data={listData}
           keyExtractor={(item) => item.localityId}
-          renderItem={({ item, index }) => {
+          renderItem={({ item }) => {
             const id = item.localityId;
             const label = item.label;
             const isActive = id === activeLocalityId;
@@ -570,8 +570,12 @@ function LocalitySelectorSheet({
                   if (isFollowed) {
                     onSelectLocality(id);
                   } else {
-                    // Guest browse — select from search results
-                    const sr = searchResults[index];
+                    // Guest browse — look up by stable localityId key so
+                    // selection is correct even if searchResults changed
+                    // between render and tap.
+                    const sr = searchResults.find(
+                      (result) => result.localityId === id,
+                    );
                     if (sr) {
                       onSelectSearchResult(sr);
                     }

--- a/apps/citizen-mobile/app/(app)/home.tsx
+++ b/apps/citizen-mobile/app/(app)/home.tsx
@@ -77,6 +77,7 @@ export default function HomeScreen(): React.ReactElement {
     activeLocality,
     followedLocalities,
     setActiveLocalityId,
+    setActiveLocality,
     setFollowedLocalities,
   } = useLocalityContext();
 
@@ -207,6 +208,7 @@ export default function HomeScreen(): React.ReactElement {
         >
           {hasNoFollows ? (
             <NoFollowsState
+              isAuthenticated={isAuthenticated}
               onOpenPicker={() => setLocalitySelectorOpen(true)}
             />
           ) : isCalmState ? (
@@ -246,7 +248,13 @@ export default function HomeScreen(): React.ReactElement {
       )}
 
       {/* ── Persistent FAB ──────────────────────────────────────────── */}
-      <FAB onPress={() => router.push('/(app)/compose/text')} />
+      <FAB onPress={() => {
+        if (!isAuthenticated) {
+          router.push('/(auth)/phone');
+          return;
+        }
+        router.push('/(app)/compose/text');
+      }} />
 
       {/* ── Feedback button ─────────────────────────────────────────── */}
       <FeedbackButton screen="home" />
@@ -257,8 +265,18 @@ export default function HomeScreen(): React.ReactElement {
           onClose={() => setLocalitySelectorOpen(false)}
           followedLocalities={followedLocalities}
           activeLocalityId={activeLocality?.localityId ?? null}
+          isAuthenticated={isAuthenticated}
           onSelectLocality={(id) => {
             setActiveLocalityId(id);
+            setLocalitySelectorOpen(false);
+          }}
+          onSelectSearchResult={(result) => {
+            setActiveLocality({
+              localityId: result.localityId,
+              wardName: result.wardName,
+              displayLabel: result.placeLabel,
+              cityName: result.cityName,
+            });
             setLocalitySelectorOpen(false);
           }}
         />
@@ -314,16 +332,22 @@ function OfficialUpdatesSection({
 // ─── Empty / error states ───────────────────────────────────────────────────
 
 function NoFollowsState({
+  isAuthenticated,
   onOpenPicker,
 }: {
+  isAuthenticated: boolean;
   onOpenPicker: () => void;
 }): React.ReactElement {
   return (
     <View style={styles.emptyContainer}>
       <MapPin size={32} color={Colors.mutedForeground} strokeWidth={1.5} />
-      <Text style={styles.emptyTitle}>Follow a ward to see activity</Text>
+      <Text style={styles.emptyTitle}>
+        {isAuthenticated ? 'Follow a ward to see activity' : 'Choose an area to explore'}
+      </Text>
       <Text style={styles.emptyBody}>
-        Hali shows you civic signals in the wards you follow. Pick up to 5.
+        {isAuthenticated
+          ? 'Hali shows you civic signals in the wards you follow. Pick up to 5.'
+          : 'Search for a ward to browse civic signals in that area.'}
       </Text>
       <TouchableOpacity
         style={styles.primaryCta}
@@ -364,14 +388,19 @@ interface LocalitySelectorSheetProps {
   onClose: () => void;
   followedLocalities: Array<{ localityId: string; wardName: string; displayLabel: string | null }>;
   activeLocalityId: string | null;
+  isAuthenticated: boolean;
   onSelectLocality: (id: string) => void;
+  /** Select a search result directly — used by anonymous browse. */
+  onSelectSearchResult: (result: LocalitySearchResult) => void;
 }
 
 function LocalitySelectorSheet({
   onClose,
   followedLocalities,
   activeLocalityId,
+  isAuthenticated,
   onSelectLocality,
+  onSelectSearchResult,
 }: LocalitySelectorSheetProps): React.ReactElement {
   const [searchQuery, setSearchQuery] = useState('');
   const [searchResults, setSearchResults] = useState<LocalitySearchResult[]>([]);
@@ -468,7 +497,7 @@ function LocalitySelectorSheet({
       <View style={styles.sheet}>
         {/* Sheet header */}
         <View style={styles.sheetHeader}>
-          <Text style={styles.sheetTitle}>Your areas</Text>
+          <Text style={styles.sheetTitle}>{isAuthenticated ? 'Your areas' : 'Browse an area'}</Text>
           <TouchableOpacity
             onPress={onClose}
             accessibilityLabel="Close"
@@ -515,33 +544,41 @@ function LocalitySelectorSheet({
         <FlatList
           data={listData}
           keyExtractor={(item) => item.localityId}
-          renderItem={({ item }) => {
+          renderItem={({ item, index }) => {
             const id = item.localityId;
             const label = item.label;
             const isActive = id === activeLocalityId;
-            // setActiveLocalityId only accepts ids that exist in
-            // followedLocalities. Search results that aren't already
-            // followed are non-selectable until follow/unfollow is wired
-            // (Phase G — wards settings).
             const isFollowed = followedLocalities.some(
               (l) => l.localityId === id,
             );
+            // Anonymous users may select any search result for browse-mode;
+            // authenticated users can only select their followed localities
+            // (unfollowed results are disabled until ward follow is wired).
+            const canSelect = isFollowed || (!isAuthenticated && !showFollowed);
 
             return (
               <TouchableOpacity
                 style={[
                   styles.localityRow,
                   isActive && styles.localityRowActive,
-                  !isFollowed && styles.localityRowDisabled,
+                  !canSelect && styles.localityRowDisabled,
                 ]}
-                disabled={!isFollowed}
+                disabled={!canSelect}
                 onPress={() => {
                   Keyboard.dismiss();
-                  if (!isFollowed) return;
-                  onSelectLocality(id);
+                  if (!canSelect) return;
+                  if (isFollowed) {
+                    onSelectLocality(id);
+                  } else {
+                    // Guest browse — select from search results
+                    const sr = searchResults[index];
+                    if (sr) {
+                      onSelectSearchResult(sr);
+                    }
+                  }
                 }}
                 accessibilityRole="button"
-                accessibilityState={{ selected: isActive, disabled: !isFollowed }}
+                accessibilityState={{ selected: isActive, disabled: !canSelect }}
               >
                 <Text
                   style={[

--- a/apps/citizen-mobile/app/(app)/home.tsx
+++ b/apps/citizen-mobile/app/(app)/home.tsx
@@ -82,6 +82,16 @@ export default function HomeScreen(): React.ReactElement {
   } = useLocalityContext();
 
   const [localitySelectorOpen, setLocalitySelectorOpen] = useState(false);
+
+  // Guard against stacking multiple auth screens if the FAB is tapped
+  // repeatedly while unauthenticated. Mirrors the navigatingToAuthRef
+  // pattern in cluster detail.
+  const navigatingToAuthRef = useRef(false);
+  useEffect(() => {
+    if (isAuthenticated) {
+      navigatingToAuthRef.current = false;
+    }
+  }, [isAuthenticated]);
   const [lastUpdatedAt, setLastUpdatedAt] = useState<Date | null>(null);
 
   // ── Load followed localities ──────────────────────────────────────────────
@@ -250,6 +260,8 @@ export default function HomeScreen(): React.ReactElement {
       {/* ── Persistent FAB ──────────────────────────────────────────── */}
       <FAB onPress={() => {
         if (!isAuthenticated) {
+          if (navigatingToAuthRef.current) return;
+          navigatingToAuthRef.current = true;
           router.push('/(auth)/phone');
           return;
         }

--- a/apps/citizen-mobile/app/index.tsx
+++ b/apps/citizen-mobile/app/index.tsx
@@ -14,7 +14,9 @@ export default function SplashScreen() {
     if (state.status === 'authenticated') {
       router.replace('/(app)/home');
     } else if (state.status === 'unauthenticated') {
-      router.replace('/(auth)/phone');
+      // Anonymous browse: guests land on the home feed and can browse
+      // read-only. Contribution actions gate to auth when tapped.
+      router.replace('/(app)/home');
     }
     // While status === 'unknown' (bootstrapping) we stay on this screen
   }, [state.status, router]);

--- a/apps/citizen-mobile/src/components/shared/AuthPrompt.tsx
+++ b/apps/citizen-mobile/src/components/shared/AuthPrompt.tsx
@@ -1,0 +1,76 @@
+// Inline auth prompt displayed when an anonymous user attempts a protected
+// action.  Renders as a small banner within the current screen — does not
+// navigate away.  The caller decides whether to show it (e.g. based on
+// isAuthenticated from AuthContext).
+
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { LogIn } from 'lucide-react-native';
+import {
+  Colors,
+  FontFamily,
+  FontSize,
+  Spacing,
+  Radius,
+} from '../../theme';
+
+interface AuthPromptProps {
+  /** Short explanation shown to the user, e.g. "Sign in to report a signal". */
+  message: string;
+  /** Called when the user taps the sign-in button. */
+  onSignIn: () => void;
+}
+
+export function AuthPrompt({ message, onSignIn }: AuthPromptProps): React.ReactElement {
+  return (
+    <View style={styles.container} accessibilityRole="alert">
+      <View style={styles.textRow}>
+        <LogIn size={16} color={Colors.primary} strokeWidth={2} />
+        <Text style={styles.message}>{message}</Text>
+      </View>
+      <TouchableOpacity
+        style={styles.button}
+        onPress={onSignIn}
+        accessibilityRole="button"
+        accessibilityLabel="Sign in"
+      >
+        <Text style={styles.buttonText}>Sign in</Text>
+      </TouchableOpacity>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    backgroundColor: Colors.primarySubtle,
+    borderRadius: Radius.lg,
+    padding: Spacing.lg,
+    gap: Spacing.md,
+    borderWidth: 1,
+    borderColor: Colors.primary + '30',
+  },
+  textRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+  },
+  message: {
+    flex: 1,
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.foreground,
+    lineHeight: FontSize.body * 1.4,
+  },
+  button: {
+    alignSelf: 'flex-start',
+    backgroundColor: Colors.primary,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.xl,
+    borderRadius: Radius.md,
+  },
+  buttonText: {
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.semiBold,
+    color: Colors.primaryForeground,
+  },
+});

--- a/apps/citizen-mobile/src/components/shared/index.ts
+++ b/apps/citizen-mobile/src/components/shared/index.ts
@@ -1,3 +1,4 @@
+export * from './AuthPrompt';
 export * from './ConditionBadge';
 export * from './SectionHeader';
 export * from './CalmState';

--- a/apps/citizen-mobile/src/context/LocalityContext.tsx
+++ b/apps/citizen-mobile/src/context/LocalityContext.tsx
@@ -28,6 +28,11 @@ export interface LocalityContextValue {
   followsLoaded: boolean;
   setActiveLocalityId: (id: string | null) => void;
   setFollowedLocalities: (items: FollowedLocality[]) => void;
+  /**
+   * Set the active locality directly — used by anonymous browse to select a
+   * locality from search results without requiring it to be in the followed set.
+   */
+  setActiveLocality: (locality: FollowedLocality | null) => void;
 }
 
 const LocalityContext = createContext<LocalityContextValue | null>(null);
@@ -70,6 +75,13 @@ export function LocalityProvider({
     });
   }, []);
 
+  const setActiveLocality = useCallback(
+    (locality: FollowedLocality | null) => {
+      setActiveLocalityRaw(locality);
+    },
+    [],
+  );
+
   const value = useMemo<LocalityContextValue>(
     () => ({
       activeLocality,
@@ -77,6 +89,7 @@ export function LocalityProvider({
       followsLoaded,
       setActiveLocalityId,
       setFollowedLocalities,
+      setActiveLocality,
     }),
     [
       activeLocality,
@@ -84,6 +97,7 @@ export function LocalityProvider({
       followsLoaded,
       setActiveLocalityId,
       setFollowedLocalities,
+      setActiveLocality,
     ],
   );
 

--- a/docs/implementation/B8_ANONYMOUS_BROWSE.md
+++ b/docs/implementation/B8_ANONYMOUS_BROWSE.md
@@ -1,0 +1,100 @@
+# B8 Anonymous Browse
+
+## What changed
+
+Anonymous (unauthenticated) users can now open the app and browse the public
+home feed and cluster detail screens without signing in. Contribution actions
+(signal creation, participation, context, restoration) remain gated behind
+authentication on both server and client.
+
+### Backend
+
+- **HomeController**: Removed the `isAuthenticated` guard on the `?localityId`
+  query parameter. Anonymous callers can now pass `?localityId=<guid>` to scope
+  the feed to a specific locality. Previously only authenticated users could
+  use this parameter; anonymous callers always received empty sections.
+- **Observability**: The `home.locality.explicit` log event now includes
+  `isAuthenticated` so anonymous browse traffic is distinguishable from
+  authenticated traffic without a separate event name.
+
+No new endpoints were added. No existing authorization attributes were changed.
+
+### Mobile
+
+- **Boot flow** (`app/index.tsx`): Unauthenticated users now route to
+  `/(app)/home` instead of `/(auth)/phone`. Both authenticated and
+  unauthenticated users land on the home feed.
+- **LocalityContext**: Added `setActiveLocality(locality)` to allow setting the
+  active locality directly from a search result, bypassing the followed-
+  localities lookup. This is used by anonymous browse where users have no
+  followed wards.
+- **Home screen**: Anonymous users see "Choose an area to explore" instead of
+  "Follow a ward to see activity". The locality selector sheet allows anonymous
+  users to select any search result for browsing (authenticated users still
+  require followed localities).
+- **FAB**: Tapping the Report FAB while unauthenticated navigates to auth
+  instead of the composer.
+- **Cluster detail**: Anonymous users see an `AuthPrompt` banner ("Sign in to
+  report how this affects you") in place of the participation action buttons.
+  The existing `requireAuth()` gate on participation handlers is preserved as
+  a defense-in-depth measure.
+- **AuthPrompt component**: New shared component for inline sign-in prompts
+  shown during anonymous browse.
+
+## Public vs protected surface decisions
+
+### Public (no auth required)
+
+| Endpoint / Surface | Rationale |
+|---|---|
+| `GET /v1/home?localityId=...` | Read-only feed data, no PII |
+| `GET /v1/clusters/{id}` | Read-only cluster detail, no CIVIS internals |
+| `GET /v1/localities/search` | Public locality lookup |
+| `GET /v1/localities/resolve-by-coordinates` | Public geocoding |
+| `POST /v1/signals/preview` | NLP preview, rate-limited per IP |
+| Home feed screen | Browseable without auth |
+| Cluster detail screen (read-only) | Viewable without auth |
+
+### Protected (auth required)
+
+| Endpoint / Surface | Enforcement |
+|---|---|
+| `POST /v1/signals/submit` | `[Authorize]` |
+| `POST /v1/clusters/{id}/participation` | `[Authorize]` |
+| `POST /v1/clusters/{id}/context` | `[Authorize]` |
+| `POST /v1/clusters/{id}/restoration-response` | `[Authorize]` |
+| `GET /v1/localities/followed` | `[Authorize]` (class-level) |
+| `PUT /v1/localities/followed` | `[Authorize]` (class-level) |
+| `GET /v1/users/me` | `[Authorize]` (class-level) |
+| `PUT /v1/users/me/notification-settings` | `[Authorize]` (class-level) |
+| `POST /v1/devices/push-token` | `[Authorize]` |
+| Report FAB | Client-side gate to auth |
+| Participation buttons | Client-side AuthPrompt + server `[Authorize]` |
+| Settings screens | Require auth to access account data |
+
+## Contract changes
+
+None. The `?localityId` query parameter on `GET /v1/home` already existed; it
+was just unnecessarily restricted to authenticated callers. The response shape
+is unchanged.
+
+## Known limitations
+
+- Anonymous users cannot follow wards. They browse by selecting localities from
+  the search interface, which creates a temporary browsing scope. This is
+  intentional: following wards requires account state and is a B6/future concern.
+- The locality selector "GPS opt-in" button does not resolve locality for
+  anonymous users (GPS locality resolution is deferred to Phase G).
+- Anonymous users do not see `myParticipation` on cluster detail (null from
+  server). This is correct behavior.
+
+## Follow-up implications
+
+- **B6 (Installation-scoped identity)**: B8 does not create pseudo-accounts or
+  silent device registrations. The anonymous browse session is purely stateless
+  on the server. B6 can introduce device-scoped identity on top of this without
+  conflicting with B8's posture.
+- **B9 (Location label exposure)**: No B9 changes were needed for B8.
+- **C12 (Analytics)**: The observability `isAuthenticated` field on home feed
+  logs provides the basis for anonymous-vs-authenticated traffic segmentation
+  without additional plumbing.

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -125,8 +125,17 @@ public class HomeController : ControllerBase
                 _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeCacheMiss);
 
                 var response = await BuildFullResponseAsync(localityIds, ct);
-                var json = JsonSerializer.Serialize(response);
-                await _redis.StringSetAsync(cacheKey, json, CacheTtl);
+
+                // Only authenticated callers write to cache.  Anonymous
+                // callers can supply arbitrary localityId GUIDs; letting
+                // them populate cache entries would allow unbounded key
+                // creation.  They still benefit from cache hits written
+                // by authenticated users for the same locality.
+                if (isAuthenticated)
+                {
+                    var json = JsonSerializer.Serialize(response);
+                    await _redis.StringSetAsync(cacheKey, json, CacheTtl);
+                }
 
                 sw.Stop();
                 _logger?.LogInformation(

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -279,6 +279,9 @@ public class HomeController : ControllerBase
     private async Task<PagedSection<ClusterResponseDto>> BuildOtherActiveSectionAsync(
         List<Guid> localityIds, DateTime? cursorBefore, CancellationToken ct)
     {
+        if (localityIds.Count == 0)
+            return EmptyClusterSection();
+
         var raw = await _feedQuery.GetAllActivePagedAsync(localityIds, LimitOtherActive + 1, cursorBefore, ct);
         return ToPagedClusterSection(raw, LimitOtherActive);
     }

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -62,24 +62,26 @@ public class HomeController : ControllerBase
 
         try
         {
-            // Only authenticated users may scope the feed to an explicit locality.
-            // Anonymous callers fall back to the followed-localities path, which
-            // returns empty sections for guests.
+            // Both authenticated and anonymous callers may scope the feed to
+            // an explicit locality via ?localityId.  When omitted,
+            // authenticated users fall back to their followed-localities set;
+            // anonymous callers receive empty sections (no followed wards).
             bool isAuthenticated = User.Identity?.IsAuthenticated == true;
-            var localityIds = localityId.HasValue && isAuthenticated
+            var localityIds = localityId.HasValue
                 ? new List<Guid> { localityId.Value }
                 : await GetFollowedLocalityIdsAsync(ct);
             var cursorDt = DecodeCursor(cursor);
 
-            // Log locality scoping mode
-            if (localityId.HasValue && isAuthenticated)
-                _logger?.LogInformation("{EventName} localityId={LocalityId}",
-                    ObservabilityEvents.HomeLocalityScopeExplicit, localityId.Value);
+            // Log locality scoping mode and auth posture
+            if (localityId.HasValue)
+                _logger?.LogInformation("{EventName} localityId={LocalityId} isAuthenticated={IsAuthenticated}",
+                    ObservabilityEvents.HomeLocalityScopeExplicit, localityId.Value, isAuthenticated);
             else if (localityIds.Count > 0)
                 _logger?.LogInformation("{EventName} localityCount={LocalityCount}",
                     ObservabilityEvents.HomeLocalityScopeFallback, localityIds.Count);
             else
-                _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeLocalityScopeGuestEmpty);
+                _logger?.LogInformation("{EventName} isAuthenticated={IsAuthenticated}",
+                    ObservabilityEvents.HomeLocalityScopeGuestEmpty, isAuthenticated);
 
             // Section-specific paginated request — skip cache, return single section
             if (section is not null)

--- a/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
@@ -147,24 +147,17 @@ public class HomeAnonymousBrowseTests
         // Arrange — anonymous user, no localityId
         var controller = CreateController();
 
-        _feedQuery
-            .GetAllActivePagedAsync(
-                Arg.Any<List<Guid>>(),
-                Arg.Any<int>(),
-                Arg.Any<DateTime?>(),
-                Arg.Any<CancellationToken>())
-            .Returns(new List<SignalCluster>().AsReadOnly());
-
         // Act
         var result = await controller.GetHome(
             section: null, cursor: null, localityId: null, ct: CancellationToken.None);
 
-        // Assert — returns OK with empty sections (no followed localities for guest)
+        // Assert — all four sections are empty (no followed localities for guest)
         var ok = Assert.IsType<OkObjectResult>(result);
         var feed = Assert.IsType<HomeResponseDto>(ok.Value);
         Assert.Empty(feed.ActiveNow.Items);
         Assert.Empty(feed.OfficialUpdates.Items);
         Assert.Empty(feed.RecurringAtThisTime.Items);
+        Assert.Empty(feed.OtherActiveSignals.Items);
     }
 
     // ── Anonymous cache behavior ───────────────────────────────────
@@ -203,7 +196,7 @@ public class HomeAnonymousBrowseTests
         await controller.GetHome(
             section: null, cursor: null, localityId: TestLocalityId, ct: CancellationToken.None);
 
-        // Assert — at least one StringSetAsync call was made to Redis.
+        // Assert — exactly one StringSetAsync call was made to Redis.
         // NSubstitute's ReceivedCalls() captures all calls regardless of overload.
         var redisCalls = _redis.ReceivedCalls()
             .Where(c => c.GetMethodInfo().Name == "StringSetAsync")

--- a/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
@@ -1,16 +1,12 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Security.Claims;
-using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Api.Controllers;
 using Hali.Application.Home;
 using Hali.Application.Notifications;
-using Hali.Contracts.Clusters;
 using Hali.Contracts.Home;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Notifications;
@@ -63,6 +59,26 @@ public class HomeAnonymousBrowseTests
             new Claim(ClaimTypes.NameIdentifier, accountId.ToString()),
         };
         return new ClaimsPrincipal(new ClaimsIdentity(claims, "Bearer"));
+    }
+
+    private void SetupEmptyFeed()
+    {
+        _feedQuery
+            .GetActiveByLocalitiesPagedAsync(
+                Arg.Any<List<Guid>>(), Arg.Any<bool>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>().AsReadOnly());
+
+        _feedQuery
+            .GetAllActivePagedAsync(
+                Arg.Any<List<Guid>>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>().AsReadOnly());
+
+        _feedQuery
+            .GetOfficialPostsByLocalityAsync(
+                Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
     }
 
     private static SignalCluster MakeCluster(Guid id, Guid localityId) =>
@@ -149,6 +165,50 @@ public class HomeAnonymousBrowseTests
         Assert.Empty(feed.ActiveNow.Items);
         Assert.Empty(feed.OfficialUpdates.Items);
         Assert.Empty(feed.RecurringAtThisTime.Items);
+    }
+
+    // ── Anonymous cache behavior ───────────────────────────────────
+
+    [Fact]
+    public async Task GetHome_AnonymousWithLocalityId_DoesNotWriteToCache()
+    {
+        // Arrange — anonymous user, cache miss
+        var controller = CreateController();
+
+        SetupEmptyFeed();
+
+        // Act
+        await controller.GetHome(
+            section: null, cursor: null, localityId: TestLocalityId, ct: CancellationToken.None);
+
+        // Assert — no StringSetAsync call was made to Redis.
+        // Uses ReceivedCalls() to avoid NSubstitute overload resolution issues
+        // with StackExchange.Redis 2.12's multiple StringSetAsync overloads.
+        var redisCalls = _redis.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == "StringSetAsync")
+            .ToList();
+        Assert.Empty(redisCalls);
+    }
+
+    [Fact]
+    public async Task GetHome_AuthenticatedWithLocalityId_WritesToCache()
+    {
+        // Arrange — authenticated user, cache miss
+        var accountId = Guid.NewGuid();
+        var controller = CreateController(AuthenticatedUser(accountId));
+
+        SetupEmptyFeed();
+
+        // Act
+        await controller.GetHome(
+            section: null, cursor: null, localityId: TestLocalityId, ct: CancellationToken.None);
+
+        // Assert — at least one StringSetAsync call was made to Redis.
+        // NSubstitute's ReceivedCalls() captures all calls regardless of overload.
+        var redisCalls = _redis.ReceivedCalls()
+            .Where(c => c.GetMethodInfo().Name == "StringSetAsync")
+            .ToList();
+        Assert.Single(redisCalls);
     }
 
     // ── Authenticated still works ────────────────────────────────────

--- a/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Security.Claims;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Home;
+using Hali.Application.Notifications;
+using Hali.Contracts.Clusters;
+using Hali.Contracts.Home;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Entities.Notifications;
+using Hali.Domain.Enums;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Hali.Tests.Unit.Home;
+
+/// <summary>
+/// Tests verifying B8 anonymous browse behavior on the HomeController.
+/// Anonymous users can pass ?localityId to scope the feed.
+/// </summary>
+public class HomeAnonymousBrowseTests
+{
+    private static readonly Guid TestLocalityId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static readonly Guid TestClusterId = Guid.Parse("11111111-2222-3333-4444-555555555555");
+
+    private readonly IHomeFeedQueryService _feedQuery = Substitute.For<IHomeFeedQueryService>();
+    private readonly IFollowService _follows = Substitute.For<IFollowService>();
+    private readonly IDatabase _redis = Substitute.For<IDatabase>();
+
+    private HomeController CreateController(ClaimsPrincipal? user = null)
+    {
+        var controller = new HomeController(
+            _feedQuery,
+            _follows,
+            _redis,
+            NullLogger<HomeController>.Instance);
+
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = user ?? new ClaimsPrincipal(new ClaimsIdentity())
+            }
+        };
+
+        return controller;
+    }
+
+    private static ClaimsPrincipal AuthenticatedUser(Guid accountId)
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, accountId.ToString()),
+        };
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, "Bearer"));
+    }
+
+    private static SignalCluster MakeCluster(Guid id, Guid localityId) =>
+        new()
+        {
+            Id = id,
+            LocalityId = localityId,
+            Category = CivicCategory.Roads,
+            SubcategorySlug = "pothole",
+            State = SignalState.Active,
+            Title = "Test cluster",
+            Summary = "Test",
+            AffectedCount = 2,
+            ObservingCount = 1,
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            UpdatedAt = DateTime.UtcNow,
+            ActivatedAt = DateTime.UtcNow.AddMinutes(-30),
+        };
+
+    // ── Anonymous with localityId ─────────────────────────────────────
+
+    [Fact]
+    public async Task GetHome_AnonymousWithLocalityId_ReturnsFeed()
+    {
+        // Arrange — anonymous user (no auth claims), passing ?localityId
+        var controller = CreateController();
+        var clusters = new List<SignalCluster> { MakeCluster(TestClusterId, TestLocalityId) };
+
+        _feedQuery
+            .GetActiveByLocalitiesPagedAsync(
+                Arg.Is<List<Guid>>(l => l.Contains(TestLocalityId)),
+                Arg.Any<bool>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(clusters.AsReadOnly());
+
+        _feedQuery
+            .GetAllActivePagedAsync(
+                Arg.Any<List<Guid>>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>().AsReadOnly());
+
+        _feedQuery
+            .GetOfficialPostsByLocalityAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
+
+        // Act
+        var result = await controller.GetHome(
+            section: null, cursor: null, localityId: TestLocalityId, ct: CancellationToken.None);
+
+        // Assert — 200 OK with feed data
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.Equal(StatusCodes.Status200OK, ok.StatusCode);
+        var feed = Assert.IsType<HomeResponseDto>(ok.Value);
+        Assert.Single(feed.ActiveNow.Items);
+    }
+
+    [Fact]
+    public async Task GetHome_AnonymousWithoutLocalityId_ReturnsEmptySections()
+    {
+        // Arrange — anonymous user, no localityId
+        var controller = CreateController();
+
+        _feedQuery
+            .GetAllActivePagedAsync(
+                Arg.Any<List<Guid>>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>().AsReadOnly());
+
+        // Act
+        var result = await controller.GetHome(
+            section: null, cursor: null, localityId: null, ct: CancellationToken.None);
+
+        // Assert — returns OK with empty sections (no followed localities for guest)
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var feed = Assert.IsType<HomeResponseDto>(ok.Value);
+        Assert.Empty(feed.ActiveNow.Items);
+        Assert.Empty(feed.OfficialUpdates.Items);
+        Assert.Empty(feed.RecurringAtThisTime.Items);
+    }
+
+    // ── Authenticated still works ────────────────────────────────────
+
+    [Fact]
+    public async Task GetHome_AuthenticatedWithLocalityId_ReturnsFeed()
+    {
+        // Arrange — authenticated user passing ?localityId
+        var accountId = Guid.NewGuid();
+        var controller = CreateController(AuthenticatedUser(accountId));
+        var clusters = new List<SignalCluster> { MakeCluster(TestClusterId, TestLocalityId) };
+
+        _feedQuery
+            .GetActiveByLocalitiesPagedAsync(
+                Arg.Is<List<Guid>>(l => l.Contains(TestLocalityId)),
+                Arg.Any<bool>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(clusters.AsReadOnly());
+
+        _feedQuery
+            .GetAllActivePagedAsync(
+                Arg.Any<List<Guid>>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>().AsReadOnly());
+
+        _feedQuery
+            .GetOfficialPostsByLocalityAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
+
+        // Act
+        var result = await controller.GetHome(
+            section: null, cursor: null, localityId: TestLocalityId, ct: CancellationToken.None);
+
+        // Assert — still returns 200 with feed
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var feed = Assert.IsType<HomeResponseDto>(ok.Value);
+        Assert.Single(feed.ActiveNow.Items);
+    }
+
+    [Fact]
+    public async Task GetHome_AuthenticatedWithoutLocalityId_FallsBackToFollowed()
+    {
+        // Arrange — authenticated user, no localityId, has followed localities
+        var accountId = Guid.NewGuid();
+        var controller = CreateController(AuthenticatedUser(accountId));
+
+        _follows
+            .GetFollowedAsync(accountId, Arg.Any<CancellationToken>())
+            .Returns(new List<Follow>
+            {
+                new() { Id = Guid.NewGuid(), AccountId = accountId, LocalityId = TestLocalityId, CreatedAt = DateTime.UtcNow }
+            });
+
+        var clusters = new List<SignalCluster> { MakeCluster(TestClusterId, TestLocalityId) };
+
+        _feedQuery
+            .GetActiveByLocalitiesPagedAsync(
+                Arg.Is<List<Guid>>(l => l.Contains(TestLocalityId)),
+                Arg.Any<bool>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(clusters.AsReadOnly());
+
+        _feedQuery
+            .GetAllActivePagedAsync(
+                Arg.Any<List<Guid>>(),
+                Arg.Any<int>(),
+                Arg.Any<DateTime?>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>().AsReadOnly());
+
+        _feedQuery
+            .GetOfficialPostsByLocalityAsync(
+                Arg.Any<Guid>(),
+                Arg.Any<CancellationToken>())
+            .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
+
+        // Act
+        var result = await controller.GetHome(
+            section: null, cursor: null, localityId: null, ct: CancellationToken.None);
+
+        // Assert — feeds from followed localities
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var feed = Assert.IsType<HomeResponseDto>(ok.Value);
+        Assert.Single(feed.ActiveNow.Items);
+
+        // Verify follows were queried
+        await _follows.Received(1).GetFollowedAsync(accountId, Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary

- Enable unauthenticated users to browse the home feed and cluster detail screens without signing in
- Contribution actions (signal creation, participation, context, restoration) remain server-enforced via `[Authorize]`
- Backend: allow anonymous `?localityId` scoping on `GET /v1/home`; add `isAuthenticated` to observability logs
- Mobile: route guests to home feed, guest-aware locality selector, FAB auth gate, `AuthPrompt` component on cluster detail

## Key decisions

- **No pseudo-accounts or silent device registration** — anonymous browse is purely stateless on the server, preserving B6 compatibility
- **No new endpoints** — existing `[AllowAnonymous]` and `[Authorize]` attributes already separated public reads from protected writes; only the `?localityId` guard on HomeController needed loosening
- **Dual-layer auth gating** — client-side `AuthPrompt` for UX + server-side `[Authorize]` for security
- **`setActiveLocality()` in LocalityContext** — allows anonymous users to browse by search result without conflating "browsing" with "following"

## Files changed

| File | Change |
|---|---|
| `src/Hali.Api/Controllers/HomeController.cs` | Allow anonymous `?localityId` scoping, observability |
| `apps/citizen-mobile/app/index.tsx` | Route unauthenticated to `/(app)/home` |
| `apps/citizen-mobile/app/(app)/home.tsx` | Guest locality selector, FAB auth gate, NoFollowsState copy |
| `apps/citizen-mobile/app/(app)/clusters/[id].tsx` | AuthPrompt for anonymous users |
| `apps/citizen-mobile/src/context/LocalityContext.tsx` | Add `setActiveLocality()` |
| `apps/citizen-mobile/src/components/shared/AuthPrompt.tsx` | New shared auth prompt component |
| `apps/citizen-mobile/src/components/shared/index.ts` | Export AuthPrompt |
| `tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs` | 4 new unit tests |
| `docs/implementation/B8_ANONYMOUS_BROWSE.md` | Implementation note |

## Test plan

- [x] 4 new unit tests: anonymous with localityId, anonymous without localityId, authenticated with localityId, authenticated fallback to followed
- [x] Full unit test suite: 260 passed, 0 failures
- [x] `npx tsc --noEmit`: zero errors
- [x] `dotnet format --verify-no-changes`: clean
- [x] Pre-commit grep checks (hex colors, forbidden icons, any types): clean
- [ ] Manual: open app unauthenticated → lands on home → search locality → see feed
- [ ] Manual: tap FAB unauthenticated → routes to auth
- [ ] Manual: open cluster detail unauthenticated → see AuthPrompt instead of participation buttons
- [ ] Manual: sign in → full participation flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)