### PR TITLE
feat(b9): expose location label from backend through to mobile UI

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -907,6 +907,13 @@ components:
         subcategorySlug: { type: string, nullable: true }
         title: { type: string, nullable: true }
         summary: { type: string, nullable: true }
+        locationLabel:
+          type: string
+          nullable: true
+          description: >
+            Canonical human-readable location label for the cluster, e.g.
+            "Ngong Road near Adams Arcade, Kilimani". Null when the
+            originating signal did not include a resolved location label.
         affectedCount: { type: integer }
         observingCount: { type: integer }
         createdAt: { type: string, format: date-time }

--- a/apps/citizen-mobile/__tests__/api/clusters.test.ts
+++ b/apps/citizen-mobile/__tests__/api/clusters.test.ts
@@ -49,6 +49,7 @@ function makeCluster(overrides: Partial<ClusterResponse> = {}): ClusterResponse 
     subcategorySlug: 'water_outage',
     title: 'Water outage on Ngong Road',
     summary: 'No water since 6am',
+    locationLabel: null,
     affectedCount: 12,
     observingCount: 3,
     createdAt: '2026-04-06T06:00:00Z',

--- a/apps/citizen-mobile/__tests__/api/homeContract.test.ts
+++ b/apps/citizen-mobile/__tests__/api/homeContract.test.ts
@@ -24,6 +24,7 @@ function wireCluster(): ClusterResponse {
     subcategorySlug: 'water_outage',
     title: 'Water outage on Ngong Road',
     summary: 'No water since 6am',
+    locationLabel: null,
     affectedCount: 12,
     observingCount: 3,
     createdAt: '2026-04-11T06:00:00Z',

--- a/apps/citizen-mobile/app/(app)/clusters/[id].tsx
+++ b/apps/citizen-mobile/app/(app)/clusters/[id].tsx
@@ -262,15 +262,16 @@ export default function ClusterDetailScreen(): React.ReactElement {
         )}
 
         {/* ── Location label ──────────────────────────────────── */}
-        {cluster.locationLabel !== null && cluster.locationLabel !== '' && (
-          <Text
-            style={styles.locationLabel}
-            numberOfLines={2}
-            accessibilityLabel={`Location: ${cluster.locationLabel}`}
-          >
-            {cluster.locationLabel}
-          </Text>
-        )}
+        {typeof cluster.locationLabel === 'string' &&
+          cluster.locationLabel.trim() !== '' && (
+            <Text
+              style={styles.locationLabel}
+              numberOfLines={2}
+              accessibilityLabel={`Location: ${cluster.locationLabel}`}
+            >
+              {cluster.locationLabel}
+            </Text>
+          )}
 
         {/* ── Institution attribution ───────────────────────────── */}
         <Text style={styles.institution}>

--- a/apps/citizen-mobile/app/(app)/clusters/[id].tsx
+++ b/apps/citizen-mobile/app/(app)/clusters/[id].tsx
@@ -261,6 +261,17 @@ export default function ClusterDetailScreen(): React.ReactElement {
           <Text style={styles.summary}>{cluster.summary}</Text>
         )}
 
+        {/* ── Location label ──────────────────────────────────── */}
+        {cluster.locationLabel !== null && cluster.locationLabel !== '' && (
+          <Text
+            style={styles.locationLabel}
+            numberOfLines={2}
+            accessibilityLabel={`Location: ${cluster.locationLabel}`}
+          >
+            {cluster.locationLabel}
+          </Text>
+        )}
+
         {/* ── Institution attribution ───────────────────────────── */}
         <Text style={styles.institution}>
           {institutionName} · {formatRelativeTime(cluster.updatedAt)}
@@ -550,6 +561,11 @@ const styles = StyleSheet.create({
     fontFamily: FontFamily.regular,
     color: Colors.mutedForeground,
     lineHeight: FontSize.body * 1.5,
+  },
+  locationLabel: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.medium,
+    color: Colors.faintForeground,
   },
   institution: {
     fontSize: FontSize.bodySmall,

--- a/apps/citizen-mobile/src/components/feed/ClusterCard.tsx
+++ b/apps/citizen-mobile/src/components/feed/ClusterCard.tsx
@@ -43,6 +43,16 @@ export const ClusterCard = React.memo(
           </Text>
         ) : null}
 
+        {cluster.locationLabel ? (
+          <Text
+            style={styles.locationLabel}
+            numberOfLines={1}
+            accessibilityLabel={`Location: ${cluster.locationLabel}`}
+          >
+            {cluster.locationLabel}
+          </Text>
+        ) : null}
+
         <View style={styles.footer}>
           <Text style={styles.meta}>
             {cluster.affectedCount} affected · {cluster.observingCount} observing
@@ -60,6 +70,7 @@ export const ClusterCard = React.memo(
     prev.cluster.observingCount === next.cluster.observingCount &&
     prev.cluster.title === next.cluster.title &&
     prev.cluster.summary === next.cluster.summary &&
+    prev.cluster.locationLabel === next.cluster.locationLabel &&
     prev.cluster.category === next.cluster.category,
 );
 
@@ -90,6 +101,11 @@ const styles = StyleSheet.create({
     fontFamily: FontFamily.regular,
     color: Colors.mutedForeground,
     lineHeight: FontSize.body * 1.5,
+  },
+  locationLabel: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.medium,
+    color: Colors.faintForeground,
   },
   footer: {
     flexDirection: 'row',

--- a/apps/citizen-mobile/src/components/feed/ClusterCard.tsx
+++ b/apps/citizen-mobile/src/components/feed/ClusterCard.tsx
@@ -43,7 +43,8 @@ export const ClusterCard = React.memo(
           </Text>
         ) : null}
 
