### PR TITLE
fix(#127): align locality Redis cache serializer with MVC JsonOptions

### DIFF
--- a/src/Hali.Api/Controllers/LocalitiesController.cs
+++ b/src/Hali.Api/Controllers/LocalitiesController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using StackExchange.Redis;
 
 namespace Hali.Api.Controllers;
@@ -29,6 +30,25 @@ public class LocalitiesController : ControllerBase
     private readonly IDatabase _redis;
     private readonly IRateLimiter _rateLimiter;
     private readonly ILogger<LocalitiesController> _logger;
+
+    /// <summary>
+    /// JSON options sourced from the MVC-configured serializer so that
+    /// cached payloads written to / read from Redis use the same
+    /// camelCase property naming and snake_case enum serialization as
+    /// the non-cached Ok() response path. Reusing
+    /// <see cref="Microsoft.AspNetCore.Mvc.JsonOptions"/> from DI
+    /// (instead of a controller-local copy or the default
+    /// <see cref="JsonSerializer"/> options) prevents silent drift
+    /// between the cache and wire contracts if global JSON
+    /// configuration changes — the cache automatically tracks it.
+    ///
+    /// MVC's JsonOptions default to <c>PropertyNameCaseInsensitive = true</c>
+    /// (the <see cref="JsonSerializerDefaults.Web"/> preset), so any
+    /// legacy PascalCase cache entries written before this change are
+    /// still deserialized cleanly during rollout. New writes are
+    /// camelCase and the reserialized wire response is always camelCase.
+    /// </summary>
+    private readonly JsonSerializerOptions _cacheJsonOptions;
 
     private static readonly TimeSpan SearchCacheTtl = TimeSpan.FromHours(1);
     private const int MaxSearchQueryLength = 80;
@@ -47,6 +67,7 @@ public class LocalitiesController : ControllerBase
         ILocalityLookupRepository localities,
         IDatabase redis,
         IRateLimiter rateLimiter,
+        IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> mvcJsonOptions,
         ILogger<LocalitiesController> logger)
     {
         _follows = follows;
@@ -54,6 +75,7 @@ public class LocalitiesController : ControllerBase
         _localities = localities;
         _redis = redis;
         _rateLimiter = rateLimiter;
+        _cacheJsonOptions = mvcJsonOptions.Value.JsonSerializerOptions;
         _logger = logger;
     }
 
@@ -112,7 +134,7 @@ public class LocalitiesController : ControllerBase
         {
             try
             {
-                var hit = JsonSerializer.Deserialize<List<LocalitySummaryDto>>((string)cached!);
+                var hit = JsonSerializer.Deserialize<List<LocalitySummaryDto>>((string)cached!, _cacheJsonOptions);
                 if (hit is not null) return Ok(hit);
             }
             catch
@@ -132,7 +154,7 @@ public class LocalitiesController : ControllerBase
             })
             .ToList();
 
-        await _redis.StringSetAsync(WardListCacheKey, JsonSerializer.Serialize(results), WardListCacheTtl);
+        await _redis.StringSetAsync(WardListCacheKey, JsonSerializer.Serialize(results, _cacheJsonOptions), WardListCacheTtl);
         return Ok(results);
     }
 
@@ -164,7 +186,7 @@ public class LocalitiesController : ControllerBase
         {
             try
             {
-                var hit = JsonSerializer.Deserialize<List<LocalitySearchResultDto>>((string)cached!);
+                var hit = JsonSerializer.Deserialize<List<LocalitySearchResultDto>>((string)cached!, _cacheJsonOptions);
                 if (hit is not null) return Ok(hit);
             }
             catch
@@ -201,7 +223,7 @@ public class LocalitiesController : ControllerBase
             if (results.Count >= 5) break;
         }
 
-        await _redis.StringSetAsync(cacheKey, JsonSerializer.Serialize(results), SearchCacheTtl);
+        await _redis.StringSetAsync(cacheKey, JsonSerializer.Serialize(results, _cacheJsonOptions), SearchCacheTtl);
         return Ok(results);
     }
 

--- a/tests/Hali.Tests.Integration/Localities/LocalitiesIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Localities/LocalitiesIntegrationTests.cs
@@ -84,12 +84,13 @@ public sealed class LocalitiesIntegrationTests : IntegrationTestBase
         // sentinel, we've proven the controller served from cache rather
         // than recomputing from the repository.
         //
-        // The controller caches via default-options JsonSerializer (PascalCase)
-        // and the ASP.NET Core output pipeline writes the wire response in
-        // camelCase — so we write the sentinel in PascalCase to match the
-        // deserialize side, and assert on the camelCase wire shape.
+        // Post-#127: the controller caches via MVC-configured JsonSerializer
+        // options (camelCase) so the cache and wire contracts match. The
+        // sentinel is written in camelCase for the same reason, and the
+        // assertion below verifies the wire response preserves the sentinel
+        // ward name.
         const string sentinelBody =
