### PR TITLE
fix(#124): finish same-class drift cleanup discovered during #123 validation

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -177,7 +177,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  required: [localityId, wardName]
+                  required: [localityId, displayLabel, wardName, cityName]
                   properties:
                     localityId: { type: string, format: uuid }
                     displayLabel:
@@ -257,7 +257,7 @@ paths:
                 type: array
                 items:
                   type: object
-                  required: [localityId, placeLabel, wardName]
+                  required: [localityId, placeLabel, wardName, cityName]
                   properties:
                     localityId: { type: string, format: uuid }
                     placeLabel:
@@ -881,7 +881,7 @@ components:
         sourceLanguage: { type: string, nullable: true }
     SignalSubmitResponse:
       type: object
-      required: [signalEventId, clusterId, isNewCluster, clusterState, createdAt]
+      required: [signalEventId, clusterId, isNewCluster, clusterState, localityId, createdAt]
       properties:
         signalEventId: { type: string, format: uuid }
         clusterId: { type: string, format: uuid }

--- a/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
+++ b/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
@@ -409,6 +409,70 @@ public class ContractDriftTests
         Assert.True(loc.TryGetProperty("locationSource", out _));
     }
 
+    [Fact]
+    public void SignalPreviewResponseDto_NullableFields_SerializedAsJsonNull()
+    {
+        // Symmetric to ClusterResponseDto_NullableFields_SerializedAsJsonNull.
+        // Backs the OpenAPI `required: [..., conditionSlug, temporalType,
+        // neutralSummary, ...]` claim on SignalPreviewResponse by asserting
+        // these nullable fields are present on the wire as JSON null.
+        var dto = new SignalPreviewResponseDto(
+            Category: "water",
+            SubcategorySlug: "water_outage",
+            ConditionSlug: null,
+            ConditionConfidence: 0.5,
+            Location: new SignalLocationDto(null, null, null, null, null, null, null, 0.0, "nlp"),
+            TemporalType: null,
+            NeutralSummary: null,
+            ShouldSuggestJoin: false);
+
+        var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        foreach (var field in new[] { "conditionSlug", "temporalType", "neutralSummary" })
+        {
+            Assert.True(doc.RootElement.TryGetProperty(field, out var value),
+                $"SignalPreviewResponse.{field} must be present on the wire");
+            Assert.Equal(JsonValueKind.Null, value.ValueKind);
+        }
+    }
+
+    // ── SignalLocationDto ───────────────────────────────────────────────────
+
+    [Fact]
+    public void SignalLocationDto_NullableFields_SerializedAsJsonNull()
+    {
+        // Symmetric to ClusterResponseDto_NullableFields_SerializedAsJsonNull.
+        // Backs the OpenAPI `required: [areaName, roadName, junctionName,
+        // landmarkName, facilityName, locationLabel, locationPrecisionType,
+        // locationConfidence, locationSource]` claim on SignalLocation by
+        // asserting every nullable field is present on the wire as JSON null.
+        var dto = new SignalLocationDto(
+            AreaName: null,
+            RoadName: null,
+            JunctionName: null,
+            LandmarkName: null,
+            FacilityName: null,
+            LocationLabel: null,
+            LocationPrecisionType: null,
+            LocationConfidence: 0.0,
+            LocationSource: "nlp");
+
+        var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        foreach (var field in new[]
+        {
+            "areaName", "roadName", "junctionName", "landmarkName",
+            "facilityName", "locationLabel", "locationPrecisionType"
+        })
+        {
+            Assert.True(doc.RootElement.TryGetProperty(field, out var value),
+                $"SignalLocation.{field} must be present on the wire");
+            Assert.Equal(JsonValueKind.Null, value.ValueKind);
+        }
+    }
+
     // ── SignalSubmitResponseDto ──────────────────────────────────────────────
 
     [Fact]
@@ -427,6 +491,29 @@ public class ContractDriftTests
         Assert.True(root.TryGetProperty("clusterState", out _));
         Assert.True(root.TryGetProperty("localityId", out _));
         Assert.True(root.TryGetProperty("createdAt", out _));
+    }
+
+    [Fact]
+    public void SignalSubmitResponseDto_LocalityId_SerializedAsJsonNullWhenNull()
+    {
+        // Backs the OpenAPI `required: [..., localityId, ...]` claim on
+        // SignalSubmitResponse added in this PR. The backend always serialises
+        // LocalityId (Guid?) on the wire — as JSON null when the submitted
+        // signal has no resolved locality.
+        var dto = new SignalSubmitResponseDto(
+            SignalEventId: Guid.NewGuid(),
+            ClusterId: Guid.NewGuid(),
+            IsNewCluster: true,
+            ClusterState: "unconfirmed",
+            LocalityId: null,
+            CreatedAt: DateTime.UtcNow);
+
+        var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        Assert.True(doc.RootElement.TryGetProperty("localityId", out var value),
+            "SignalSubmitResponse.localityId must be present on the wire");
+        Assert.Equal(JsonValueKind.Null, value.ValueKind);
     }
 
     // ── OfficialPostResponseDto ─────────────────────────────────────────────
@@ -449,6 +536,69 @@ public class ContractDriftTests
         Assert.True(root.TryGetProperty("isRestorationClaim", out _));
         Assert.True(root.TryGetProperty("relatedClusterId", out _));
         Assert.True(root.TryGetProperty("startsAt", out _));