-        {cluster.locationLabel ? (
+        {typeof cluster.locationLabel === 'string' &&
+        cluster.locationLabel.trim() !== '' ? (
           <Text
             style={styles.locationLabel}
             numberOfLines={1}

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -157,7 +157,7 @@ export interface ClusterResponse {
   subcategorySlug: string | null;
   title: string | null;
   summary: string | null;
-  locationLabel: string | null;
+  locationLabel?: string | null;
   affectedCount: number;
   observingCount: number;
   createdAt: string;

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -157,6 +157,7 @@ export interface ClusterResponse {
   subcategorySlug: string | null;
   title: string | null;
   summary: string | null;
+  locationLabel: string | null;
   affectedCount: number;
   observingCount: number;
   createdAt: string;

--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -93,6 +93,7 @@ public class ClustersController : ControllerBase
             cluster.PossibleRestorationAt,
             cluster.ResolvedAt)
         {
+            LocationLabel = cluster.LocationLabelText,
             OfficialPosts = officialPosts,
             MyParticipation = myParticipation,
         };

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -357,7 +357,10 @@ public class HomeController : ControllerBase
             c.UpdatedAt,
             c.ActivatedAt,
             c.PossibleRestorationAt,
-            c.ResolvedAt);
+            c.ResolvedAt)
+        {
+            LocationLabel = c.LocationLabelText
+        };
 
     private static PagedSection<ClusterResponseDto> EmptyClusterSection() =>
         new() { Items = [], NextCursor = null, TotalCount = 0 };

--- a/src/Hali.Application/Clusters/ClusteringService.cs
+++ b/src/Hali.Application/Clusters/ClusteringService.cs
@@ -14,167 +14,174 @@ namespace Hali.Application.Clusters;
 
 public class ClusteringService : IClusteringService
 {
-	private readonly IClusterRepository _repo;
+    private readonly IClusterRepository _repo;
 
-	private readonly IH3CellService _h3;
+    private readonly IH3CellService _h3;
 
-	private readonly ICivisEvaluationService _civis;
+    private readonly ICivisEvaluationService _civis;
 
-	private readonly CivisOptions _options;
+    private readonly CivisOptions _options;
 
-	private readonly ILogger<ClusteringService>? _logger;
+    private readonly ILogger<ClusteringService>? _logger;
 
-	public ClusteringService(IClusterRepository repo, IH3CellService h3, ICivisEvaluationService civis, IOptions<CivisOptions> options, ILogger<ClusteringService>? logger = null)
-	{
-		_repo = repo;
-		_h3 = h3;
-		_civis = civis;
-		_options = options.Value;
-		_logger = logger;
-	}
+    public ClusteringService(IClusterRepository repo, IH3CellService h3, ICivisEvaluationService civis, IOptions<CivisOptions> options, ILogger<ClusteringService>? logger = null)
+    {
+        _repo = repo;
+        _h3 = h3;
+        _civis = civis;
+        _options = options.Value;
+        _logger = logger;
+    }
 
-	public async Task<ClusterRoutingResult> RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken))
-	{
-		if (signal.SpatialCellId is null)
-		{
-			throw new InvalidOperationException("CLUSTERING_NO_SPATIAL_CELL");
-		}
-		string[] searchCells = _h3.GetKRingCells(signal.SpatialCellId, 1);
-		IReadOnlyList<SignalCluster> candidates = await _repo.FindCandidateClustersAsync(searchCells, signal.Category, ct);
-		SignalCluster? bestCluster = null;
-		double bestScore = 0.0;
-		foreach (SignalCluster candidate in candidates)
-		{
-			// Skip candidates with a different locality to prevent inconsistency
-			if (signal.LocalityId.HasValue
-				&& candidate.LocalityId.HasValue
-				&& candidate.LocalityId.Value != signal.LocalityId.Value)
-			{
-				continue;
-			}
+    public async Task<ClusterRoutingResult> RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken))
+    {
+        if (signal.SpatialCellId is null)
+        {
+            throw new InvalidOperationException("CLUSTERING_NO_SPATIAL_CELL");
+        }
+        string[] searchCells = _h3.GetKRingCells(signal.SpatialCellId, 1);
+        IReadOnlyList<SignalCluster> candidates = await _repo.FindCandidateClustersAsync(searchCells, signal.Category, ct);
+        SignalCluster? bestCluster = null;
+        double bestScore = 0.0;
+        foreach (SignalCluster candidate in candidates)
+        {
+            // Skip candidates with a different locality to prevent inconsistency
+            if (signal.LocalityId.HasValue
+                && candidate.LocalityId.HasValue
+                && candidate.LocalityId.Value != signal.LocalityId.Value)
+            {
+                continue;
+            }
 
-			double score = ComputeJoinScore(signal, candidate);
-			if (score >= _options.JoinThreshold && score > bestScore)
-			{
-				bestScore = score;
-				bestCluster = candidate;
-			}
-		}
-		if (bestCluster is not null)
-		{
-			await _repo.AttachToClusterAsync(bestCluster.Id, signal.Id, signal.DeviceId, "join", ct);
-			bestCluster.LastSeenAt = DateTime.UtcNow;
-			bestCluster.UpdatedAt = DateTime.UtcNow;
-			bestCluster.RawConfirmationCount++;
-			if (!string.IsNullOrEmpty(signal.ConditionSlug))
-			{
-				bestCluster.DominantConditionSlug = signal.ConditionSlug;
-			}
-			await _repo.UpdateClusterAsync(bestCluster, ct);
-			await _repo.WriteOutboxEventAsync(new OutboxEvent
-			{
-				Id = Guid.NewGuid(),
-				AggregateType = "cluster",
-				AggregateId = bestCluster.Id,
-				EventType = "cluster.updated",
-				Payload = JsonSerializer.Serialize(new
-				{
-					cluster_id = bestCluster.Id,
-					signal_event_id = signal.Id,
-					raw_confirmation_count = bestCluster.RawConfirmationCount
-				}),
-				OccurredAt = DateTime.UtcNow
-			}, ct);
-			await _civis.EvaluateClusterAsync(bestCluster.Id, ct);
+            double score = ComputeJoinScore(signal, candidate);
+            if (score >= _options.JoinThreshold && score > bestScore)
+            {
+                bestScore = score;
+                bestCluster = candidate;
+            }
+        }
+        if (bestCluster is not null)
+        {
+            await _repo.AttachToClusterAsync(bestCluster.Id, signal.Id, signal.DeviceId, "join", ct);
+            bestCluster.LastSeenAt = DateTime.UtcNow;
+            bestCluster.UpdatedAt = DateTime.UtcNow;
+            bestCluster.RawConfirmationCount++;
+            if (!string.IsNullOrEmpty(signal.ConditionSlug))
+            {
+                bestCluster.DominantConditionSlug = signal.ConditionSlug;
+            }
+            // Backfill location label if the cluster was created before B9
+            if (string.IsNullOrEmpty(bestCluster.LocationLabelText)
+                && !string.IsNullOrEmpty(signal.LocationLabelText))
+            {
+                bestCluster.LocationLabelText = signal.LocationLabelText;
+            }
+            await _repo.UpdateClusterAsync(bestCluster, ct);
+            await _repo.WriteOutboxEventAsync(new OutboxEvent
+            {
+                Id = Guid.NewGuid(),
+                AggregateType = "cluster",
+                AggregateId = bestCluster.Id,
+                EventType = "cluster.updated",
+                Payload = JsonSerializer.Serialize(new
+                {
+                    cluster_id = bestCluster.Id,
+                    signal_event_id = signal.Id,
+                    raw_confirmation_count = bestCluster.RawConfirmationCount
+                }),
+                OccurredAt = DateTime.UtcNow
+            }, ct);
+            await _civis.EvaluateClusterAsync(bestCluster.Id, ct);
 
-			_logger?.LogInformation(
-				"{EventName} clusterId={ClusterId} outcome={Outcome} joinScore={JoinScore} candidateCount={CandidateCount}",
-				ObservabilityEvents.SignalRouted, bestCluster.Id, "joined", bestScore, candidates.Count);
+            _logger?.LogInformation(
+                "{EventName} clusterId={ClusterId} outcome={Outcome} joinScore={JoinScore} candidateCount={CandidateCount}",
+                ObservabilityEvents.SignalRouted, bestCluster.Id, "joined", bestScore, candidates.Count);
 
-			return new ClusterRoutingResult(
-				bestCluster.Id,
-				WasCreated: false,
-				WasJoined: true,
-				ToSnakeCase(bestCluster.State),
-				bestCluster.LocalityId);
-		}
-		else
-		{
-			DateTime now = DateTime.UtcNow;
-			SignalCluster newCluster = new SignalCluster
-			{
-				Id = Guid.NewGuid(),
-				LocalityId = signal.LocalityId,
-				Category = signal.Category,
-				SubcategorySlug = signal.SubcategorySlug,
-				DominantConditionSlug = signal.ConditionSlug,
-				State = SignalState.Unconfirmed,
-				SpatialCellId = signal.SpatialCellId,
-				TemporalType = (signal.TemporalType ?? "episodic_unknown"),
-				Title = BuildClusterTitle(signal),
-				Summary = (signal.NeutralSummary ?? string.Empty),
-				CreatedAt = now,
-				UpdatedAt = now,
-				FirstSeenAt = now,
-				LastSeenAt = now,
-				RawConfirmationCount = 1
-			};
-			await _repo.CreateClusterAsync(newCluster, signal.Id, signal.DeviceId, ct);
-			await _repo.WriteOutboxEventAsync(new OutboxEvent
-			{
-				Id = Guid.NewGuid(),
-				AggregateType = "cluster",
-				AggregateId = newCluster.Id,
-				EventType = "cluster.created",
-				Payload = JsonSerializer.Serialize(new
-				{
-					cluster_id = newCluster.Id,
-					signal_event_id = signal.Id,
-					category = signal.Category.ToString().ToLowerInvariant()
-				}),
-				OccurredAt = now
-			}, ct);
-			await _civis.EvaluateClusterAsync(newCluster.Id, ct);
+            return new ClusterRoutingResult(
+                bestCluster.Id,
+                WasCreated: false,
+                WasJoined: true,
+                ToSnakeCase(bestCluster.State),
+                bestCluster.LocalityId);
+        }
+        else
+        {
+            DateTime now = DateTime.UtcNow;
+            SignalCluster newCluster = new SignalCluster
+            {
+                Id = Guid.NewGuid(),
+                LocalityId = signal.LocalityId,
+                Category = signal.Category,
+                SubcategorySlug = signal.SubcategorySlug,
+                DominantConditionSlug = signal.ConditionSlug,
+                State = SignalState.Unconfirmed,
+                SpatialCellId = signal.SpatialCellId,
+                TemporalType = (signal.TemporalType ?? "episodic_unknown"),
+                Title = BuildClusterTitle(signal),
+                Summary = (signal.NeutralSummary ?? string.Empty),
+                LocationLabelText = signal.LocationLabelText,
+                CreatedAt = now,
+                UpdatedAt = now,
+                FirstSeenAt = now,
+                LastSeenAt = now,
+                RawConfirmationCount = 1
+            };
+            await _repo.CreateClusterAsync(newCluster, signal.Id, signal.DeviceId, ct);
+            await _repo.WriteOutboxEventAsync(new OutboxEvent
+            {
+                Id = Guid.NewGuid(),
+                AggregateType = "cluster",
+                AggregateId = newCluster.Id,
+                EventType = "cluster.created",
+                Payload = JsonSerializer.Serialize(new
+                {
+                    cluster_id = newCluster.Id,
+                    signal_event_id = signal.Id,
+                    category = signal.Category.ToString().ToLowerInvariant()
+                }),
+                OccurredAt = now
+            }, ct);
+            await _civis.EvaluateClusterAsync(newCluster.Id, ct);
 
-			_logger?.LogInformation(
-				"{EventName} clusterId={ClusterId} outcome={Outcome} candidateCount={CandidateCount}",
-				ObservabilityEvents.SignalRouted, newCluster.Id, "created", candidates.Count);
+            _logger?.LogInformation(
+                "{EventName} clusterId={ClusterId} outcome={Outcome} candidateCount={CandidateCount}",
+                ObservabilityEvents.SignalRouted, newCluster.Id, "created", candidates.Count);
 
-			return new ClusterRoutingResult(
-				newCluster.Id,
-				WasCreated: true,
-				WasJoined: false,
-				ToSnakeCase(newCluster.State),
-				newCluster.LocalityId);
-		}
-	}
+            return new ClusterRoutingResult(
+                newCluster.Id,
+                WasCreated: true,
+                WasJoined: false,
+                ToSnakeCase(newCluster.State),
+                newCluster.LocalityId);
+        }
+    }
 
