### PR TITLE
fix(#122): finish C12 same-class contract drift cleanup

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -823,7 +823,9 @@ components:
       description: |
         Mirrors `Hali.Contracts.Signals.SignalLocationDto`. Resolved location
         descriptors and a confidence score.
-      required: [locationConfidence, locationSource]
+      required:
+        [areaName, roadName, junctionName, landmarkName, facilityName,
+         locationLabel, locationPrecisionType, locationConfidence, locationSource]
       properties:
         areaName: { type: string, nullable: true }
         roadName: { type: string, nullable: true }
@@ -841,7 +843,8 @@ components:
         previously-documented `candidates[]` and `existingClusterCandidates[]`
         arrays do NOT exist in the backend.
       required:
-        [category, subcategorySlug, conditionConfidence, location, shouldSuggestJoin]
+        [category, subcategorySlug, conditionSlug, conditionConfidence, location,
+         temporalType, neutralSummary, shouldSuggestJoin]
       properties:
         category: { $ref: '#/components/schemas/CivicCategory' }
         subcategorySlug: { type: string }
@@ -1014,8 +1017,8 @@ components:
     OfficialPostResponse:
       type: object
       required:
-        [id, institutionId, type, category, title, body, status,
-         isRestorationClaim, createdAt]
+        [id, institutionId, type, category, title, body, startsAt, endsAt,
+         status, relatedClusterId, isRestorationClaim, createdAt]
       properties:
         id: { type: string, format: uuid }
         institutionId: { type: string, format: uuid }
@@ -1039,7 +1042,7 @@ components:
         clusterResolved: { type: boolean }
     UserMeResponse:
       type: object
-      required: [id, status, createdAt, notificationSettings]
+      required: [id, displayName, phoneE164, email, status, createdAt, notificationSettings]
       properties:
         id: { type: string, format: uuid }
         displayName: { type: string, nullable: true }

--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -82,7 +82,7 @@ public class ClustersController : ControllerBase
         var dto = new ClusterResponseDto(
             cluster.Id,
             JsonNamingPolicy.SnakeCaseLower.ConvertName(cluster.State.ToString()),
-            cluster.Category.ToString().ToLowerInvariant(),
+            JsonNamingPolicy.SnakeCaseLower.ConvertName(cluster.Category.ToString()),
             cluster.SubcategorySlug,
             cluster.Title,
             cluster.Summary,

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -360,7 +360,7 @@ public class HomeController : ControllerBase
         new ClusterResponseDto(
             c.Id,
             JsonNamingPolicy.SnakeCaseLower.ConvertName(c.State.ToString()),
-            c.Category.ToString().ToLowerInvariant(),
+            JsonNamingPolicy.SnakeCaseLower.ConvertName(c.Category.ToString()),
             c.SubcategorySlug,
             c.Title,
             c.Summary,

--- a/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
+++ b/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
@@ -9,6 +9,7 @@ using Hali.Api.Controllers;
 using Hali.Api.Serialization;
 using Hali.Application.Home;
 using Hali.Application.Notifications;
+using Hali.Application.Signals;
 using Hali.Contracts.Advisories;
 using Hali.Contracts.Clusters;
 using Hali.Contracts.Home;
@@ -123,16 +124,45 @@ public class ContractDriftTests
     [Fact]
     public void ClusterResponseDto_NullableFields_SerializedAsJsonNull()
     {
-        var dto = MakeClusterResponse();
+        // Build a cluster response with every nullable OpenAPI-required field
+        // set to null, and verify each one appears on the wire as JSON null
+        // (not absent). Covers every nullable field listed in ClusterResponse
+        // required[] — including the four (subcategorySlug, title, summary,
+        // locationLabel) that weren't explicitly asserted in the original
+        // C12 tests.
+        var dto = new ClusterResponseDto(
+            Guid.Parse("11111111-1111-1111-1111-111111111111"),
+            "active",
+            "water",
+            SubcategorySlug: null,
+            Title: null,
+            Summary: null,
+            AffectedCount: 0,
+            ObservingCount: 0,
+            CreatedAt: DateTime.UtcNow,
+            UpdatedAt: DateTime.UtcNow,
+            ActivatedAt: null,
+            PossibleRestorationAt: null,
+            ResolvedAt: null)
+        {
+            LocationLabel = null,
+            MyParticipation = null
+        };
         var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
         using var doc = JsonDocument.Parse(json);
 
         // Nullable fields are always present on the wire (required in OpenAPI
         // 3.1 means present-on-wire, not non-null). They serialize as JSON null.
-        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("activatedAt").ValueKind);
-        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("possibleRestorationAt").ValueKind);
-        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("resolvedAt").ValueKind);
-        Assert.Equal(JsonValueKind.Null, doc.RootElement.GetProperty("myParticipation").ValueKind);
+        foreach (var field in new[]
+        {
+            "subcategorySlug", "title", "summary", "locationLabel",
+            "activatedAt", "possibleRestorationAt", "resolvedAt", "myParticipation"
+        })
+        {
+            Assert.True(doc.RootElement.TryGetProperty(field, out var value),
+                $"ClusterResponse.{field} must be present on the wire");
+            Assert.Equal(JsonValueKind.Null, value.ValueKind);
+        }
     }
 
     // ── MyParticipationDto ──────────────────────────────────────────────────
