### PR TITLE
docs: add schema-bootstrap drift guardrails

### DIFF
--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -143,6 +143,12 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
 - [ ] Down() must never drop shared tables (e.g., `outbox_events`) used by other modules
 - [ ] If a spec or arch doc references a DB table/column that does not exist in the
       current schema, mark it explicitly as a planned schema change before implementation
+- [ ] When adding, removing, or renaming a persisted column, table, index, constraint,
+      or enum in any `*DbContext` model builder or EF migration, also update the raw SQL
+      integration test schema bootstrap in
+      `tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.EnsureSchemaAsync()`
+      — both the `CREATE TABLE` definition and an idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS`
+      for existing test databases
 
 ### Outbox pattern
 - [ ] Every cluster state mutation writes an outbox event in the same DB transaction

--- a/docs/arch/CODING_STANDARDS.md
+++ b/docs/arch/CODING_STANDARDS.md
@@ -143,12 +143,14 @@ files=$(git diff --name-only --cached -- '*.ts' '*.tsx')
 - [ ] Down() must never drop shared tables (e.g., `outbox_events`) used by other modules
 - [ ] If a spec or arch doc references a DB table/column that does not exist in the
       current schema, mark it explicitly as a planned schema change before implementation
-- [ ] When adding, removing, or renaming a persisted column, table, index, constraint,
-      or enum in any `*DbContext` model builder or EF migration, also update the raw SQL
-      integration test schema bootstrap in
+- [ ] When changing any persisted schema object (column, table, index, constraint, or enum)
+      in any `*DbContext` model builder or EF migration, also update the raw SQL integration
+      test schema bootstrap in
       `tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.EnsureSchemaAsync()`
-      — both the `CREATE TABLE` definition and an idempotent `ALTER TABLE ADD COLUMN IF NOT EXISTS`
-      for existing test databases
+      to match the new schema using the appropriate idempotent SQL pattern for that change
+      (e.g. column additions use `ALTER TABLE ... ADD COLUMN IF NOT EXISTS`;
+      tables use `CREATE TABLE IF NOT EXISTS`; indexes use `CREATE INDEX IF NOT EXISTS`;
+      enums/constraints use guarded `DO $$ ... EXCEPTION WHEN duplicate_object ...`)
 
 ### Outbox pattern
 - [ ] Every cluster state mutation writes an outbox event in the same DB transaction

--- a/docs/arch/COPILOT_LESSONS.md
+++ b/docs/arch/COPILOT_LESSONS.md
@@ -50,3 +50,10 @@ treated as a blocking issue.
 When a service changes which exception it throws, the interface XML docs
 stay stale. Copilot catches the mismatch. Update docs in the same commit.
 -> CODING_STANDARDS: C# Conventions > XML documentation
+
+## 8. Integration test schema bootstrap drifts from EF model
+Adding a persisted column via EF model/migration without updating the raw
+SQL in `HaliWebApplicationFactory.EnsureSchemaAsync()` causes integration
+tests to fail with 500 errors — the test DB lacks the column EF expects.
+This is invisible in unit tests and only surfaces in integration CI.
+-> CODING_STANDARDS: Pre-commit checklist > Migrations


### PR DESCRIPTION
## Summary

- Add pre-commit checklist rule requiring `HaliWebApplicationFactory.EnsureSchemaAsync()` updates whenever a persisted schema change lands in any `*DbContext` or EF migration
- Add lessons-learned entry #8 in `COPILOT_LESSONS.md` documenting the B9 failure mode
- Open follow-up issue #118 to track longer-term migration-based test bootstrap replacement

## Root cause this prevents

In B9 (PR #117), `location_label_text` was added to the EF model + migration but not to the raw SQL integration test schema bootstrap. Integration tests failed with 500 errors because the test DB lacked the column EF expected. The failure was initially misclassified as pre-existing.

## What changed

| File | Change |
|------|--------|
| `docs/arch/CODING_STANDARDS.md` | New Migrations checklist item |
| `docs/arch/COPILOT_LESSONS.md` | Entry #8: schema bootstrap drift |

## Test plan

- [x] Docs-only PR — no code changes, no build/test impact
- [x] Follow-up issue #118 created for structural improvement

## Scope check

This PR is intentionally docs/process only. No feature logic, API changes, mobile changes, or test harness refactors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)