-	private double ComputeJoinScore(SignalEvent signal, SignalCluster cluster)
-	{
-		double num = ((signal.SpatialCellId == cluster.SpatialCellId) ? 1.0 : 0.75);
-		double totalHours = (DateTime.UtcNow - cluster.LastSeenAt).TotalHours;
-		double num2 = Math.Max(0.0, 1.0 - totalHours / _options.TimeScoreMaxAgeHours);
-		double num3 = ((!string.IsNullOrEmpty(signal.ConditionSlug) && signal.ConditionSlug == cluster.DominantConditionSlug) ? 1.0 : 0.0);
-		return 0.4 + 0.25 * num + 0.2 * num2 + 0.15 * num3;
-	}
+    private double ComputeJoinScore(SignalEvent signal, SignalCluster cluster)
+    {
+        double num = ((signal.SpatialCellId == cluster.SpatialCellId) ? 1.0 : 0.75);
+        double totalHours = (DateTime.UtcNow - cluster.LastSeenAt).TotalHours;
+        double num2 = Math.Max(0.0, 1.0 - totalHours / _options.TimeScoreMaxAgeHours);
+        double num3 = ((!string.IsNullOrEmpty(signal.ConditionSlug) && signal.ConditionSlug == cluster.DominantConditionSlug) ? 1.0 : 0.0);
+        return 0.4 + 0.25 * num + 0.2 * num2 + 0.15 * num3;
+    }
 
-	private static string ToSnakeCase(SignalState state)
-	{
-		string pascal = state.ToString();
-		var sb = new System.Text.StringBuilder(pascal.Length + 4);
-		for (int i = 0; i < pascal.Length; i++)
-		{
-			char c = pascal[i];
-			if (i > 0 && char.IsUpper(c)) sb.Append('_');
-			sb.Append(char.ToLowerInvariant(c));
-		}
-		return sb.ToString();
-	}
+    private static string ToSnakeCase(SignalState state)
+    {
+        string pascal = state.ToString();
+        var sb = new System.Text.StringBuilder(pascal.Length + 4);
+        for (int i = 0; i < pascal.Length; i++)
+        {
+            char c = pascal[i];
+            if (i > 0 && char.IsUpper(c)) sb.Append('_');
+            sb.Append(char.ToLowerInvariant(c));
+        }
+        return sb.ToString();
+    }
 
-	private static string BuildClusterTitle(SignalEvent signal)
-	{
-		string text = signal.Category.ToString().ToLowerInvariant();
-		string text2 = (string.IsNullOrEmpty(signal.SubcategorySlug) ? "" : (" — " + signal.SubcategorySlug));
-		return text + text2;
-	}
+    private static string BuildClusterTitle(SignalEvent signal)
+    {
+        string text = signal.Category.ToString().ToLowerInvariant();
+        string text2 = (string.IsNullOrEmpty(signal.SubcategorySlug) ? "" : (" — " + signal.SubcategorySlug));
+        return text + text2;
+    }
 }

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -147,7 +147,11 @@ public class SignalIngestionService : ISignalIngestionService
                 SourceChannel = "app",
                 SpatialCellId = spatialCellId,
                 LocalityId = locality.Id,
-                CivisPrecheck = "{}"
+                CivisPrecheck = "{}",
+                // Transient — not persisted to signal_events but carried
+                // in-memory to the clustering service so the cluster can
+                // store a denormalized copy of the display label.
+                LocationLabelText = request.LocationLabel
             };
             SignalEvent saved = await _repo.PersistSignalAsync(signal, ct);
             await _repo.SetIdempotencyKeyAsync(idemKey, TimeSpan.FromHours(24), ct);

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -29,6 +29,8 @@ public class SignalIngestionService : ISignalIngestionService
 
     private const int H3Resolution = 9;
 
+    private const int MaxLocationLabelLength = 400;
+
     private static readonly HashSet<string> AllowedCategories = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "roads", "transport", "electricity", "water", "environment", "safety", "governance", "infrastructure" };
 
     private static readonly HashSet<string> AllowedTemporalTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "temporary", "continuous", "recurring", "scheduled", "episodic_unknown" };
@@ -123,6 +125,13 @@ public class SignalIngestionService : ISignalIngestionService
 
             _logger?.LogInformation("{EventName} localityId={LocalityId}",
                 ObservabilityEvents.SignalLocalityResolved, locality.Id);
+
+            if (request.LocationLabel is not null && request.LocationLabel.Length > MaxLocationLabelLength)
+            {
+                throw new ValidationException(
+                    $"Location label must not exceed {MaxLocationLabelLength} characters.",
+                    code: "validation.location_label_too_long");
+            }
 
             string temporalType = (AllowedTemporalTypes.Contains(request.TemporalType ?? "") ? request.TemporalType : "episodic_unknown");
             SignalEvent signal = new SignalEvent

--- a/src/Hali.Contracts/Clusters/ClusterResponseDto.cs
+++ b/src/Hali.Contracts/Clusters/ClusterResponseDto.cs
@@ -19,6 +19,13 @@ public record ClusterResponseDto(
     DateTime? PossibleRestorationAt,
     DateTime? ResolvedAt)
 {
+    /// <summary>
+    /// Canonical human-readable location label for this cluster, e.g.
+    /// "Ngong Road near Adams Arcade, Kilimani". Null when the originating
+    /// signal did not include a resolved location label.
+    /// </summary>
+    public string? LocationLabel { get; init; }
+
     public List<OfficialPostResponseDto> OfficialPosts { get; init; } = new();
 
     /// <summary>

--- a/src/Hali.Domain/Entities/Clusters/SignalCluster.cs
+++ b/src/Hali.Domain/Entities/Clusters/SignalCluster.cs
@@ -54,4 +54,11 @@ public class SignalCluster
     public int AffectedCount { get; set; }
 
     public int ObservingCount { get; set; }
+
+    /// <summary>
+    /// Denormalized human-readable location label copied from the seed signal
+    /// at cluster creation time. Used as the canonical location display text
+    /// in feed cards and detail screens.
+    /// </summary>
+    public string? LocationLabelText { get; set; }
 }

--- a/src/Hali.Domain/Entities/Signals/SignalEvent.cs
+++ b/src/Hali.Domain/Entities/Signals/SignalEvent.cs
@@ -48,4 +48,11 @@ public class SignalEvent
     public string? SpatialCellId { get; set; }
 
     public string? CivisPrecheck { get; set; }
+
+    /// <summary>
+    /// Transient (not persisted) — carries the human-readable location label
+    /// from the submit request through to the clustering service so the
+    /// cluster can store it as a denormalized display field.
+    /// </summary>
+    public string? LocationLabelText { get; set; }
 }