-            "[{\"LocalityId\":\"00000000-0000-0000-0000-000000000001\",\"WardName\":\"__cache_sentinel__\",\"CityName\":null}]";
+            "[{\"localityId\":\"00000000-0000-0000-0000-000000000001\",\"wardName\":\"__cache_sentinel__\",\"cityName\":null}]";
         await redis.StringSetAsync(WardListCacheKey, sentinelBody);
 
         var warm = await Client.GetAsync("/v1/localities/wards");
@@ -106,6 +107,89 @@ public sealed class LocalitiesIntegrationTests : IntegrationTestBase
         Assert.Equal(
             "__cache_sentinel__",
             doc.RootElement[0].GetProperty("wardName").GetString());
+    }
+
+    /// <summary>
+    /// Regression lock for Issue #127. The Redis cache payload MUST use the
+    /// same camelCase property naming as the HTTP wire response — any future
+    /// drift back to default-options <see cref="JsonSerializer"/> would
+    /// produce PascalCase cache entries while the ASP.NET Core output
+    /// pipeline continues to write camelCase, silently breaking clients on
+    /// cache hits that pass through without reserialization.
+    /// </summary>
+    [Fact]
+    public async Task ListWards_CachedPayload_UsesCamelCasePropertyNames()
+    {
+        await ClearWardListCacheAsync();
+
+        // Cold — populates cache via the repository → serializer path.
+        var response = await Client.GetAsync("/v1/localities/wards");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        await using var scope = Factory.Services.CreateAsyncScope();
+        var redis = scope.ServiceProvider.GetRequiredService<IDatabase>();
+        var raw = (string?)await redis.StringGetAsync(WardListCacheKey);
+
+        Assert.False(
+            string.IsNullOrEmpty(raw),
+            "Expected ward list to be cached in Redis after the cold call.");
+
+        // Casing invariant: the cache must carry the camelCase keys the
+        // client consumes over the wire. Assert both the presence of the
+        // camelCase keys AND the absence of the PascalCase ones.
+        Assert.Contains("\"localityId\"", raw);
+        Assert.Contains("\"wardName\"", raw);
+        Assert.Contains("\"cityName\"", raw);
+        Assert.DoesNotContain("\"LocalityId\"", raw);
+        Assert.DoesNotContain("\"WardName\"", raw);
+        Assert.DoesNotContain("\"CityName\"", raw);
+    }
+
+    // ----------------------------------------------------------------------
+    // GET /v1/localities/search — cache JSON alignment (Issue #127)
+    // ----------------------------------------------------------------------
+
+    /// <summary>
+    /// Rollout compatibility for Issue #127. Any Redis entry written before
+    /// the fix uses PascalCase property names (default-options
+    /// <see cref="JsonSerializer"/>). The fix uses MVC-configured options
+    /// whose <c>PropertyNameCaseInsensitive = true</c> handles those legacy
+    /// entries cleanly, so no cache-key bump or manual invalidation is
+    /// needed during deploy. This test seeds a PascalCase sentinel and
+    /// asserts the wire response comes back as camelCase (i.e. the
+    /// deserialize + Ok() reserialize path works end to end).
+    /// </summary>
+    [Fact]
+    public async Task Search_LegacyPascalCaseCacheEntry_IsServedAsCamelCase()
+    {
+        const string query = "jsonoptions-rollout-probe";
+        var cacheKey = $"locality_search:{query}";
+
+        await using var scope = Factory.Services.CreateAsyncScope();
+        var redis = scope.ServiceProvider.GetRequiredService<IDatabase>();
+
+        // Pre-seed a PascalCase entry — the exact shape the OLD controller
+        // would have written before this fix.
+        const string legacyPascalCaseEntry =
+            "[{\"LocalityId\":\"00000000-0000-0000-0000-000000000002\"," +
+            "\"PlaceLabel\":\"Legacy Place\"," +
+            "\"WardName\":\"Legacy Ward\"," +
+            "\"CityName\":\"Nairobi\"}]";
+        await redis.StringSetAsync(cacheKey, legacyPascalCaseEntry);
+
+        var response = await Client.GetAsync($"/v1/localities/search?q={query}");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        Assert.Equal(JsonValueKind.Array, doc.RootElement.ValueKind);
+        Assert.Equal(1, doc.RootElement.GetArrayLength());
+
+        var first = doc.RootElement[0];
+        // Wire must be camelCase regardless of the cached entry's casing.
+        Assert.Equal("Legacy Ward", first.GetProperty("wardName").GetString());
+        Assert.Equal("Legacy Place", first.GetProperty("placeLabel").GetString());
+        Assert.Equal("Nairobi", first.GetProperty("cityName").GetString());
     }
 
     // ----------------------------------------------------------------------

--- a/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
+++ b/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
@@ -669,6 +669,7 @@ public class ContractDriftTests
             localities,
             Substitute.For<IDatabase>(),
             Substitute.For<Hali.Application.Auth.IRateLimiter>(),
+            BuildMvcJsonOptions(),
             NullLogger<LocalitiesController>.Instance);
 
         var result = await controller.ResolveByCoordinates(-1.3, 36.8, CancellationToken.None);


### PR DESCRIPTION
Closes #127.

## Goal

Align `LocalitiesController`'s Redis cache serialization with the MVC-configured `JsonSerializerOptions` so cache bytes and wire bytes use the same contract. Tight, production-grade hardening — not a caching refactor.