@@ -439,6 +469,72 @@ public class ContractDriftTests
             expected.Replace("_", ""), ignoreCase: true);
         string serialized = JsonNamingPolicy.SnakeCaseLower.ConvertName(state.ToString());
         Assert.Equal(expected, serialized);
+    }
+
+    [Theory]
+    [MemberData(nameof(CivicCategoryValues))]
+    public void CivicCategory_WireValue_MatchesSnakeCaseLowerPolicy(CivicCategory category)
+    {
+        // Guard against latent drift on the Category enum: the manual
+        // conversion in HomeController.ToDto and ClustersController.GetCluster
+        // must produce exactly what JsonNamingPolicy.SnakeCaseLower.ConvertName
+        // produces (the same policy the global JsonStringEnumConverter uses).
+        // All current values are single-word, but any multi-word value added
+        // later would silently diverge under the old `.ToLowerInvariant()`
+        // path — this test locks the policy, not the specific current values.
+        string viaPolicy = JsonNamingPolicy.SnakeCaseLower.ConvertName(category.ToString());
+
+        // Round-trip through the OpenAPI-configured enum converter as the
+        // source of truth for "what the wire should say":
+        string wireViaConverter = JsonSerializer.Serialize(category, ApiJsonOptions).Trim('"');
+
+        Assert.Equal(wireViaConverter, viaPolicy);
+    }
+
+    public static IEnumerable<object[]> CivicCategoryValues() =>
+        Enum.GetValues<CivicCategory>().Select(v => new object[] { v });
+
+    // ── LocalityResolveResponse (resolve-by-coordinates) ────────────────────
+
+    [Fact]
+    public async Task LocalitiesController_ResolveByCoordinates_AllRequiredFieldsPresentOnWire()
+    {
+        // Drives LocalitiesController.ResolveByCoordinates and verifies the
+        // response shape matches the OpenAPI `required: [localityId, wardName,
+        // cityName]` claim — in particular that `cityName` is present on the
+        // wire as JSON null when the locality has no city name.
+        var locality = new LocalitySummary(
+            Id: Guid.Parse("22222222-2222-2222-2222-222222222222"),
+            WardName: "South B",
+            CityName: null,
+            CountyName: null);
+
+        var localities = Substitute.For<ILocalityLookupRepository>();
+        localities.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(locality);
+
+        var controller = new LocalitiesController(
+            Substitute.For<IFollowService>(),
+            Substitute.For<IGeocodingService>(),
+            localities,
+            Substitute.For<IDatabase>(),
+            Substitute.For<Hali.Application.Auth.IRateLimiter>(),
+            NullLogger<LocalitiesController>.Instance);
+
+        var result = await controller.ResolveByCoordinates(-1.3, 36.8, CancellationToken.None);
+        var okResult = Assert.IsType<OkObjectResult>(result);
+
+        // Serialize through the MVC-configured options — the same path MVC
+        // takes when the controller returns Ok(value).
+        var json = JsonSerializer.Serialize(okResult.Value, ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        Assert.True(root.TryGetProperty("localityId", out _));
+        Assert.True(root.TryGetProperty("wardName", out _));
+        Assert.True(root.TryGetProperty("cityName", out var cityName),
+            "cityName must be present on the wire (OpenAPI required = present-on-wire)");
+        Assert.Equal(JsonValueKind.Null, cityName.ValueKind);
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #122.

Finishes the same-class cleanup [PR #121](https://github.com/irvinesunday/Hali/pull/121) (C12) intentionally deferred. Three tight buckets from the issue, no unrelated work.

## A) OpenAPI `required` arrays — "required = present-on-wire"

Applied the rule C12 applied to `ClusterResponse` to four more schemas. Every field added is unconditionally serialised by the backend (no `[JsonIgnore]` anywhere in `Hali.Contracts`, no `DefaultIgnoreCondition = WhenWritingNull` in `ApiJsonConfiguration.Configure`).

| Schema | Fields added to `required` | Backing DTO |
|---|---|---|
| `OfficialPostResponse` | `startsAt`, `endsAt`, `relatedClusterId` | `Hali.Contracts.Advisories.OfficialPostResponseDto` |
| `SignalLocation` | `areaName`, `roadName`, `junctionName`, `landmarkName`, `facilityName`, `locationLabel`, `locationPrecisionType` | `Hali.Contracts.Signals.SignalLocationDto` |
| `SignalPreviewResponse` | `conditionSlug`, `temporalType`, `neutralSummary` | `Hali.Contracts.Signals.SignalPreviewResponseDto` |
| `UserMeResponse` | `displayName`, `phoneE164`, `email` | `Hali.Contracts.Auth.UserMeResponseDto` |

## B) Category enum serialization cleanup

Replaced `.Category.ToString().ToLowerInvariant()` with `JsonNamingPolicy.SnakeCaseLower.ConvertName(.Category.ToString())` in `HomeController.ToDto` and `ClustersController.GetCluster`.

All 8 current `CivicCategory` values (`Roads`, `Transport`, `Electricity`, `Water`, `Environment`, `Safety`, `Governance`, `Infrastructure`) are single-word, so **behaviour is preserved exactly**. What this fix does is eliminate the latent drift the old path would have produced for any future multi-word category — same class of fix C12 applied for `SignalState`.

## C) Contract-regression tests

- **Extended** `ClusterResponseDto_NullableFields_SerializedAsJsonNull` to cover `subcategorySlug`, `title`, `summary`, `locationLabel` — the four required-nullable fields C12 added but didn't explicitly assert. Loop-driven so new nullables can be added in one line.
- **Added** `CivicCategory_WireValue_MatchesSnakeCaseLowerPolicy [Theory]`. Theory data is `Enum.GetValues<CivicCategory>()` so new enum values are automatically covered. Asserts the controller path's output matches what `JsonStringEnumConverter` would produce — locking the policy, not the specific current values.
- **Added** `LocalitiesController_ResolveByCoordinates_AllRequiredFieldsPresentOnWire`. Drives the real `LocalitiesController.ResolveByCoordinates` with a substituted `ILocalityLookupRepository` returning `cityName: null` and asserts `cityName` is present on the wire as JSON null — backing the new OpenAPI `required: [...cityName]` claim added in C12.

## Files changed

- `02_openapi.yaml` — 4 `required` array extensions
- `src/Hali.Api/Controllers/HomeController.cs` — Category serialisation
- `src/Hali.Api/Controllers/ClustersController.cs` — Category serialisation
- `tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs` — extended + 2 new tests

## Test plan

- [x] `dotnet build`: 0 errors
- [x] `dotnet test`: **295 passed**, 0 failed (was 286; +9 from the new theory rows and the new test)
- [x] `dotnet format --verify-no-changes` on changed files: clean
- [x] OpenAPI YAML valid

## Non-goals (deferred)

- Ad hoc error envelopes in 6 controllers — tracked as #120
- Any contract work outside the four schemas audited here

## Risk

- **Low.** `OfficialPostResponse`, `SignalLocation`, `SignalPreviewResponse`, `UserMeResponse` — the `required` changes are spec-only and reflect what the backend already serialises. Any mobile/web client that was previously treating these fields as optional continues to work (an always-present null is still a null). The Dredd contract test will validate the claim end-to-end.
- **Low.** Category enum change produces identical wire values for all current categories. Change is a behaviour-preserving refactor that removes a latent future-drift path.
- **Low.** New tests pin policy behaviour (`JsonStringEnumConverter` + `SnakeCaseLower`) rather than specific hardcoded strings, so they don't add churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)