--- a/src/Hali.Infrastructure/Data/Clusters/ClustersDbContext.cs
+++ b/src/Hali.Infrastructure/Data/Clusters/ClustersDbContext.cs
@@ -8,92 +8,93 @@ namespace Hali.Infrastructure.Data.Clusters;
 
 public class ClustersDbContext : DbContext
 {
-	public DbSet<SignalCluster> SignalClusters => Set<SignalCluster>();
+    public DbSet<SignalCluster> SignalClusters => Set<SignalCluster>();
 
-	public DbSet<ClusterEventLink> ClusterEventLinks => Set<ClusterEventLink>();
+    public DbSet<ClusterEventLink> ClusterEventLinks => Set<ClusterEventLink>();
 
-	public DbSet<CivisDecision> CivisDecisions => Set<CivisDecision>();
+    public DbSet<CivisDecision> CivisDecisions => Set<CivisDecision>();
 
-	public DbSet<OutboxEvent> OutboxEvents => Set<OutboxEvent>();
+    public DbSet<OutboxEvent> OutboxEvents => Set<OutboxEvent>();
 
-	public ClustersDbContext(DbContextOptions<ClustersDbContext> options)
-		: base(options)
-	{
-	}
+    public ClustersDbContext(DbContextOptions<ClustersDbContext> options)
+        : base(options)
+    {
+    }
 
-	protected override void OnModelCreating(ModelBuilder modelBuilder)
-	{
-		modelBuilder.HasPostgresEnum<CivicCategory>("civic_category");
-		modelBuilder.HasPostgresEnum<SignalState>("signal_state");
-		modelBuilder.Entity(delegate(EntityTypeBuilder<SignalCluster> e)
-		{
-			e.ToTable("signal_clusters");
-			e.HasKey((SignalCluster x) => x.Id);
-			e.Property((SignalCluster x) => x.Id).HasColumnName("id");
-			e.Property((SignalCluster x) => x.LocalityId).HasColumnName("locality_id");
-			e.Property((SignalCluster x) => x.Category).HasColumnName("category");
-			e.Property((SignalCluster x) => x.SubcategorySlug).HasColumnName("subcategory_slug").HasMaxLength(80);
-			e.Property((SignalCluster x) => x.DominantConditionSlug).HasColumnName("dominant_condition_slug").HasMaxLength(80);
-			e.Property((SignalCluster x) => x.State).HasColumnName("state");
-			e.Property((SignalCluster x) => x.Title).HasColumnName("title").HasMaxLength(240);
-			e.Property((SignalCluster x) => x.Summary).HasColumnName("summary");
-			e.Property((SignalCluster x) => x.LocationLabelId).HasColumnName("location_label_id");
-			e.Property((SignalCluster x) => x.SpatialCellId).HasColumnName("spatial_cell_id").HasMaxLength(80);
-			e.Ignore((SignalCluster x) => x.CreatedAt);
-			e.Ignore((SignalCluster x) => x.UpdatedAt);
-			e.Property((SignalCluster x) => x.FirstSeenAt).HasColumnName("first_seen_at");
-			e.Property((SignalCluster x) => x.LastSeenAt).HasColumnName("last_seen_at");
-			e.Property((SignalCluster x) => x.ActivatedAt).HasColumnName("activated_at");
-			e.Property((SignalCluster x) => x.ResolvedAt).HasColumnName("resolved_at");
-			e.Property((SignalCluster x) => x.PossibleRestorationAt).HasColumnName("possible_restoration_at");
-			e.Property((SignalCluster x) => x.CivisScore).HasColumnName("civis_score").HasPrecision(8, 4);
-			e.Property((SignalCluster x) => x.Wrab).HasColumnName("wrab").HasPrecision(10, 4);
-			e.Property((SignalCluster x) => x.Sds).HasColumnName("sds").HasPrecision(10, 4);
-			e.Property((SignalCluster x) => x.Macf).HasColumnName("macf");
-			e.Property((SignalCluster x) => x.RawConfirmationCount).HasColumnName("raw_confirmation_count");
-			e.Property((SignalCluster x) => x.TemporalType).HasColumnName("temporal_type").HasMaxLength(40);
-			e.Property((SignalCluster x) => x.AffectedCount).HasColumnName("affected_count");
-			e.Property((SignalCluster x) => x.ObservingCount).HasColumnName("observing_count");
-			e.Property<Point>("Centroid").HasColumnName("centroid").HasColumnType("geometry(Point, 4326)");
-			e.HasIndex((SignalCluster x) => new { x.State, x.LocalityId, x.Category }).HasDatabaseName("ix_signal_clusters_state_locality_category");
-			e.HasIndex((SignalCluster x) => x.LastSeenAt).IsDescending().HasDatabaseName("ix_signal_clusters_last_seen");
-			e.HasIndex((SignalCluster x) => new { x.SpatialCellId, x.Category }).HasDatabaseName("ix_signal_clusters_spatial_cell_category");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<ClusterEventLink> e)
-		{
-			e.ToTable("cluster_event_links");
-			e.HasKey((ClusterEventLink x) => x.Id);
-			e.Property((ClusterEventLink x) => x.Id).HasColumnName("id");
-			e.Property((ClusterEventLink x) => x.ClusterId).HasColumnName("cluster_id");
-			e.Property((ClusterEventLink x) => x.SignalEventId).HasColumnName("signal_event_id");
-			e.Ignore((ClusterEventLink x) => x.DeviceId);
-			e.Property((ClusterEventLink x) => x.LinkReason).HasColumnName("link_reason").HasMaxLength(50);
-			e.Property((ClusterEventLink x) => x.LinkedAt).HasColumnName("linked_at");
-			e.HasIndex((ClusterEventLink x) => new { x.ClusterId, x.SignalEventId }).IsUnique().HasDatabaseName("uq_cluster_event_link");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<CivisDecision> e)
-		{
-			e.ToTable("civis_decisions");
-			e.HasKey((CivisDecision x) => x.Id);
-			e.Property((CivisDecision x) => x.Id).HasColumnName("id");
-			e.Property((CivisDecision x) => x.ClusterId).HasColumnName("cluster_id");
-			e.Property((CivisDecision x) => x.DecisionType).HasColumnName("decision_type").HasMaxLength(50);
-			e.Property((CivisDecision x) => x.ReasonCodes).HasColumnName("reason_codes").HasColumnType("jsonb");
-			e.Property((CivisDecision x) => x.Metrics).HasColumnName("metrics").HasColumnType("jsonb");
-			e.Property((CivisDecision x) => x.CreatedAt).HasColumnName("created_at");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<OutboxEvent> e)
-		{
-			e.ToTable("outbox_events");
-			e.HasKey((OutboxEvent x) => x.Id);
-			e.Property((OutboxEvent x) => x.Id).HasColumnName("id");
-			e.Property((OutboxEvent x) => x.AggregateType).HasColumnName("aggregate_type").HasMaxLength(100);
-			e.Property((OutboxEvent x) => x.AggregateId).HasColumnName("aggregate_id");
-			e.Property((OutboxEvent x) => x.EventType).HasColumnName("event_type").HasMaxLength(100);
-			e.Property((OutboxEvent x) => x.Payload).HasColumnName("payload").HasColumnType("jsonb");
-			e.Property((OutboxEvent x) => x.OccurredAt).HasColumnName("occurred_at");
-			e.Property((OutboxEvent x) => x.PublishedAt).HasColumnName("published_at");
-			e.HasIndex((OutboxEvent x) => x.OccurredAt).HasDatabaseName("ix_outbox_events_unpublished").HasFilter("published_at IS NULL");
-		});
-	}
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasPostgresEnum<CivicCategory>("civic_category");
+        modelBuilder.HasPostgresEnum<SignalState>("signal_state");
+        modelBuilder.Entity(delegate (EntityTypeBuilder<SignalCluster> e)
+        {
+            e.ToTable("signal_clusters");
+            e.HasKey((SignalCluster x) => x.Id);
+            e.Property((SignalCluster x) => x.Id).HasColumnName("id");
+            e.Property((SignalCluster x) => x.LocalityId).HasColumnName("locality_id");
+            e.Property((SignalCluster x) => x.Category).HasColumnName("category");
+            e.Property((SignalCluster x) => x.SubcategorySlug).HasColumnName("subcategory_slug").HasMaxLength(80);
+            e.Property((SignalCluster x) => x.DominantConditionSlug).HasColumnName("dominant_condition_slug").HasMaxLength(80);
+            e.Property((SignalCluster x) => x.State).HasColumnName("state");
+            e.Property((SignalCluster x) => x.Title).HasColumnName("title").HasMaxLength(240);
+            e.Property((SignalCluster x) => x.Summary).HasColumnName("summary");
+            e.Property((SignalCluster x) => x.LocationLabelId).HasColumnName("location_label_id");
+            e.Property((SignalCluster x) => x.LocationLabelText).HasColumnName("location_label_text").HasMaxLength(400);
+            e.Property((SignalCluster x) => x.SpatialCellId).HasColumnName("spatial_cell_id").HasMaxLength(80);
+            e.Ignore((SignalCluster x) => x.CreatedAt);
+            e.Ignore((SignalCluster x) => x.UpdatedAt);
+            e.Property((SignalCluster x) => x.FirstSeenAt).HasColumnName("first_seen_at");
+            e.Property((SignalCluster x) => x.LastSeenAt).HasColumnName("last_seen_at");
+            e.Property((SignalCluster x) => x.ActivatedAt).HasColumnName("activated_at");
+            e.Property((SignalCluster x) => x.ResolvedAt).HasColumnName("resolved_at");
+            e.Property((SignalCluster x) => x.PossibleRestorationAt).HasColumnName("possible_restoration_at");
+            e.Property((SignalCluster x) => x.CivisScore).HasColumnName("civis_score").HasPrecision(8, 4);
+            e.Property((SignalCluster x) => x.Wrab).HasColumnName("wrab").HasPrecision(10, 4);
+            e.Property((SignalCluster x) => x.Sds).HasColumnName("sds").HasPrecision(10, 4);
+            e.Property((SignalCluster x) => x.Macf).HasColumnName("macf");
+            e.Property((SignalCluster x) => x.RawConfirmationCount).HasColumnName("raw_confirmation_count");
+            e.Property((SignalCluster x) => x.TemporalType).HasColumnName("temporal_type").HasMaxLength(40);
+            e.Property((SignalCluster x) => x.AffectedCount).HasColumnName("affected_count");
+            e.Property((SignalCluster x) => x.ObservingCount).HasColumnName("observing_count");
+            e.Property<Point>("Centroid").HasColumnName("centroid").HasColumnType("geometry(Point, 4326)");
+            e.HasIndex((SignalCluster x) => new { x.State, x.LocalityId, x.Category }).HasDatabaseName("ix_signal_clusters_state_locality_category");
+            e.HasIndex((SignalCluster x) => x.LastSeenAt).IsDescending().HasDatabaseName("ix_signal_clusters_last_seen");
+            e.HasIndex((SignalCluster x) => new { x.SpatialCellId, x.Category }).HasDatabaseName("ix_signal_clusters_spatial_cell_category");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<ClusterEventLink> e)
+        {
+            e.ToTable("cluster_event_links");
+            e.HasKey((ClusterEventLink x) => x.Id);
+            e.Property((ClusterEventLink x) => x.Id).HasColumnName("id");
+            e.Property((ClusterEventLink x) => x.ClusterId).HasColumnName("cluster_id");
+            e.Property((ClusterEventLink x) => x.SignalEventId).HasColumnName("signal_event_id");
+            e.Ignore((ClusterEventLink x) => x.DeviceId);
+            e.Property((ClusterEventLink x) => x.LinkReason).HasColumnName("link_reason").HasMaxLength(50);
+            e.Property((ClusterEventLink x) => x.LinkedAt).HasColumnName("linked_at");
+            e.HasIndex((ClusterEventLink x) => new { x.ClusterId, x.SignalEventId }).IsUnique().HasDatabaseName("uq_cluster_event_link");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<CivisDecision> e)
+        {
+            e.ToTable("civis_decisions");
+            e.HasKey((CivisDecision x) => x.Id);
+            e.Property((CivisDecision x) => x.Id).HasColumnName("id");
+            e.Property((CivisDecision x) => x.ClusterId).HasColumnName("cluster_id");
+            e.Property((CivisDecision x) => x.DecisionType).HasColumnName("decision_type").HasMaxLength(50);
+            e.Property((CivisDecision x) => x.ReasonCodes).HasColumnName("reason_codes").HasColumnType("jsonb");
+            e.Property((CivisDecision x) => x.Metrics).HasColumnName("metrics").HasColumnType("jsonb");
+            e.Property((CivisDecision x) => x.CreatedAt).HasColumnName("created_at");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<OutboxEvent> e)
+        {
+            e.ToTable("outbox_events");
+            e.HasKey((OutboxEvent x) => x.Id);
+            e.Property((OutboxEvent x) => x.Id).HasColumnName("id");
+            e.Property((OutboxEvent x) => x.AggregateType).HasColumnName("aggregate_type").HasMaxLength(100);
+            e.Property((OutboxEvent x) => x.AggregateId).HasColumnName("aggregate_id");
+            e.Property((OutboxEvent x) => x.EventType).HasColumnName("event_type").HasMaxLength(100);
+            e.Property((OutboxEvent x) => x.Payload).HasColumnName("payload").HasColumnType("jsonb");
+            e.Property((OutboxEvent x) => x.OccurredAt).HasColumnName("occurred_at");
+            e.Property((OutboxEvent x) => x.PublishedAt).HasColumnName("published_at");
+            e.HasIndex((OutboxEvent x) => x.OccurredAt).HasDatabaseName("ix_outbox_events_unpublished").HasFilter("published_at IS NULL");
+        });
+    }
 }