+    }
+
+    [Fact]
+    public void OfficialPostResponseDto_NullableFields_SerializedAsJsonNull()
+    {
+        // Symmetric to ClusterResponseDto_NullableFields_SerializedAsJsonNull.
+        // Backs the OpenAPI `required: [..., startsAt, endsAt, ...,
+        // relatedClusterId, ...]` claim on OfficialPostResponse by asserting
+        // these nullable fields are present on the wire as JSON null.
+        var dto = new OfficialPostResponseDto(
+            Id: Guid.NewGuid(),
+            InstitutionId: Guid.NewGuid(),
+            Type: "live_update",
+            Category: "water",
+            Title: "Repair crew dispatched",
+            Body: "A repair crew is on the way.",
+            StartsAt: null,
+            EndsAt: null,
+            Status: "published",
+            RelatedClusterId: null,
+            IsRestorationClaim: false,
+            CreatedAt: DateTime.UtcNow);
+
+        var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        foreach (var field in new[] { "startsAt", "endsAt", "relatedClusterId" })
+        {
+            Assert.True(doc.RootElement.TryGetProperty(field, out var value),
+                $"OfficialPostResponse.{field} must be present on the wire");
+            Assert.Equal(JsonValueKind.Null, value.ValueKind);
+        }
+    }
+
+    // ── UserMeResponseDto ───────────────────────────────────────────────────
+
+    [Fact]
+    public void UserMeResponseDto_NullableFields_SerializedAsJsonNull()
+    {
+        // Symmetric to ClusterResponseDto_NullableFields_SerializedAsJsonNull.
+        // Backs the OpenAPI `required: [id, displayName, phoneE164, email, ...]`
+        // claim on UserMeResponse by asserting these nullable fields are
+        // present on the wire as JSON null.
+        var dto = new Hali.Contracts.Auth.UserMeResponseDto
+        {
+            Id = Guid.NewGuid(),
+            DisplayName = null,
+            PhoneE164 = null,
+            Email = null,
+            Status = "active",
+            CreatedAt = DateTime.UtcNow,
+            NotificationSettings = new Hali.Contracts.Notifications.NotificationSettingsDto(),
+        };
+
+        var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
+        using var doc = JsonDocument.Parse(json);
+
+        foreach (var field in new[] { "displayName", "phoneE164", "email" })
+        {
+            Assert.True(doc.RootElement.TryGetProperty(field, out var value),
+                $"UserMeResponse.{field} must be present on the wire");
+            Assert.Equal(JsonValueKind.Null, value.ValueKind);
+        }
     }
 
     // ── Enum snake_case contract tests ──────────────────────────────────────


### PR DESCRIPTION
Closes #124.

Finishes the same-class drift cleanup surfaced by strict diff validation of [PR #123](https://github.com/irvinesunday/Hali/pull/123). Two buckets exactly as Issue #124 specifies, no scope expansion.

## A) OpenAPI `required` — 3 remaining gaps

Each field is **unconditionally serialised** by the backend (`System.Text.Json` emits `null` when the value is null; verified by grep: no `[JsonIgnore]` in `Hali.Contracts`, no `DefaultIgnoreCondition = WhenWritingNull` on `ApiJsonConfiguration.Configure`).

| Location in `02_openapi.yaml` | Fields added to `required` | Backing DTO |
|---|---|---|
| Line 884 — `SignalSubmitResponse` schema | `localityId` | `SignalSubmitResponseDto.LocalityId: Guid?` (positional record) |
| Line 260 — inline response for `GET /v1/localities/search` | `cityName` | `LocalitySearchResultDto.CityName: string?` |
| Line 180 — inline response for `GET /v1/localities/followed` | `displayLabel`, `cityName` | `FollowedLocalityDto.DisplayLabel: string?`, `CityName: string?` |

All three endpoints route through MVC's configured `ApiJsonConfiguration` — no custom path that would omit nulls.

## B) Symmetric JSON-null contract tests

Five new tests modelled on the existing `ClusterResponseDto_NullableFields_SerializedAsJsonNull` pattern:

- `SignalPreviewResponseDto_NullableFields_SerializedAsJsonNull` — asserts `conditionSlug`, `temporalType`, `neutralSummary` present on wire as JSON null when null
- `SignalLocationDto_NullableFields_SerializedAsJsonNull` — asserts all 7 nullable fields (`areaName`, `roadName`, `junctionName`, `landmarkName`, `facilityName`, `locationLabel`, `locationPrecisionType`) present on wire as JSON null when null
- `SignalSubmitResponseDto_LocalityId_SerializedAsJsonNullWhenNull` — backs this PR's new `SignalSubmitResponse.required` `+localityId` claim
- `OfficialPostResponseDto_NullableFields_SerializedAsJsonNull` — asserts `startsAt`, `endsAt`, `relatedClusterId` present on wire as JSON null when null
- `UserMeResponseDto_NullableFields_SerializedAsJsonNull` — asserts `displayName`, `phoneE164`, `email` present on wire as JSON null when null

## Files changed

- `02_openapi.yaml` — 3 `required` array extensions (6 line edits)
- `tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs` — 5 new tests inserted next to the corresponding `*_Serializes_WithCamelCasePropertyNames` test for each DTO

## Test plan

- [x] `dotnet build`: 0 errors
- [x] `dotnet test`: **300 passed**, 0 failed (was 295; +5 from new tests)
- [x] `dotnet format --verify-no-changes` on changed files: clean
- [x] OpenAPI YAML valid (`python3 yaml`)
- Spectral OpenAPI Lint + Dredd API Contract — validated end-to-end in CI

## Non-goals (deferred)

- Ad hoc error envelopes in 6 controllers — tracked as #120
- Any contract work outside the three schemas and five test DTOs named in #124

## Risk

- **Low.** OpenAPI changes are spec-only tightenings that faithfully describe what the backend already serialises. Clients that previously treated these fields as optional continue to work (always-present null is still a null).
- **Low.** New tests assert behaviour that already holds for the merged C12 / #122 state. They lock in the spec claims at the unit-test layer earlier than Dredd's end-to-end CI check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)