## Root cause

`LocalitiesController.ListWards` and `LocalitiesController.Search` both serialize to Redis via default-options `System.Text.Json.JsonSerializer` (PascalCase property names). The ASP.NET Core output pipeline writes HTTP responses via the MVC-configured `JsonOptions` (camelCase + snake_case enums — see `Hali.Api.Serialization.ApiJsonConfiguration`).

The two branches round-trip cleanly today only because neither DTO (`LocalitySummaryDto`, `LocalitySearchResultDto`) carries a `[JsonPropertyName(...)]` attribute, so default-options deserialize happens to pick up the PascalCase keys. The invariant is implicit and fragile:

- adding a renamed property (or any property-naming attribute)
- changing global JSON config
- switching to the `Content(cached, "application/json")` pass-through pattern `HomeController` uses

...would each silently break clients on cache hits. `HomeController` already demonstrates the correct precedent (`IOptions<MvcJsonOptions>` injected, options reused for cache serialize + deserialize).

## Fix approach — smallest correct change

- Inject `IOptions<Microsoft.AspNetCore.Mvc.JsonOptions>` into `LocalitiesController`; expose its `JsonSerializerOptions` as a private `_cacheJsonOptions` field. Same shape `HomeController` uses.
- Pass `_cacheJsonOptions` to all 4 cache-path `JsonSerializer.Serialize`/`Deserialize` calls (ListWards + Search, serialize + deserialize).
- Keep existing control flow (deserialize → `Ok()`). Not switching to `Content()` here by design — see \"Optional improvement\" below.

## On cache hits: deserialize + `Ok()` vs. `Content(cached, ...)`

I kept the existing deserialize-then-`Ok()` pattern rather than adopting `HomeController`'s `Content()` pass-through. Rationale:

- `HomeController`'s cache key is a hash of locality IDs, so any schema drift naturally forces a cache rotation. `LocalitiesController`'s cache keys (`locality_list:wards`, `locality_search:{q}`) don't encode format — pass-through would lock us into the exact bytes that were cached.
- Keeping deserialize + `Ok()` means the wire format is authoritatively produced by the MVC output pipeline every time, so cache corruption or legacy PascalCase entries cannot leak onto the wire. MVC options' `PropertyNameCaseInsensitive = true` handles the legacy entries for free.
- The controller already has a `try/catch` around deserialize to fall through to live fetch on malformed cache — that safety rail stays intact. `Content()` would discard it.

## Rollout / TTL

No cache-key bump, no manual invalidation. Existing PascalCase entries deserialize cleanly via the MVC options' case-insensitive matching and re-emerge camelCase on the wire. Stale entries expire naturally via existing TTLs (24h for `locality_list:wards`, 1h for `locality_search:{q}`). New writes are always camelCase.

Covered explicitly by the new `Search_LegacyPascalCaseCacheEntry_IsServedAsCamelCase` test.

## Risks checked

- ✅ **Wire-format change for clients** — None. Wire output was already camelCase via MVC; only the cache bytes were PascalCase before. Response shape is unchanged.
- ✅ **Sort / filter / status codes** — Untouched.
- ✅ **Rate limiter on `/search`** — Untouched (30/min per IP).
- ✅ **Regression in cache-hit path** — Covered by the updated sentinel test (`ListWards_SecondCall_IsServedFromRedisCache`).
- ✅ **Rollout with stale PascalCase entries** — Explicit test (`Search_LegacyPascalCaseCacheEntry_IsServedAsCamelCase`). MVC options' `PropertyNameCaseInsensitive` handles the legacy shape.
- ✅ **`try/catch` on deserialize** — Preserved. Malformed cache still falls through to live fetch rather than bubbling.
- ✅ **DI wiring** — `IOptions<JsonOptions>` is already registered by `Program.cs` calling `.AddControllers().AddJsonOptions(ApiJsonConfiguration.Configure)`; no new service registration needed. `HomeController` consumes the same options.

## Tests added / updated

- **Updated** `ListWards_SecondCall_IsServedFromRedisCache` — sentinel rewritten in camelCase to reflect the new invariant. Cache-hit assertion unchanged.
- **New** `ListWards_CachedPayload_UsesCamelCasePropertyNames` — reads raw Redis bytes after a cold populate and asserts camelCase keys present + PascalCase keys absent. This is the drift-regression catcher — had this existed before #127, it would have caught the old behaviour.
- **New** `Search_LegacyPascalCaseCacheEntry_IsServedAsCamelCase` — pre-seeds a PascalCase entry that the old code would have written and asserts the wire response is camelCase. Proves the rollout-compatibility assumption.

## Checks run

| Command | Result |
|---|---|
| `dotnet format src/Hali.Api/Hali.Api.csproj --verify-no-changes` | PASS (exit 0) |
| `dotnet build src/Hali.Api` | 0 errors |
| `dotnet test tests/Hali.Tests.Unit` | 300/300 PASS |
| `dotnet test tests/Hali.Tests.Integration` | 19/19 PASS (was 17; +2 new) |

## Follow-up issues created

None. Scope stayed inside #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)