--- a/src/Hali.Infrastructure/Data/Clusters/Migrations/20260413202812_B9_AddLocationLabelTextToCluster.Designer.cs
+++ b/src/Hali.Infrastructure/Data/Clusters/Migrations/20260413202812_B9_AddLocationLabelTextToCluster.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Hali.Infrastructure.Data.Clusters;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NetTopologySuite.Geometries;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hali.Infrastructure.Data.Clusters.Migrations
 {
     [DbContext(typeof(ClustersDbContext))]
-    partial class ClustersDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260413202812_B9_AddLocationLabelTextToCluster")]
+    partial class B9_AddLocationLabelTextToCluster
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Hali.Infrastructure/Data/Clusters/Migrations/20260413202812_B9_AddLocationLabelTextToCluster.cs
+++ b/src/Hali.Infrastructure/Data/Clusters/Migrations/20260413202812_B9_AddLocationLabelTextToCluster.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hali.Infrastructure.Data.Clusters.Migrations
+{
+    /// <inheritdoc />
+    public partial class B9_AddLocationLabelTextToCluster : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "location_label_text",
+                table: "signal_clusters",
+                type: "character varying(400)",
+                maxLength: 400,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "location_label_text",
+                table: "signal_clusters");
+        }
+    }
+}

--- a/src/Hali.Infrastructure/Data/Signals/SignalsDbContext.cs
+++ b/src/Hali.Infrastructure/Data/Signals/SignalsDbContext.cs
@@ -9,122 +9,123 @@ namespace Hali.Infrastructure.Data.Signals;
 
 public class SignalsDbContext : DbContext
 {
-	public DbSet<Locality> Localities => Set<Locality>();
+    public DbSet<Locality> Localities => Set<Locality>();
 
-	public DbSet<LocationLabel> LocationLabels => Set<LocationLabel>();
+    public DbSet<LocationLabel> LocationLabels => Set<LocationLabel>();
 
-	public DbSet<TaxonomyCategory> TaxonomyCategories => Set<TaxonomyCategory>();
+    public DbSet<TaxonomyCategory> TaxonomyCategories => Set<TaxonomyCategory>();
 
-	public DbSet<TaxonomyCondition> TaxonomyConditions => Set<TaxonomyCondition>();
+    public DbSet<TaxonomyCondition> TaxonomyConditions => Set<TaxonomyCondition>();
 
-	public DbSet<SignalEvent> SignalEvents => Set<SignalEvent>();
+    public DbSet<SignalEvent> SignalEvents => Set<SignalEvent>();
 
-	public DbSet<OutboxEvent> OutboxEvents => Set<OutboxEvent>();
+    public DbSet<OutboxEvent> OutboxEvents => Set<OutboxEvent>();
 
-	public SignalsDbContext(DbContextOptions<SignalsDbContext> options)
-		: base(options)
-	{
-	}
+    public SignalsDbContext(DbContextOptions<SignalsDbContext> options)
+        : base(options)
+    {
+    }
 
-	protected override void OnModelCreating(ModelBuilder modelBuilder)
-	{
-		modelBuilder.HasPostgresEnum<CivicCategory>("civic_category");
-		modelBuilder.HasPostgresEnum<LocationPrecisionType>("location_precision_type");
-		modelBuilder.Entity(delegate(EntityTypeBuilder<Locality> e)
-		{
-			e.ToTable("localities");
-			e.HasKey((Locality x) => x.Id);
-			e.Property((Locality x) => x.Id).HasColumnName("id");
-			e.Property((Locality x) => x.CountryCode).HasColumnName("country_code").HasMaxLength(3);
-			e.Property((Locality x) => x.CountyName).HasColumnName("county_name").HasMaxLength(100);
-			e.Property((Locality x) => x.CityName).HasColumnName("city_name").HasMaxLength(100);
-			e.Property((Locality x) => x.WardName).HasColumnName("ward_name").HasMaxLength(100);
-			e.Property((Locality x) => x.WardCode).HasColumnName("ward_code").HasMaxLength(50);
-			e.Property((Locality x) => x.CreatedAt).HasColumnName("created_at");
-			e.Property<MultiPolygon>("Geom").HasColumnName("geom").HasColumnType("geometry(MultiPolygon, 4326)");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<LocationLabel> e)
-		{
-			e.ToTable("location_labels");
-			e.HasKey((LocationLabel x) => x.Id);
-			e.Property((LocationLabel x) => x.Id).HasColumnName("id");
-			e.Property((LocationLabel x) => x.LocalityId).HasColumnName("locality_id");
-			e.Property((LocationLabel x) => x.AreaName).HasColumnName("area_name").HasMaxLength(200);
-			e.Property((LocationLabel x) => x.RoadName).HasColumnName("road_name").HasMaxLength(200);
-			e.Property((LocationLabel x) => x.JunctionDescription).HasColumnName("junction_description").HasMaxLength(300);
-			e.Property((LocationLabel x) => x.LandmarkName).HasColumnName("landmark_name").HasMaxLength(200);
-			e.Property((LocationLabel x) => x.FacilityName).HasColumnName("facility_name").HasMaxLength(200);
-			e.Property((LocationLabel x) => x.LocationLabelText).HasColumnName("location_label").HasMaxLength(400);
-			e.Property((LocationLabel x) => x.PrecisionType).HasColumnName("precision_type");
-			e.Property((LocationLabel x) => x.Latitude).HasColumnName("latitude");
-			e.Property((LocationLabel x) => x.Longitude).HasColumnName("longitude");
-			e.Property((LocationLabel x) => x.CreatedAt).HasColumnName("created_at");
-			e.Property<Point>("Geom").HasColumnName("geom").HasColumnType("geometry(Point, 4326)");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<TaxonomyCategory> e)
-		{
-			e.ToTable("taxonomy_categories");
-			e.HasKey((TaxonomyCategory x) => x.Id);
-			e.Property((TaxonomyCategory x) => x.Id).HasColumnName("id");
-			e.Property((TaxonomyCategory x) => x.Category).HasColumnName("category");
-			e.Property((TaxonomyCategory x) => x.SubcategorySlug).HasColumnName("subcategory_slug").HasMaxLength(60);
-			e.Property((TaxonomyCategory x) => x.DisplayName).HasColumnName("display_name").HasMaxLength(120);
-			e.Property((TaxonomyCategory x) => x.Description).HasColumnName("description");
-			e.Property((TaxonomyCategory x) => x.IsActive).HasColumnName("is_active");
-			e.HasIndex((TaxonomyCategory x) => new { x.Category, x.SubcategorySlug }).IsUnique().HasDatabaseName("uq_taxonomy_category_slug");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<TaxonomyCondition> e)
-		{
-			e.ToTable("taxonomy_conditions");
-			e.HasKey((TaxonomyCondition x) => x.Id);
-			e.Property((TaxonomyCondition x) => x.Id).HasColumnName("id");
-			e.Property((TaxonomyCondition x) => x.Category).HasColumnName("category");
-			e.Property((TaxonomyCondition x) => x.ConditionSlug).HasColumnName("condition_slug").HasMaxLength(60);
-			e.Property((TaxonomyCondition x) => x.DisplayName).HasColumnName("display_name").HasMaxLength(120);
-			e.Property((TaxonomyCondition x) => x.Ordinal).HasColumnName("ordinal");
-			e.Property((TaxonomyCondition x) => x.IsPositive).HasColumnName("is_positive");
-			e.HasIndex((TaxonomyCondition x) => new { x.Category, x.ConditionSlug }).IsUnique().HasDatabaseName("uq_taxonomy_condition_slug");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<SignalEvent> e)
-		{
-			e.ToTable("signal_events");
-			e.HasKey((SignalEvent x) => x.Id);
-			e.Property((SignalEvent x) => x.Id).HasColumnName("id");
-			e.Property((SignalEvent x) => x.AccountId).HasColumnName("account_id");
-			e.Property((SignalEvent x) => x.DeviceId).HasColumnName("device_id");
-			e.Property((SignalEvent x) => x.LocalityId).HasColumnName("locality_id");
-			e.Property((SignalEvent x) => x.LocationLabelId).HasColumnName("location_label_id");
-			e.Property((SignalEvent x) => x.Category).HasColumnName("category");
-			e.Property((SignalEvent x) => x.SubcategorySlug).HasColumnName("subcategory_slug").HasMaxLength(60);
-			e.Property((SignalEvent x) => x.ConditionSlug).HasColumnName("condition_slug").HasMaxLength(60);
-			e.Property((SignalEvent x) => x.FreeText).HasColumnName("free_text");
-			e.Property((SignalEvent x) => x.NeutralSummary).HasColumnName("neutral_summary");
-			e.Property((SignalEvent x) => x.TemporalType).HasColumnName("temporal_type").HasMaxLength(30);
-			e.Property((SignalEvent x) => x.Latitude).HasColumnName("latitude");
-			e.Property((SignalEvent x) => x.Longitude).HasColumnName("longitude");
-			e.Property((SignalEvent x) => x.LocationConfidence).HasColumnName("location_confidence").HasPrecision(4, 3);
-			e.Property((SignalEvent x) => x.LocationSource).HasColumnName("location_source").HasMaxLength(20);
-			e.Property((SignalEvent x) => x.ConditionConfidence).HasColumnName("condition_confidence").HasPrecision(4, 3);
-			e.Property((SignalEvent x) => x.OccurredAt).HasColumnName("occurred_at");
-			e.Property((SignalEvent x) => x.CreatedAt).HasColumnName("created_at");
-			e.Property((SignalEvent x) => x.SourceLanguage).HasColumnName("source_language").HasMaxLength(10);
-			e.Property((SignalEvent x) => x.SourceChannel).HasColumnName("source_channel").HasMaxLength(20);
-			e.Property((SignalEvent x) => x.SpatialCellId).HasColumnName("spatial_cell_id").HasMaxLength(20);
-			e.Property((SignalEvent x) => x.CivisPrecheck).HasColumnName("civis_precheck").HasColumnType("jsonb");
-			e.HasIndex((SignalEvent x) => new { x.LocalityId, x.Category, x.OccurredAt }).HasDatabaseName("ix_signal_events_locality_category_time");
-			e.HasIndex((SignalEvent x) => new { x.SpatialCellId, x.OccurredAt }).HasDatabaseName("ix_signal_events_spatial_cell_time");
-		});
-		modelBuilder.Entity(delegate(EntityTypeBuilder<OutboxEvent> e)
-		{
-			e.ToTable("outbox_events");
-			e.HasKey((OutboxEvent x) => x.Id);
-			e.Property((OutboxEvent x) => x.Id).HasColumnName("id");
-			e.Property((OutboxEvent x) => x.AggregateType).HasColumnName("aggregate_type").HasMaxLength(100);
-			e.Property((OutboxEvent x) => x.AggregateId).HasColumnName("aggregate_id");
-			e.Property((OutboxEvent x) => x.EventType).HasColumnName("event_type").HasMaxLength(100);
-			e.Property((OutboxEvent x) => x.Payload).HasColumnName("payload").HasColumnType("jsonb");
-			e.Property((OutboxEvent x) => x.OccurredAt).HasColumnName("occurred_at");
-			e.Property((OutboxEvent x) => x.PublishedAt).HasColumnName("published_at");
-		});
-	}
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        modelBuilder.HasPostgresEnum<CivicCategory>("civic_category");
+        modelBuilder.HasPostgresEnum<LocationPrecisionType>("location_precision_type");
+        modelBuilder.Entity(delegate (EntityTypeBuilder<Locality> e)
+        {
+            e.ToTable("localities");
+            e.HasKey((Locality x) => x.Id);
+            e.Property((Locality x) => x.Id).HasColumnName("id");
+            e.Property((Locality x) => x.CountryCode).HasColumnName("country_code").HasMaxLength(3);
+            e.Property((Locality x) => x.CountyName).HasColumnName("county_name").HasMaxLength(100);
+            e.Property((Locality x) => x.CityName).HasColumnName("city_name").HasMaxLength(100);
+            e.Property((Locality x) => x.WardName).HasColumnName("ward_name").HasMaxLength(100);
+            e.Property((Locality x) => x.WardCode).HasColumnName("ward_code").HasMaxLength(50);
+            e.Property((Locality x) => x.CreatedAt).HasColumnName("created_at");
+            e.Property<MultiPolygon>("Geom").HasColumnName("geom").HasColumnType("geometry(MultiPolygon, 4326)");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<LocationLabel> e)
+        {
+            e.ToTable("location_labels");
+            e.HasKey((LocationLabel x) => x.Id);
+            e.Property((LocationLabel x) => x.Id).HasColumnName("id");
+            e.Property((LocationLabel x) => x.LocalityId).HasColumnName("locality_id");
+            e.Property((LocationLabel x) => x.AreaName).HasColumnName("area_name").HasMaxLength(200);
+            e.Property((LocationLabel x) => x.RoadName).HasColumnName("road_name").HasMaxLength(200);
+            e.Property((LocationLabel x) => x.JunctionDescription).HasColumnName("junction_description").HasMaxLength(300);
+            e.Property((LocationLabel x) => x.LandmarkName).HasColumnName("landmark_name").HasMaxLength(200);
+            e.Property((LocationLabel x) => x.FacilityName).HasColumnName("facility_name").HasMaxLength(200);
+            e.Property((LocationLabel x) => x.LocationLabelText).HasColumnName("location_label").HasMaxLength(400);
+            e.Property((LocationLabel x) => x.PrecisionType).HasColumnName("precision_type");
+            e.Property((LocationLabel x) => x.Latitude).HasColumnName("latitude");
+            e.Property((LocationLabel x) => x.Longitude).HasColumnName("longitude");
+            e.Property((LocationLabel x) => x.CreatedAt).HasColumnName("created_at");
+            e.Property<Point>("Geom").HasColumnName("geom").HasColumnType("geometry(Point, 4326)");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<TaxonomyCategory> e)
+        {
+            e.ToTable("taxonomy_categories");
+            e.HasKey((TaxonomyCategory x) => x.Id);
+            e.Property((TaxonomyCategory x) => x.Id).HasColumnName("id");
+            e.Property((TaxonomyCategory x) => x.Category).HasColumnName("category");
+            e.Property((TaxonomyCategory x) => x.SubcategorySlug).HasColumnName("subcategory_slug").HasMaxLength(60);
+            e.Property((TaxonomyCategory x) => x.DisplayName).HasColumnName("display_name").HasMaxLength(120);
+            e.Property((TaxonomyCategory x) => x.Description).HasColumnName("description");
+            e.Property((TaxonomyCategory x) => x.IsActive).HasColumnName("is_active");
+            e.HasIndex((TaxonomyCategory x) => new { x.Category, x.SubcategorySlug }).IsUnique().HasDatabaseName("uq_taxonomy_category_slug");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<TaxonomyCondition> e)
+        {
+            e.ToTable("taxonomy_conditions");
+            e.HasKey((TaxonomyCondition x) => x.Id);
+            e.Property((TaxonomyCondition x) => x.Id).HasColumnName("id");
+            e.Property((TaxonomyCondition x) => x.Category).HasColumnName("category");
+            e.Property((TaxonomyCondition x) => x.ConditionSlug).HasColumnName("condition_slug").HasMaxLength(60);
+            e.Property((TaxonomyCondition x) => x.DisplayName).HasColumnName("display_name").HasMaxLength(120);
+            e.Property((TaxonomyCondition x) => x.Ordinal).HasColumnName("ordinal");
+            e.Property((TaxonomyCondition x) => x.IsPositive).HasColumnName("is_positive");
+            e.HasIndex((TaxonomyCondition x) => new { x.Category, x.ConditionSlug }).IsUnique().HasDatabaseName("uq_taxonomy_condition_slug");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<SignalEvent> e)
+        {
+            e.ToTable("signal_events");
+            e.HasKey((SignalEvent x) => x.Id);
+            e.Property((SignalEvent x) => x.Id).HasColumnName("id");
+            e.Property((SignalEvent x) => x.AccountId).HasColumnName("account_id");
+            e.Property((SignalEvent x) => x.DeviceId).HasColumnName("device_id");
+            e.Property((SignalEvent x) => x.LocalityId).HasColumnName("locality_id");
+            e.Property((SignalEvent x) => x.LocationLabelId).HasColumnName("location_label_id");
+            e.Property((SignalEvent x) => x.Category).HasColumnName("category");
+            e.Property((SignalEvent x) => x.SubcategorySlug).HasColumnName("subcategory_slug").HasMaxLength(60);
+            e.Property((SignalEvent x) => x.ConditionSlug).HasColumnName("condition_slug").HasMaxLength(60);
+            e.Property((SignalEvent x) => x.FreeText).HasColumnName("free_text");
+            e.Property((SignalEvent x) => x.NeutralSummary).HasColumnName("neutral_summary");
+            e.Property((SignalEvent x) => x.TemporalType).HasColumnName("temporal_type").HasMaxLength(30);
+            e.Property((SignalEvent x) => x.Latitude).HasColumnName("latitude");
+            e.Property((SignalEvent x) => x.Longitude).HasColumnName("longitude");
+            e.Property((SignalEvent x) => x.LocationConfidence).HasColumnName("location_confidence").HasPrecision(4, 3);
+            e.Property((SignalEvent x) => x.LocationSource).HasColumnName("location_source").HasMaxLength(20);
+            e.Property((SignalEvent x) => x.ConditionConfidence).HasColumnName("condition_confidence").HasPrecision(4, 3);
+            e.Property((SignalEvent x) => x.OccurredAt).HasColumnName("occurred_at");
+            e.Property((SignalEvent x) => x.CreatedAt).HasColumnName("created_at");
+            e.Property((SignalEvent x) => x.SourceLanguage).HasColumnName("source_language").HasMaxLength(10);
+            e.Property((SignalEvent x) => x.SourceChannel).HasColumnName("source_channel").HasMaxLength(20);
+            e.Property((SignalEvent x) => x.SpatialCellId).HasColumnName("spatial_cell_id").HasMaxLength(20);
+            e.Property((SignalEvent x) => x.CivisPrecheck).HasColumnName("civis_precheck").HasColumnType("jsonb");
+            e.Ignore((SignalEvent x) => x.LocationLabelText);
+            e.HasIndex((SignalEvent x) => new { x.LocalityId, x.Category, x.OccurredAt }).HasDatabaseName("ix_signal_events_locality_category_time");
+            e.HasIndex((SignalEvent x) => new { x.SpatialCellId, x.OccurredAt }).HasDatabaseName("ix_signal_events_spatial_cell_time");
+        });
+        modelBuilder.Entity(delegate (EntityTypeBuilder<OutboxEvent> e)
+        {
+            e.ToTable("outbox_events");
+            e.HasKey((OutboxEvent x) => x.Id);
+            e.Property((OutboxEvent x) => x.Id).HasColumnName("id");
+            e.Property((OutboxEvent x) => x.AggregateType).HasColumnName("aggregate_type").HasMaxLength(100);
+            e.Property((OutboxEvent x) => x.AggregateId).HasColumnName("aggregate_id");
+            e.Property((OutboxEvent x) => x.EventType).HasColumnName("event_type").HasMaxLength(100);
+            e.Property((OutboxEvent x) => x.Payload).HasColumnName("payload").HasColumnType("jsonb");
+            e.Property((OutboxEvent x) => x.OccurredAt).HasColumnName("occurred_at");
+            e.Property((OutboxEvent x) => x.PublishedAt).HasColumnName("published_at");
+        });
+    }
 }

--- a/tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.cs
+++ b/tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.cs
@@ -369,7 +369,8 @@ CREATE TABLE IF NOT EXISTS signal_clusters (
     raw_confirmation_count integer NOT NULL DEFAULT 0,
     temporal_type varchar(40),
     affected_count integer NOT NULL DEFAULT 0,
-    observing_count integer NOT NULL DEFAULT 0
+    observing_count integer NOT NULL DEFAULT 0,
+    location_label_text varchar(400)
 )");
         await ExecAsync(conn, @"
 CREATE TABLE IF NOT EXISTS cluster_event_links (
@@ -389,6 +390,8 @@ CREATE TABLE IF NOT EXISTS civis_decisions (
     metrics jsonb,
     created_at timestamptz NOT NULL DEFAULT now()
 )");
+        // B9: location label text (idempotent — adds only if missing from pre-B9 test DBs)
+        await ExecAsync(conn, "ALTER TABLE signal_clusters ADD COLUMN IF NOT EXISTS location_label_text varchar(400)");
         await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_signal_clusters_state_locality_category ON signal_clusters(state, locality_id, category)");
         await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_signal_clusters_last_seen ON signal_clusters(last_seen_at DESC)");
         await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_signal_clusters_spatial_cell_category ON signal_clusters(spatial_cell_id, category)");

--- a/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
@@ -408,4 +408,67 @@ public class ClusteringServiceTests
 
         Assert.Equal("possible_restoration", result.ClusterState);
     }
+
+    // -----------------------------------------------------------------------
+    // B9: Location label propagation
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task RouteSignal_WhenNewCluster_CopiesLocationLabelFromSignal()
+    {
+        var (svc, repo, h3, civis) = Build();
+        var signal = MakeSignal();
+        signal.LocationLabelText = "Ngong Road near Adams Arcade, Kilimani";
+
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>());
+        SignalCluster? created = null;
+        repo.CreateClusterAsync(Arg.Do<SignalCluster>(c => created = c), signal.Id, signal.DeviceId, Arg.Any<CancellationToken>())
+            .Returns(callInfo => Task.FromResult(callInfo.Arg<SignalCluster>()));
+
+        await svc.RouteSignalAsync(signal);
+
+        Assert.NotNull(created);
+        Assert.Equal("Ngong Road near Adams Arcade, Kilimani", created!.LocationLabelText);
+    }
+
+    [Fact]
+    public async Task RouteSignal_WhenJoinClusterWithoutLabel_BackfillsLocationLabel()
+    {
+        var (svc, repo, h3, civis) = Build();
+        var signal = MakeSignal();
+        signal.LocationLabelText = "Waiyaki Way, Westlands";
+
+        var existingCluster = MakeCluster(lastSeenAgoHours: 0.1);
+        existingCluster.LocationLabelText = null; // pre-B9 cluster without label
+
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster> { existingCluster });
+
+        await svc.RouteSignalAsync(signal);
+
+        Assert.Equal("Waiyaki Way, Westlands", existingCluster.LocationLabelText);
+    }
+
+    [Fact]
+    public async Task RouteSignal_WhenJoinClusterWithExistingLabel_DoesNotOverwrite()
+    {
+        var (svc, repo, h3, civis) = Build();
+        var signal = MakeSignal();
+        signal.LocationLabelText = "Some other road";
+
+        var existingCluster = MakeCluster(lastSeenAgoHours: 0.1);
+        existingCluster.LocationLabelText = "Original label";
+
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster> { existingCluster });
+
+        await svc.RouteSignalAsync(signal);
+
+        // Must preserve the original label, not overwrite
+        Assert.Equal("Original label", existingCluster.LocationLabelText);
+    }
 }

--- a/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
@@ -389,4 +389,51 @@ public class SignalIngestionServiceTests
 		Assert.NotEqual(Guid.Empty, result.ClusterId);
 		Assert.NotEqual(default, result.CreatedAt);
 	}
+
+	// --- B9: Location label length validation ---
+
+	[Fact]
+	public async Task SubmitAsync_LocationLabelExceedsMaxLength_ThrowsValidation()
+	{
+		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+		SetupDefaultH3();
+		SetupDefaultLocality();
+		string oversized = new string('x', 401);
+		SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = oversized };
+		SignalIngestionService svc = CreateService();
+
+		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+		Assert.Equal("validation.location_label_too_long", ex.Code);
+		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+	}
+
+	[Fact]
+	public async Task SubmitAsync_LocationLabelAtMaxLength_Succeeds()
+	{
+		SetupDefaultRepo();
+		SetupDefaultH3();
+		SetupDefaultLocality();
+		string atLimit = new string('x', 400);
+		SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = atLimit };
+		SignalIngestionService svc = CreateService();
+
+		var result = await svc.SubmitAsync(request, null, null);
+
+		Assert.NotEqual(Guid.Empty, result.SignalEventId);
+	}
+
+	[Fact]
+	public async Task SubmitAsync_NullLocationLabel_Succeeds()
+	{
+		SetupDefaultRepo();
+		SetupDefaultH3();
+		SetupDefaultLocality();
+		SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = null };
+		SignalIngestionService svc = CreateService();
+
+		var result = await svc.SubmitAsync(request, null, null);
+
+		Assert.NotEqual(Guid.Empty, result.SignalEventId);
+	}
 }


### PR DESCRIPTION
## Summary

- Wire canonical human-readable location labels end-to-end: signal submission → clustering → API responses → mobile UI rendering
- Add `locationLabel` field to `ClusterResponseDto` (init property — no breaking constructor change)
- Denormalize `location_label_text` on `signal_clusters` table (EF migration + integration test schema bootstrap)
- Render location labels in home feed cards and cluster detail screens
- Backfill label on join when existing clusters lack one (pre-B9 cluster compatibility)

## What changed

### Backend
| File | Change |
|------|--------|
| `SignalCluster.cs` | Add `LocationLabelText` persisted property |
| `SignalEvent.cs` | Add `LocationLabelText` transient property (not persisted) |
| `ClusterResponseDto.cs` | Add `LocationLabel` init property |
| `SignalIngestionService.cs` | Set `LocationLabelText` from submit request; validate max length (400 chars) |
| `ClusteringService.cs` | Copy label on create; backfill on join |
| `HomeController.cs` | Map `LocationLabelText` in ToDto |
| `ClustersController.cs` | Map `LocationLabelText` in GetCluster |
| `ClustersDbContext.cs` | Map `location_label_text` column |
| `SignalsDbContext.cs` | Ignore transient `LocationLabelText` |
| `02_openapi.yaml` | Add `locationLabel` to ClusterResponse schema |
| Migration | Add `location_label_text varchar(400)` to `signal_clusters` |

### Mobile
| File | Change |
|------|--------|
| `api.ts` | Add `locationLabel` (optional) to `ClusterResponse` |
| `ClusterCard.tsx` | Render location label below summary with typeof+trim guard |
| `[id].tsx` | Render location label in detail header with typeof+trim guard |
| Test fixtures | Add `locationLabel: null` to contract test fixtures |

### Integration test infrastructure
| File | Change |
|------|--------|
| `HaliWebApplicationFactory.cs` | Add `location_label_text` to raw SQL schema bootstrap (CREATE TABLE + ALTER TABLE ADD COLUMN IF NOT EXISTS) |

### Tests
- 3 new unit tests for location label propagation in `ClusteringServiceTests`
- 3 new unit tests for location label length validation in `SignalIngestionServiceTests`
- All 268 unit tests pass
- All 15 integration tests pass
- All 184 mobile tests pass

## Contract changes

`ClusterResponse` now includes:
```yaml
locationLabel:
  type: string
  nullable: true
```

Added as a nullable, non-required field — fully backward compatible.

## Test plan

- [x] `dotnet build` — 0 errors
- [x] `dotnet format --verify-no-changes` — clean on changed files
- [x] `dotnet test` (unit) — 268 passed, 0 failed
- [x] `dotnet test` (integration) — 15 passed, 0 failed
- [x] `npx tsc --noEmit` — 0 errors
- [x] `npx jest` — 184 passed, 0 failed
- [x] Pre-commit grep checks (hex colors, icons, Animated, any) — all clean
- [x] Anonymous browse unaffected (AllowAnonymous preserved, no auth changes)
- [x] Home/detail response alignment preserved (A4/A5 not regressed)
- [x] All CI checks green (9/9 jobs pass)

## Copilot review resolution

All three Copilot review comments resolved in code and threads:
1. **Length validation** — Added `MaxLocationLabelLength = 400` constant + rejection with `validation.location_label_too_long`
2. **Render guard** — Changed to `typeof + trim` check in both detail and card components
3. **Optional type** — Changed `locationLabel` to optional (`?:`) to match non-required OpenAPI contract

## Integration test fix note

The initial commit omitted `location_label_text` from the raw SQL schema bootstrap in `HaliWebApplicationFactory.EnsureSchemaAsync()`. Investigation confirmed this was **not a pre-existing failure on develop** — develop integration tests pass (15/15). The failure was introduced by B9's EF model change without a corresponding update to the test bootstrap SQL. Fixed in commit 66234dd by adding the column to both the CREATE TABLE definition and an idempotent ALTER TABLE statement.

## Pre-existing issues noted (not in scope)

- `HomeController.ToDto` and `ClustersController.GetCluster` use `.ToString().ToLowerInvariant()` for cluster state — produces `possiblerestoration` instead of `possible_restoration` for `PossibleRestoration` state. Pre-existing, flagged for C12 contract-first drift elimination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)