### PR TITLE
feat(c11): map/place fallback for low-confidence location

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -340,6 +340,88 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
 
+  # ── Places (C11 low-confidence location fallback) ──────────────────
+  /v1/places/search:
+    get:
+      tags: [Places]
+      summary: Search for a place (road / landmark / area) by free text — composer fallback
+      description: |
+        Forward-geocodes the query via Nominatim (biased to Kenya), then resolves
+        each candidate to a Hali locality via PostGIS point-in-polygon. Returns
+        up to 5 matches, each with coordinates and resolved ward context.
+        Candidates outside any covered locality are filtered out — every
+        returned candidate is a valid submit target. Anonymous, rate-limited
+        per client IP, Redis-cached (1h).
+      security: []
+      parameters:
+        - name: q
+          in: query
+          required: true
+          schema:
+            type: string
+            minLength: 2
+            maxLength: 80
+      responses:
+        '200':
+          description: Candidate places (possibly empty)
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/PlaceCandidate' }
+        '400':
+          description: Query too short or too long
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
+  /v1/places/reverse:
+    get:
+      tags: [Places]
+      summary: Reverse geocode coordinates to a single place candidate — composer fallback
+      description: |
+        Reverse-geocodes the coordinate via Nominatim and resolves it to a
+        Hali locality. Used by the composer's "Use my current location"
+        action in the low-confidence fallback flow. Returns 404 when the
+        coordinates are outside any known locality. Anonymous, rate-limited,
+        Redis-cached (1d).
+      security: []
+      parameters:
+        - name: latitude
+          in: query
+          required: true
+          schema: { type: number, format: double, minimum: -90, maximum: 90 }
+        - name: longitude
+          in: query
+          required: true
+          schema: { type: number, format: double, minimum: -180, maximum: 180 }
+      responses:
+        '200':
+          description: Resolved place candidate
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/PlaceCandidate' }
+        '400':
+          description: Invalid coordinates
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '404':
+          description: No locality found for the given coordinates
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: Rate limit exceeded
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+
   /v1/feedback:
     post:
       tags: [Feedback]
@@ -849,6 +931,25 @@ components:
         locale: { type: string, nullable: true, example: en }
         knownCity: { type: string, nullable: true }
         countryCode: { type: string, nullable: true, example: KE }
+    LocationSource:
+      type: string
+      description: |
+        Canonical wire values for `SignalLocation.locationSource` and
+        `SignalSubmitRequest.locationSource`. Mirrors
+        `Hali.Contracts.Signals.LocationSource`.
+
+          * `nlp` — derived from CSI-NLP extraction, unchanged by the user.
+          * `user_edit` — user accepted or edited the human-readable label;
+            coordinates remain device-GPS or NLP-suggested.
+          * `place_search` — user picked a Nominatim-backed place from the
+            C11 low-confidence fallback picker (search results OR
+            `Use my current location`). Both label and coordinates are
+            authoritative from the picker.
+
+        The draggable map-pin fallback (`map_pin`) is intentionally deferred
+        to a follow-up and is NOT in this enum. Do not add it here until
+        that surface ships.
+      enum: [nlp, user_edit, place_search]
     SignalLocation:
       type: object
       description: |
@@ -866,16 +967,21 @@ components:
         locationLabel: { type: string, nullable: true }
         locationPrecisionType: { type: string, nullable: true }
         locationConfidence: { type: number, minimum: 0, maximum: 1 }
-        locationSource: { type: string }
+        locationSource: { $ref: '#/components/schemas/LocationSource' }
     SignalPreviewResponse:
       type: object
       description: |
         Single extraction result. Mirrors `SignalPreviewResponseDto`. The
         previously-documented `candidates[]` and `existingClusterCandidates[]`
         arrays do NOT exist in the backend.
+
+        `requiresLocationFallback` (C11) is the server-authoritative flag
+        indicating the NLP-extracted location is too weak to submit as-is;
+        the composer routes the user into the place-search / current-location
+        picker when it is true. See `LocationFallbackPolicy` in the backend.
       required:
         [category, subcategorySlug, conditionSlug, conditionConfidence, location,
-         temporalType, neutralSummary, shouldSuggestJoin]
+         temporalType, neutralSummary, shouldSuggestJoin, requiresLocationFallback]
       properties:
         category: { $ref: '#/components/schemas/CivicCategory' }
         subcategorySlug: { type: string }
@@ -885,11 +991,22 @@ components:
         temporalType: { type: string, nullable: true }
         neutralSummary: { type: string, nullable: true }
         shouldSuggestJoin: { type: boolean }
+        requiresLocationFallback:
+          type: boolean
+          description: |
+            True when the composer MUST route the user into the low-confidence
+            location fallback picker before allowing submit. Triggered when
+            `location.locationConfidence < 0.5` OR `location.locationLabel`
+            is blank.
     SignalSubmitRequest:
       type: object
       description: |
         Flat shape — no nested `candidate` wrapper. `spatialCellId` is derived
         server-side from lat/lng and must NOT be sent by the client.
+
+        When `locationSource` is `place_search`, `locationLabel` is required
+        (non-blank). The server rejects unknown `locationSource` values with
+        `validation.invalid_location_source`.
       required:
         [idempotencyKey, deviceHash, freeText, category, subcategorySlug,
          conditionConfidence, latitude, longitude, locationConfidence, locationSource]
@@ -906,10 +1023,27 @@ components:
         locationLabel: { type: string, nullable: true }
         locationPrecisionType: { type: string, nullable: true }
         locationConfidence: { type: number, minimum: 0, maximum: 1 }
-        locationSource: { type: string }
+        locationSource: { $ref: '#/components/schemas/LocationSource' }
         temporalType: { type: string, nullable: true }
         neutralSummary: { type: string, nullable: true }
         sourceLanguage: { type: string, nullable: true }
+    PlaceCandidate:
+      type: object
+      description: |
+        A single geocoding candidate returned by the C11 places endpoints.
+        Mirrors `Hali.Contracts.Signals.PlaceCandidateDto`. Every candidate
+        is resolved to a Hali locality (otherwise filtered out by the
+        backend); the composer uses this to supply authoritative submit
+        coordinates and label.
+      required:
+        [displayName, latitude, longitude, localityId, wardName, cityName]
+      properties:
+        displayName: { type: string }
+        latitude: { type: number, format: double, minimum: -90, maximum: 90 }
+        longitude: { type: number, format: double, minimum: -180, maximum: 180 }
+        localityId: { type: string, format: uuid, nullable: true }
+        wardName: { type: string, nullable: true }
+        cityName: { type: string, nullable: true }
     SignalSubmitResponse:
       type: object
       required: [signalEventId, clusterId, isNewCluster, clusterState, localityId, createdAt]

--- a/apps/citizen-mobile/__tests__/api/places.test.ts
+++ b/apps/citizen-mobile/__tests__/api/places.test.ts
@@ -1,0 +1,116 @@
+// apps/citizen-mobile/__tests__/api/places.test.ts
+//
+// Unit tests for the places API service layer (C11 fallback).
+
+import { searchPlaces, reverseGeocodePoint } from '../../src/api/places';
+
+const mockApiRequest = jest.fn();
+
+jest.mock('../../src/api/client', () => ({
+  apiRequest: (...args: unknown[]) => mockApiRequest(...args),
+}));
+
+describe('searchPlaces', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls GET /v1/places/search with a URL-encoded query', async () => {
+    mockApiRequest.mockResolvedValueOnce({ ok: true, value: [] });
+
+    await searchPlaces('Ngong Road');
+
+    const calledUrl = mockApiRequest.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/v1/places/search?q=');
+    expect(calledUrl).toContain('Ngong%20Road');
+    expect(mockApiRequest).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ method: 'GET' }),
+    );
+  });
+
+  it('trims whitespace before encoding the query', async () => {
+    mockApiRequest.mockResolvedValueOnce({ ok: true, value: [] });
+
+    await searchPlaces('  Uhuru Park  ');
+
+    const calledUrl = mockApiRequest.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('Uhuru%20Park');
+    expect(calledUrl).not.toContain('%20Uhuru'); // no leading-space encoding
+  });
+
+  it('returns the candidate list on success', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      value: [
+        {
+          displayName: 'Ngong Road, Nairobi',
+          latitude: -1.3,
+          longitude: 36.78,
+          localityId: 'abc-123',
+          wardName: 'Nairobi West',
+          cityName: 'Nairobi',
+        },
+      ],
+    });
+
+    const result = await searchPlaces('Ngong Road');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.value).toHaveLength(1);
+      expect(result.value[0].localityId).toBe('abc-123');
+    }
+  });
+
+  it('propagates backend 400 (query_too_short) as an err result', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: { status: 400, code: 'query_too_short', message: 'Query too short' },
+    });
+
+    const result = await searchPlaces('a');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('query_too_short');
+    }
+  });
+});
+
+describe('reverseGeocodePoint', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('calls GET /v1/places/reverse with latitude and longitude params', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: true,
+      value: {
+        displayName: 'Ngong Road, Nairobi West',
+        latitude: -1.3,
+        longitude: 36.78,
+        localityId: 'abc-123',
+        wardName: 'Nairobi West',
+        cityName: 'Nairobi',
+      },
+    });
+
+    await reverseGeocodePoint(-1.3, 36.78);
+
+    const calledUrl = mockApiRequest.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('/v1/places/reverse?');
+    expect(calledUrl).toContain('latitude=-1.3');
+    expect(calledUrl).toContain('longitude=36.78');
+  });
+
+  it('surfaces 404 (locality_not_found) as an err result', async () => {
+    mockApiRequest.mockResolvedValueOnce({
+      ok: false,
+      error: { status: 404, code: 'locality_not_found', message: 'No locality found' },
+    });
+
+    const result = await reverseGeocodePoint(0, 0);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('locality_not_found');
+    }
+  });
+});

--- a/apps/citizen-mobile/__tests__/composer/canProceed.test.ts
+++ b/apps/citizen-mobile/__tests__/composer/canProceed.test.ts
@@ -1,0 +1,191 @@
+// apps/citizen-mobile/__tests__/composer/canProceed.test.ts
+//
+// Composer-level "Next button enablement" logic, extracted from
+// confirm.tsx so it can be unit-tested without React Native.
+//
+// The 'fallback' tier regression tests (see "B-1") are the reason
+// this helper exists: a preview with a non-empty NLP label and
+// confidence < 0.5 previously let the user tap Next without engaging
+// the picker, silently bypassing the fallback gate.
+
+import {
+  canProceedFromLocationGate,
+  type LocationProceedInput,
+} from '../../src/utils/composerGates';
+
+const DEFAULT: Omit<LocationProceedInput, 'gate' | 'hasOverride'> = {
+  label: '',
+  originalLabel: '',
+  confirmed: false,
+};
+
+describe('canProceedFromLocationGate', () => {
+  describe('override wins regardless of gate', () => {
+    it.each(['accept', 'confirm', 'fallback', 'required'] as const)(
+      'returns true when hasOverride=true at gate=%s',
+      (gate) => {
+        expect(
+          canProceedFromLocationGate({ ...DEFAULT, gate, hasOverride: true }),
+        ).toBe(true);
+      },
+    );
+
+    it('override wins even when the text-input label is empty', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'fallback',
+          hasOverride: true,
+          label: '',
+          originalLabel: 'Ngong Rd',
+          confirmed: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('accept tier', () => {
+    it('always allows proceed with no action', () => {
+      expect(
+        canProceedFromLocationGate({
+          ...DEFAULT,
+          gate: 'accept',
+          hasOverride: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe('confirm tier', () => {
+    it('blocks proceed until the user confirms or edits', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'confirm',
+          hasOverride: false,
+          label: 'Ngong Road',
+          originalLabel: 'Ngong Road',
+          confirmed: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('allows proceed after user taps "Looks right"', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'confirm',
+          hasOverride: false,
+          label: 'Ngong Road',
+          originalLabel: 'Ngong Road',
+          confirmed: true,
+        }),
+      ).toBe(true);
+    });
+
+    it('allows proceed when the user edits the label to something non-empty and different', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'confirm',
+          hasOverride: false,
+          label: 'Lusaka Road',
+          originalLabel: 'Ngong Road',
+          confirmed: false,
+        }),
+      ).toBe(true);
+    });
+
+    it('does not treat a blank edit as a user edit', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'confirm',
+          hasOverride: false,
+          label: '   ',
+          originalLabel: 'Ngong Road',
+          confirmed: false,
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('fallback tier — override-only (B-1 regression)', () => {
+    // Before the fix, this path returned true because the switch
+    // branch read the stale NLP label out of the text-input state.
+    // With fallback rendering the picker (and not the text input),
+    // a non-empty NLP label cannot be treated as a user correction.
+    it('blocks proceed when preview carries a non-empty NLP label but no override is picked', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'fallback',
+          hasOverride: false,
+          label: 'somewhere in Nairobi West',
+          originalLabel: 'somewhere in Nairobi West',
+          confirmed: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('blocks proceed when the label has been edited but no override is picked', () => {
+      // The picker is the only authoritative correction in this tier;
+      // an edit to the hidden text input state must not unlock Next.
+      expect(
+        canProceedFromLocationGate({
+          gate: 'fallback',
+          hasOverride: false,
+          label: 'user typed something',
+          originalLabel: 'somewhere in Nairobi West',
+          confirmed: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('blocks proceed when label is blank and no override is picked', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'fallback',
+          hasOverride: false,
+          label: '',
+          originalLabel: null,
+          confirmed: false,
+        }),
+      ).toBe(false);
+    });
+
+    it('allows proceed when an override is present (happy-path complement to the bug test)', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'fallback',
+          hasOverride: true,
+          label: 'somewhere in Nairobi West',
+          originalLabel: 'somewhere in Nairobi West',
+          confirmed: false,
+        }),
+      ).toBe(true);
+    });
+  });
+
+  describe("required tier (not emitted by location gate today)", () => {
+    // Defensive coverage: classifyLocationGate never returns 'required'
+    // for location, but the union still contains it because the
+    // condition classifier uses it. If a future change starts emitting
+    // 'required' for location, the helper falls back to requiring a
+    // non-empty label rather than unlocking Next.
+    it('requires a non-empty label when gate is required', () => {
+      expect(
+        canProceedFromLocationGate({
+          gate: 'required',
+          hasOverride: false,
+          label: 'Lusaka Road',
+          originalLabel: null,
+          confirmed: false,
+        }),
+      ).toBe(true);
+      expect(
+        canProceedFromLocationGate({
+          gate: 'required',
+          hasOverride: false,
+          label: '',
+          originalLabel: null,
+          confirmed: false,
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/apps/citizen-mobile/__tests__/composer/locationGate.test.ts
+++ b/apps/citizen-mobile/__tests__/composer/locationGate.test.ts
@@ -8,30 +8,32 @@
 //   LOCATION_CONFIDENCE_WARN_THRESHOLD  = 0.5
 //   LOCATION_CONFIDENCE_AMBER_THRESHOLD = 0.8
 //
-// Expected classification:
-//   confidence < 0.5              → 'required'  (empty field, MUST fill)
-//   0.5 ≤ confidence < 0.8        → 'confirm'   (amber, MUST confirm or edit)
+// C11 tiers (see composerGates.ts):
+//   confidence < 0.5              → 'fallback'  (place-search / current-location picker)
+//   0.5 ≤ confidence < 0.8        → 'confirm'   (amber, confirm or edit)
 //   confidence ≥ 0.8              → 'accept'    (pre-filled, no action)
+//
+// Additional rule: the server flag wins, and a blank label at any
+// confidence drops the tier to 'fallback'.
 
-// Pure utility — no React Native imports, fully testable under Jest.
 import { classifyLocationGate } from '../../src/utils/composerGates';
 
-describe('classifyLocationGate', () => {
-  describe('required tier (< 0.5)', () => {
-    it('classifies 0.0 as required', () => {
-      expect(classifyLocationGate(0)).toBe('required');
+describe('classifyLocationGate — legacy numeric form', () => {
+  describe('fallback tier (< 0.5)', () => {
+    it('classifies 0.0 as fallback', () => {
+      expect(classifyLocationGate(0)).toBe('fallback');
     });
 
-    it('classifies 0.25 as required', () => {
-      expect(classifyLocationGate(0.25)).toBe('required');
+    it('classifies 0.25 as fallback', () => {
+      expect(classifyLocationGate(0.25)).toBe('fallback');
     });
 
-    it('classifies 0.49 as required', () => {
-      expect(classifyLocationGate(0.49)).toBe('required');
+    it('classifies 0.49 as fallback', () => {
+      expect(classifyLocationGate(0.49)).toBe('fallback');
     });
 
-    it('classifies 0.4999 as required (just below boundary)', () => {
-      expect(classifyLocationGate(0.4999)).toBe('required');
+    it('classifies 0.4999 as fallback (just below boundary)', () => {
+      expect(classifyLocationGate(0.4999)).toBe('fallback');
     });
   });
 
@@ -75,8 +77,70 @@ describe('classifyLocationGate', () => {
       expect(classifyLocationGate(1.5)).toBe('accept');
     });
 
-    it('treats negative values as required', () => {
-      expect(classifyLocationGate(-0.1)).toBe('required');
+    it('treats negative values as fallback', () => {
+      expect(classifyLocationGate(-0.1)).toBe('fallback');
+    });
+  });
+});
+
+describe('classifyLocationGate — C11 object form', () => {
+  describe('server flag wins', () => {
+    it('returns fallback when requiresFallback=true even at high confidence', () => {
+      expect(
+        classifyLocationGate({
+          confidence: 0.95,
+          requiresFallback: true,
+          label: 'Ngong Road',
+        }),
+      ).toBe('fallback');
+    });
+
+    it('still classifies normally when requiresFallback=false', () => {
+      expect(
+        classifyLocationGate({
+          confidence: 0.9,
+          requiresFallback: false,
+          label: 'Ngong Road',
+        }),
+      ).toBe('accept');
+    });
+
+    it('ignores an undefined server flag and uses client-side rule', () => {
+      expect(
+        classifyLocationGate({ confidence: 0.3, label: 'Ngong Road' }),
+      ).toBe('fallback');
+    });
+  });
+
+  describe('blank label drops tier to fallback', () => {
+    it('treats a null label at high confidence as fallback', () => {
+      expect(
+        classifyLocationGate({ confidence: 0.95, label: null }),
+      ).toBe('fallback');
+    });
+
+    it('treats an empty-string label at high confidence as fallback', () => {
+      expect(classifyLocationGate({ confidence: 0.95, label: '' })).toBe(
+        'fallback',
+      );
+    });
+
+    it('treats a whitespace-only label at high confidence as fallback', () => {
+      expect(
+        classifyLocationGate({ confidence: 0.95, label: '   ' }),
+      ).toBe('fallback');
+    });
+
+    it('does not apply the label check when label arg is omitted', () => {
+      // Legacy bare-number contract must still return 'accept' on high
+      // confidence without a label argument.
+      expect(classifyLocationGate({ confidence: 0.95 })).toBe('accept');
+    });
+
+    it('non-blank label at mid confidence remains confirm', () => {
+      expect(
+        classifyLocationGate({ confidence: 0.6, label: 'Ngong Road' }),
+      ).toBe('confirm');
     });
   });
 });

--- a/apps/citizen-mobile/app/(app)/compose/confirm.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/confirm.tsx
@@ -16,7 +16,11 @@ import { Button } from '../../../src/components/common/Button';
 import { ConditionBadge } from '../../../src/components/shared';
 import { LocationFallbackPicker } from '../../../src/components/compose/LocationFallbackPicker';
 import { formatCategoryLabel } from '../../../src/utils/formatters';
-import { classifyLocationGate, type ConfidenceGate } from '../../../src/utils/composerGates';
+import {
+  canProceedFromLocationGate,
+  classifyLocationGate,
+  type ConfidenceGate,
+} from '../../../src/utils/composerGates';
 import { Colors, FontFamily, FontSize, Spacing, Radius, ScreenPaddingH } from '../../../src/theme';
 import type { SignalPreviewResponse } from '../../../src/types/api';
 
@@ -86,22 +90,27 @@ function ConfirmScreenContent({
   const renderFallbackPicker =
     locationOverride !== null || locationGate === 'fallback';
 
-  const canProceed = useMemo<boolean>(() => {
-    // Override path: the picker's selection stands on its own.
-    if (locationOverride !== null) return true;
-    const trimmed = locationLabel.trim();
-    const original = (preview.location.locationLabel ?? '').trim();
-    const userEdited = trimmed !== original && trimmed.length > 0;
-    switch (locationGate) {
-      case 'accept':   return true;
-      case 'confirm':  return locationConfirmed || userEdited;
-      // 'fallback' / 'required' both gate on the user supplying a label
-      // (via the text input) OR picking from the fallback picker (handled
-      // by the locationOverride early-return above).
-      case 'fallback': return trimmed.length > 0;
-      case 'required': return trimmed.length > 0;
-    }
-  }, [locationGate, locationLabel, locationConfirmed, preview.location.locationLabel, locationOverride]);
+  // Pure helper; see composerGates.canProceedFromLocationGate for the full
+  // rules. The 'fallback' tier is override-only — the text input is not
+  // rendered in that tier, and the stale NLP label in `locationLabel`
+  // state must not be allowed to silently bypass the fallback gate.
+  const canProceed = useMemo<boolean>(
+    () =>
+      canProceedFromLocationGate({
+        gate: locationGate,
+        hasOverride: locationOverride !== null,
+        label: locationLabel,
+        originalLabel: preview.location.locationLabel,
+        confirmed: locationConfirmed,
+      }),
+    [
+      locationGate,
+      locationOverride,
+      locationLabel,
+      locationConfirmed,
+      preview.location.locationLabel,
+    ],
+  );
 
   function handleNext(): void {
     // If the user picked an override, the override is authoritative and

--- a/apps/citizen-mobile/app/(app)/compose/confirm.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/confirm.tsx
@@ -7,9 +7,13 @@ import {
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { ArrowLeft, Check } from 'lucide-react-native';
-import { useComposerContext } from '../../../src/context/ComposerContext';
+import {
+  useComposerContext,
+  type ComposerLocationOverride,
+} from '../../../src/context/ComposerContext';
 import { Button } from '../../../src/components/common/Button';
 import { ConditionBadge } from '../../../src/components/shared';
+import { LocationFallbackPicker } from '../../../src/components/compose/LocationFallbackPicker';
 import { formatCategoryLabel } from '../../../src/utils/formatters';
 import { classifyLocationGate, type ConfidenceGate } from '../../../src/utils/composerGates';
 import { Colors, FontFamily, FontSize, Spacing, Radius, ScreenPaddingH } from '../../../src/theme';
@@ -17,41 +21,85 @@ import type { SignalPreviewResponse } from '../../../src/types/api';
 
 export default function ComposerConfirmScreen(): React.ReactElement {
   const router = useRouter();
-  const { preview, setPreview } = useComposerContext();
+  const {
+    preview,
+    setPreview,
+    locationOverride,
+    setLocationOverride,
+  } = useComposerContext();
   if (preview === null) {
     return <PreviewMissingFallback onBack={() => router.replace('/(app)/compose/text')} />;
   }
-  return <ConfirmScreenContent preview={preview} setPreview={setPreview} />;
+  return (
+    <ConfirmScreenContent
+      preview={preview}
+      setPreview={setPreview}
+      locationOverride={locationOverride}
+      setLocationOverride={setLocationOverride}
+    />
+  );
 }
 
 function ConfirmScreenContent({
-  preview, setPreview,
-}: { preview: SignalPreviewResponse; setPreview: (p: SignalPreviewResponse | null) => void }): React.ReactElement {
+  preview, setPreview, locationOverride, setLocationOverride,
+}: {
+  preview: SignalPreviewResponse;
+  setPreview: (p: SignalPreviewResponse | null) => void;
+  locationOverride: ComposerLocationOverride | null;
+  setLocationOverride: (o: ComposerLocationOverride | null) => void;
+}): React.ReactElement {
   const router = useRouter();
   const [locationLabel, setLocationLabel] = useState(preview.location.locationLabel ?? '');
   const [locationConfirmed, setLocationConfirmed] = useState(false);
 
+  // C11: gate combines (server flag, numeric confidence, label).
+  // The server wins when it has spoken. Once the user has picked an
+  // override, we treat the location as accepted — the override is
+  // authoritative.
   const locationGate = useMemo<ConfidenceGate>(
-    () => classifyLocationGate(preview.location.locationConfidence),
-    [preview.location.locationConfidence],
+    () =>
+      locationOverride !== null
+        ? 'accept'
+        : classifyLocationGate({
+            confidence: preview.location.locationConfidence,
+            requiresFallback: preview.requiresLocationFallback,
+            label: locationLabel,
+          }),
+    [
+      locationOverride,
+      preview.location.locationConfidence,
+      preview.requiresLocationFallback,
+      locationLabel,
+    ],
   );
 
   const canProceed = useMemo<boolean>(() => {
+    // Override path: the picker's selection stands on its own.
+    if (locationOverride !== null) return true;
     const trimmed = locationLabel.trim();
     const original = (preview.location.locationLabel ?? '').trim();
     const userEdited = trimmed !== original && trimmed.length > 0;
     switch (locationGate) {
       case 'accept':   return true;
       case 'confirm':  return locationConfirmed || userEdited;
+      // 'fallback' / 'required' both gate on the user supplying a label
+      // (via the text input) OR picking from the fallback picker (handled
+      // by the locationOverride early-return above).
+      case 'fallback': return trimmed.length > 0;
       case 'required': return trimmed.length > 0;
     }
-  }, [locationGate, locationLabel, locationConfirmed, preview.location.locationLabel]);
+  }, [locationGate, locationLabel, locationConfirmed, preview.location.locationLabel, locationOverride]);
 
   function handleNext(): void {
-    setPreview({
-      ...preview,
-      location: { ...preview.location, locationLabel: locationLabel.trim() || preview.location.locationLabel },
-    });
+    // If the user picked an override, the override is authoritative and
+    // we don't need to mutate preview.location.locationLabel — submit.tsx
+    // reads the override directly and overrides both coords and label.
+    if (locationOverride === null) {
+      setPreview({
+        ...preview,
+        location: { ...preview.location, locationLabel: locationLabel.trim() || preview.location.locationLabel },
+      });
+    }
     router.push('/(app)/compose/submit');
   }
 
@@ -92,40 +140,40 @@ function ConfirmScreenContent({
 
           <View style={styles.locationBlock}>
             <Text style={styles.fieldLabel}>Location</Text>
-            {locationGate === 'required' && (
-              <Text style={styles.warningRequired}>
-                We couldn't confidently identify the location. Please enter it below.
-              </Text>
-            )}
-            {locationGate === 'confirm' && (
-              <Text style={styles.warningAmber}>
-                We extracted this location but aren't fully confident. Confirm or correct it.
-              </Text>
-            )}
-            <TextInput
-              style={[
-                styles.locationInput,
-                locationGate === 'required' && locationLabel.trim() === '' && styles.locationInputError,
-              ]}
-              value={locationLabel}
-              onChangeText={(v) => { setLocationLabel(v); setLocationConfirmed(false); }}
-              placeholder={locationGate === 'required' ? 'Enter the location…' : 'Confirm or correct the location…'}
-              placeholderTextColor={Colors.faintForeground}
-              accessibilityLabel="Location"
-              accessibilityHint={locationGate === 'required'
-                ? "Required. We couldn't confidently identify the location, so please enter it."
-                : "Optional. Confirm the extracted location or correct it if needed."}
-            />
-            {locationGate === 'confirm' && !locationConfirmed && (
-              <TouchableOpacity style={styles.confirmChip}
-                onPress={() => setLocationConfirmed(true)}
-                accessibilityRole="button" accessibilityLabel="Confirm location">
-                <Check size={14} color={Colors.primary} strokeWidth={2.5} />
-                <Text style={styles.confirmChipText}>Looks right</Text>
-              </TouchableOpacity>
-            )}
-            {locationGate === 'confirm' && locationConfirmed && (
-              <Text style={styles.confirmedText}>Location confirmed.</Text>
+            {locationGate === 'fallback' ? (
+              <LocationFallbackPicker
+                selected={locationOverride}
+                onPick={(o) => setLocationOverride(o)}
+                onClear={() => setLocationOverride(null)}
+              />
+            ) : (
+              <>
+                {locationGate === 'confirm' && (
+                  <Text style={styles.warningAmber}>
+                    We extracted this location but aren&apos;t fully confident. Confirm or correct it.
+                  </Text>
+                )}
+                <TextInput
+                  style={styles.locationInput}
+                  value={locationLabel}
+                  onChangeText={(v) => { setLocationLabel(v); setLocationConfirmed(false); }}
+                  placeholder="Confirm or correct the location…"
+                  placeholderTextColor={Colors.faintForeground}
+                  accessibilityLabel="Location"
+                  accessibilityHint="Confirm the extracted location or correct it if needed."
+                />
+                {locationGate === 'confirm' && !locationConfirmed && (
+                  <TouchableOpacity style={styles.confirmChip}
+                    onPress={() => setLocationConfirmed(true)}
+                    accessibilityRole="button" accessibilityLabel="Confirm location">
+                    <Check size={14} color={Colors.primary} strokeWidth={2.5} />
+                    <Text style={styles.confirmChipText}>Looks right</Text>
+                  </TouchableOpacity>
+                )}
+                {locationGate === 'confirm' && locationConfirmed && (
+                  <Text style={styles.confirmedText}>Location confirmed.</Text>
+                )}
+              </>
             )}
           </View>
 
@@ -182,7 +230,6 @@ const styles = StyleSheet.create({
   },
   fieldValue: { fontSize: FontSize.body, fontFamily: FontFamily.regular, color: Colors.foreground },
   locationBlock: { gap: Spacing.sm },
-  warningRequired: { fontSize: FontSize.bodySmall, fontFamily: FontFamily.regular, color: Colors.destructive },
   warningAmber: { fontSize: FontSize.bodySmall, fontFamily: FontFamily.regular, color: Colors.conditionBadge.amber.text },
   locationInput: {
     borderWidth: 1.5, borderColor: Colors.border, borderRadius: Radius.md,
@@ -190,7 +237,6 @@ const styles = StyleSheet.create({
     fontSize: FontSize.body, fontFamily: FontFamily.regular,
     color: Colors.foreground, backgroundColor: Colors.card,
   },
-  locationInputError: { borderColor: Colors.destructive },
   confirmChip: {
     alignSelf: 'flex-start', flexDirection: 'row', alignItems: 'center', gap: Spacing.xs,
     backgroundColor: Colors.primarySubtle, borderRadius: Radius.full,

--- a/apps/citizen-mobile/app/(app)/compose/confirm.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/confirm.tsx
@@ -10,6 +10,7 @@ import { ArrowLeft, Check } from 'lucide-react-native';
 import {
   useComposerContext,
   type ComposerLocationOverride,
+  type LocationOverridePickedVia,
 } from '../../../src/context/ComposerContext';
 import { Button } from '../../../src/components/common/Button';
 import { ConditionBadge } from '../../../src/components/shared';
@@ -25,6 +26,7 @@ export default function ComposerConfirmScreen(): React.ReactElement {
     preview,
     setPreview,
     locationOverride,
+    locationOverridePickedVia,
     setLocationOverride,
   } = useComposerContext();
   if (preview === null) {
@@ -35,43 +37,54 @@ export default function ComposerConfirmScreen(): React.ReactElement {
       preview={preview}
       setPreview={setPreview}
       locationOverride={locationOverride}
+      locationOverridePickedVia={locationOverridePickedVia}
       setLocationOverride={setLocationOverride}
     />
   );
 }
 
 function ConfirmScreenContent({
-  preview, setPreview, locationOverride, setLocationOverride,
+  preview, setPreview, locationOverride, locationOverridePickedVia, setLocationOverride,
 }: {
   preview: SignalPreviewResponse;
   setPreview: (p: SignalPreviewResponse | null) => void;
   locationOverride: ComposerLocationOverride | null;
-  setLocationOverride: (o: ComposerLocationOverride | null) => void;
+  locationOverridePickedVia: LocationOverridePickedVia | null;
+  setLocationOverride: (
+    o: ComposerLocationOverride | null,
+    pickedVia?: LocationOverridePickedVia | null,
+  ) => void;
 }): React.ReactElement {
   const router = useRouter();
   const [locationLabel, setLocationLabel] = useState(preview.location.locationLabel ?? '');
   const [locationConfirmed, setLocationConfirmed] = useState(false);
 
   // C11: gate combines (server flag, numeric confidence, label).
-  // The server wins when it has spoken. Once the user has picked an
-  // override, we treat the location as accepted — the override is
-  // authoritative.
+  // The server wins when it has spoken. We intentionally do NOT force the
+  // gate to 'accept' when an override is picked — that would un-render the
+  // picker (which displays the selected-state card with a "Change"
+  // affordance). Instead, we keep the underlying gate and let the render
+  // branch prefer the picker whenever an override is present.
   const locationGate = useMemo<ConfidenceGate>(
     () =>
-      locationOverride !== null
-        ? 'accept'
-        : classifyLocationGate({
-            confidence: preview.location.locationConfidence,
-            requiresFallback: preview.requiresLocationFallback,
-            label: locationLabel,
-          }),
+      classifyLocationGate({
+        confidence: preview.location.locationConfidence,
+        requiresFallback: preview.requiresLocationFallback,
+        label: locationLabel,
+      }),
     [
-      locationOverride,
       preview.location.locationConfidence,
       preview.requiresLocationFallback,
       locationLabel,
     ],
   );
+
+  // Render the picker when the server / gate asked for fallback OR when
+  // the user has already locked in an override (e.g. returning to Step 2
+  // from Step 3). Otherwise show the text-input path for the happy /
+  // amber tiers.
+  const renderFallbackPicker =
+    locationOverride !== null || locationGate === 'fallback';
 
   const canProceed = useMemo<boolean>(() => {
     // Override path: the picker's selection stands on its own.
@@ -140,10 +153,11 @@ function ConfirmScreenContent({
 
           <View style={styles.locationBlock}>
             <Text style={styles.fieldLabel}>Location</Text>
-            {locationGate === 'fallback' ? (
+            {renderFallbackPicker ? (
               <LocationFallbackPicker
                 selected={locationOverride}
-                onPick={(o) => setLocationOverride(o)}
+                pickedVia={locationOverridePickedVia}
+                onPick={(o, pickedVia) => setLocationOverride(o, pickedVia)}
                 onClear={() => setLocationOverride(null)}
               />
             ) : (

--- a/apps/citizen-mobile/app/(app)/compose/submit.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/submit.tsx
@@ -208,15 +208,19 @@ function SubmitScreenContent({
 /**
  * Narrow an arbitrary wire string (typically `preview.location.locationSource`
  * from the backend NLP extraction) to the SignalLocationSource allowlist.
- * Unknown values fall back to 'user_edit' so the server's allowlist guard
- * doesn't reject the submit; the happy path is always 'nlp' from the
- * backend today.
+ *
+ * The server now normalizes any unknown NLP-emitted value to `'nlp'` in
+ * SignalIngestionService.PreviewAsync, so in practice this shim is only
+ * exercised when a stale cached preview from an older client version
+ * survives. In that case the honest default is `'nlp'` — the preview is
+ * NLP-origin data by construction. Defaulting to `'user_edit'` (the
+ * prior behaviour) misattributed authorship to the user.
  */
 function narrowLocationSource(raw: string): SignalLocationSource {
   if (raw === 'nlp' || raw === 'user_edit' || raw === 'place_search') {
     return raw;
   }
-  return 'user_edit';
+  return 'nlp';
 }
 
 function Field({ label, value }: { label: string; value: string }): React.ReactElement {

--- a/apps/citizen-mobile/app/(app)/compose/submit.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/submit.tsx
@@ -7,23 +7,31 @@ import { ArrowLeft, Info } from 'lucide-react-native';
 import * as Crypto from 'expo-crypto';
 import * as Location from 'expo-location';
 import { submitSignal } from '../../../src/api/signals';
-import { useComposerContext } from '../../../src/context/ComposerContext';
+import {
+  useComposerContext,
+  type ComposerLocationOverride,
+} from '../../../src/context/ComposerContext';
 import { Button } from '../../../src/components/common/Button';
 import { formatCategoryLabel } from '../../../src/utils/formatters';
 import { Colors, FontFamily, FontSize, Spacing, Radius, ScreenPaddingH } from '../../../src/theme';
-import type { SignalSubmitRequest, SignalPreviewResponse } from '../../../src/types/api';
+import type {
+  SignalLocationSource,
+  SignalSubmitRequest,
+  SignalPreviewResponse,
+} from '../../../src/types/api';
 
 type ScreenState = 'idle' | 'loading' | 'error';
 
 export default function ComposerSubmitScreen(): React.ReactElement {
   const router = useRouter();
-  const { freeText, preview, deviceHash, reset } = useComposerContext();
+  const { freeText, preview, deviceHash, locationOverride, reset } = useComposerContext();
   if (preview === null) {
     return <PreviewMissingFallback onBack={() => router.replace('/(app)/compose/text')} />;
   }
   return (
     <SubmitScreenContent
       freeText={freeText} preview={preview} deviceHash={deviceHash}
+      locationOverride={locationOverride}
       onSuccess={(clusterId?: string) => {
         reset();
         if (clusterId) {
@@ -37,8 +45,14 @@ export default function ComposerSubmitScreen(): React.ReactElement {
 }
 
 function SubmitScreenContent({
-  freeText, preview, deviceHash, onSuccess,
-}: { freeText: string; preview: SignalPreviewResponse; deviceHash: string; onSuccess: (clusterId?: string) => void }): React.ReactElement {
+  freeText, preview, deviceHash, locationOverride, onSuccess,
+}: {
+  freeText: string;
+  preview: SignalPreviewResponse;
+  deviceHash: string;
+  locationOverride: ComposerLocationOverride | null;
+  onSuccess: (clusterId?: string) => void;
+}): React.ReactElement {
   const router = useRouter();
   const [screenState, setScreenState] = useState<ScreenState>('idle');
   const [errorMessage, setErrorMessage] = useState('');
@@ -47,22 +61,55 @@ function SubmitScreenContent({
     if (screenState === 'loading') return;
     setScreenState('loading');
     setErrorMessage('');
-    const { status } = await Location.requestForegroundPermissionsAsync();
-    let position: Location.LocationObject | null = null;
-    if (status === 'granted') {
-      try {
-        position = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
-      } catch {
+
+    // Resolve the authoritative submit coordinates + label + source.
+    //
+    // Path 1 — C11 fallback override: the user picked a PlaceCandidate in
+    // the confirm step (or tapped "use my current location"). Both coords
+    // and label come from the override and are considered authoritative;
+    // we deliberately skip the device-GPS capture here because the
+    // override's coordinates are what the user actually chose.
+    //
+    // Path 2 — default: device GPS provides coords; label + source come
+    // from the (possibly user-edited) NLP preview. Source is narrowed
+    // through the SignalLocationSource allowlist on the wire.
+    let submitLatitude: number;
+    let submitLongitude: number;
+    let submitLabel: string | undefined;
+    let submitSource: SignalLocationSource;
+
+    if (locationOverride !== null) {
+      submitLatitude = locationOverride.latitude;
+      submitLongitude = locationOverride.longitude;
+      submitLabel = locationOverride.label;
+      submitSource = locationOverride.source;
+    } else {
+      const { status } = await Location.requestForegroundPermissionsAsync();
+      let position: Location.LocationObject | null = null;
+      if (status === 'granted') {
+        try {
+          position = await Location.getCurrentPositionAsync({ accuracy: Location.Accuracy.Balanced });
+        } catch {
+          position = await Location.getLastKnownPositionAsync();
+        }
+      } else {
         position = await Location.getLastKnownPositionAsync();
       }
-    } else {
-      position = await Location.getLastKnownPositionAsync();
+      if (!position) {
+        setScreenState('error');
+        setErrorMessage('Could not determine location. Please enable location services and try again.');
+        return;
+      }
+      submitLatitude = position.coords.latitude;
+      submitLongitude = position.coords.longitude;
+      submitLabel = preview.location.locationLabel ?? undefined;
+      // Narrow the preview's raw string to the wire-allowlist union. If NLP
+      // ever reports a source we don't recognise we default to 'user_edit'
+      // so the backend doesn't reject the submit with
+      // validation.invalid_location_source.
+      submitSource = narrowLocationSource(preview.location.locationSource);
     }
-    if (!position) {
-      setScreenState('error');
-      setErrorMessage('Could not determine location. Please enable location services and try again.');
-      return;
-    }
+
     const idempotencyKey = await Crypto.digestStringAsync(
       Crypto.CryptoDigestAlgorithm.SHA256, `${freeText}:${Date.now()}`,
     );
@@ -72,12 +119,12 @@ function SubmitScreenContent({
       subcategorySlug: preview.subcategorySlug,
       conditionSlug: preview.conditionSlug ?? undefined,
       conditionConfidence: preview.conditionConfidence,
-      latitude: position.coords.latitude,
-      longitude: position.coords.longitude,
-      locationLabel: preview.location.locationLabel ?? undefined,
+      latitude: submitLatitude,
+      longitude: submitLongitude,
+      locationLabel: submitLabel,
       locationPrecisionType: preview.location.locationPrecisionType ?? undefined,
       locationConfidence: preview.location.locationConfidence,
-      locationSource: preview.location.locationSource,
+      locationSource: submitSource,
       temporalType: preview.temporalType ?? undefined,
       neutralSummary: preview.neutralSummary ?? undefined,
     };
@@ -114,8 +161,14 @@ function SubmitScreenContent({
         <View style={styles.card}>
           <Field label="Category" value={formatCategoryLabel(preview.category)} />
           <Field label="Subcategory" value={formatCategoryLabel(preview.subcategorySlug)} />
-          {preview.location.locationLabel !== null && preview.location.locationLabel !== '' && (
-            <Field label="Location" value={preview.location.locationLabel} />
+          {/* Override wins for display too — if the user picked in the
+              fallback picker, show that label instead of the stale NLP one. */}
+          {locationOverride !== null ? (
+            <Field label="Location" value={locationOverride.label} />
+          ) : (
+            preview.location.locationLabel !== null && preview.location.locationLabel !== '' && (
+              <Field label="Location" value={preview.location.locationLabel} />
+            )
           )}
           {preview.neutralSummary !== null && preview.neutralSummary !== '' && (
             <Field label="Summary" value={preview.neutralSummary} />
@@ -150,6 +203,20 @@ function SubmitScreenContent({
       </ScrollView>
     </SafeAreaView>
   );
+}
+
+/**
+ * Narrow an arbitrary wire string (typically `preview.location.locationSource`
+ * from the backend NLP extraction) to the SignalLocationSource allowlist.
+ * Unknown values fall back to 'user_edit' so the server's allowlist guard
+ * doesn't reject the submit; the happy path is always 'nlp' from the
+ * backend today.
+ */
+function narrowLocationSource(raw: string): SignalLocationSource {
+  if (raw === 'nlp' || raw === 'user_edit' || raw === 'place_search') {
+    return raw;
+  }
+  return 'user_edit';
 }
 
 function Field({ label, value }: { label: string; value: string }): React.ReactElement {

--- a/apps/citizen-mobile/src/api/places.ts
+++ b/apps/citizen-mobile/src/api/places.ts
@@ -1,0 +1,52 @@
+// apps/citizen-mobile/src/api/places.ts
+//
+// Low-confidence location fallback (C11).
+// Thin wrapper around /v1/places/search and /v1/places/reverse. These
+// endpoints are anonymous on the backend but the composer flow is always
+// authenticated; we still send the token via apiRequest for consistency.
+
+import { apiRequest } from './client';
+import type { ApiError, PlaceCandidate, Result } from '../types/api';
+
+/**
+ * GET /v1/places/search?q=
+ * Free-text place search → up to 5 candidates with coordinates + resolved
+ * Hali locality. Candidates outside known localities are filtered by the
+ * backend (spatial integrity), so every result is a valid submit target.
+ *
+ * Short queries (< 2 characters) and oversized queries (> 80) are rejected
+ * by the backend with 400. Callers should debounce and trim before invoking.
+ */
+export async function searchPlaces(
+  query: string,
+): Promise<Result<PlaceCandidate[], ApiError>> {
+  const q = encodeURIComponent(query.trim());
+  return apiRequest<PlaceCandidate[]>(`/v1/places/search?q=${q}`, {
+    method: 'GET',
+  });
+}
+
+/**
+ * GET /v1/places/reverse?latitude=&longitude=
+ * Reverse geocode a coordinate pair to a single PlaceCandidate with a
+ * human-readable label and the Hali locality the point falls inside.
+ *
+ * Returns 404 when the coordinates fall outside any known locality — the
+ * client should fall back to place-search in that case.
+ *
+ * Used by the "Use my current location" action in the composer's fallback
+ * picker.
+ */
+export async function reverseGeocodePoint(
+  latitude: number,
+  longitude: number,
+): Promise<Result<PlaceCandidate, ApiError>> {
+  const params = new URLSearchParams({
+    latitude: latitude.toString(),
+    longitude: longitude.toString(),
+  });
+  return apiRequest<PlaceCandidate>(
+    `/v1/places/reverse?${params.toString()}`,
+    { method: 'GET' },
+  );
+}

--- a/apps/citizen-mobile/src/components/compose/LocationFallbackPicker.tsx
+++ b/apps/citizen-mobile/src/components/compose/LocationFallbackPicker.tsx
@@ -1,0 +1,363 @@
+// apps/citizen-mobile/src/components/compose/LocationFallbackPicker.tsx
+//
+// C11 low-confidence location fallback UX.
+//
+// Rendered inside the composer's confirm screen (Step 2) when the server
+// flags the NLP extraction as low-confidence. Offers:
+//   1. Debounced place search (/v1/places/search) — up to 5 Hali-resolved
+//      candidates with ward context.
+//   2. "Use my current location" (expo-location + /v1/places/reverse) —
+//      one-tap capture of device GPS resolved to a civic label.
+//
+// Selecting either path produces a ComposerLocationOverride with
+// authoritative latitude / longitude / label / source. The component does
+// not itself call any composer-context setters — it reports the pick via
+// `onPick` so the parent screen can wire it into its own state machine
+// and keep the picker stateless from the context's perspective.
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  View,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  ActivityIndicator,
+} from 'react-native';
+import { MapPin, Navigation2, Search, X } from 'lucide-react-native';
+import * as Location from 'expo-location';
+import { searchPlaces, reverseGeocodePoint } from '../../api/places';
+import type {
+  ComposerLocationOverride,
+} from '../../context/ComposerContext';
+import type { PlaceCandidate } from '../../types/api';
+import {
+  Colors,
+  FontFamily,
+  FontSize,
+  Spacing,
+  Radius,
+} from '../../theme';
+
+export interface LocationFallbackPickerProps {
+  /**
+   * The picked override, if any. Rendering the "selected" state when
+   * non-null so the user sees their choice and can change it.
+   */
+  selected: ComposerLocationOverride | null;
+  onPick: (override: ComposerLocationOverride) => void;
+  onClear: () => void;
+}
+
+const SEARCH_DEBOUNCE_MS = 400;
+const MIN_QUERY_LENGTH = 2;
+
+export function LocationFallbackPicker({
+  selected,
+  onPick,
+  onClear,
+}: LocationFallbackPickerProps): React.ReactElement {
+  const [query, setQuery] = useState('');
+  const [candidates, setCandidates] = useState<PlaceCandidate[]>([]);
+  const [searching, setSearching] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
+
+  const [resolvingGps, setResolvingGps] = useState(false);
+  const [gpsError, setGpsError] = useState<string | null>(null);
+
+  // Debounced search. Every effect registration schedules the search and
+  // clears the previous pending timer; the cleanup also cancels in-flight
+  // requests when a newer query fires. This keeps the list consistent with
+  // whatever the user last typed and prevents ghost results after unmount.
+  const searchCounter = useRef(0);
+  useEffect(() => {
+    const trimmed = query.trim();
+    if (trimmed.length < MIN_QUERY_LENGTH) {
+      setCandidates([]);
+      setSearching(false);
+      setSearchError(null);
+      return;
+    }
+
+    const myTicket = ++searchCounter.current;
+    setSearching(true);
+    setSearchError(null);
+
+    const handle = setTimeout(async () => {
+      const res = await searchPlaces(trimmed);
+      // Stale response guard: a newer query has started, drop this one.
+      if (myTicket !== searchCounter.current) return;
+      setSearching(false);
+      if (res.ok) {
+        setCandidates(res.value);
+      } else {
+        setCandidates([]);
+        setSearchError('Search is temporarily unavailable.');
+      }
+    }, SEARCH_DEBOUNCE_MS);
+
+    return () => clearTimeout(handle);
+  }, [query]);
+
+  const handlePickCandidate = useCallback(
+    (c: PlaceCandidate) => {
+      onPick({
+        latitude: c.latitude,
+        longitude: c.longitude,
+        label: c.displayName,
+        source: 'place_search',
+      });
+      setQuery('');
+      setCandidates([]);
+    },
+    [onPick],
+  );
+
+  const handleUseCurrentLocation = useCallback(async () => {
+    if (resolvingGps) return;
+    setResolvingGps(true);
+    setGpsError(null);
+    try {
+      const perm = await Location.requestForegroundPermissionsAsync();
+      if (perm.status !== 'granted') {
+        setGpsError('Location permission is required to use your current location.');
+        return;
+      }
+      let point: Location.LocationObject | null = null;
+      try {
+        point = await Location.getCurrentPositionAsync({
+          accuracy: Location.Accuracy.Balanced,
+        });
+      } catch {
+        point = await Location.getLastKnownPositionAsync();
+      }
+      if (!point) {
+        setGpsError('Could not determine your current location.');
+        return;
+      }
+      const reverse = await reverseGeocodePoint(
+        point.coords.latitude,
+        point.coords.longitude,
+      );
+      if (!reverse.ok) {
+        if (reverse.error.status === 404) {
+          setGpsError('Your current location is outside known wards.');
+        } else {
+          setGpsError('Could not resolve your current location.');
+        }
+        return;
+      }
+      onPick({
+        latitude: reverse.value.latitude,
+        longitude: reverse.value.longitude,
+        label: reverse.value.displayName,
+        source: 'place_search',
+      });
+    } finally {
+      setResolvingGps(false);
+    }
+  }, [onPick, resolvingGps]);
+
+  if (selected !== null) {
+    return (
+      <View style={styles.selectedCard} accessibilityLiveRegion="polite">
+        <MapPin size={18} color={Colors.primary} strokeWidth={2} />
+        <View style={styles.selectedTextWrap}>
+          <Text style={styles.selectedLabel}>{selected.label}</Text>
+          <Text style={styles.selectedMeta}>
+            {selected.source === 'place_search'
+              ? 'Selected from place search'
+              : 'Current location'}
+          </Text>
+        </View>
+        <TouchableOpacity
+          onPress={onClear}
+          hitSlop={12}
+          accessibilityRole="button"
+          accessibilityLabel="Change location"
+        >
+          <X size={18} color={Colors.mutedForeground} strokeWidth={2} />
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.hint} accessibilityRole="alert">
+        We couldn&apos;t confidently identify the location. Help us confirm
+        where this is.
+      </Text>
+
+      <View style={styles.searchRow}>
+        <Search size={18} color={Colors.mutedForeground} strokeWidth={2} />
+        <TextInput
+          style={styles.searchInput}
+          value={query}
+          onChangeText={setQuery}
+          placeholder="Search for a place or landmark"
+          placeholderTextColor={Colors.faintForeground}
+          autoCapitalize="none"
+          autoCorrect={false}
+          accessibilityLabel="Search for a place"
+          accessibilityHint="Enter a road, landmark, or area name to see matching places"
+        />
+        {searching && (
+          <ActivityIndicator size="small" color={Colors.mutedForeground} />
+        )}
+      </View>
+
+      {searchError !== null && (
+        <Text style={styles.errorText} accessibilityRole="alert">
+          {searchError}
+        </Text>
+      )}
+
+      {candidates.length > 0 && (
+        <View style={styles.resultList} accessible accessibilityLabel="Place search results">
+          {candidates.map((c) => (
+            <TouchableOpacity
+              // Nominatim does not always return stable IDs; the
+              // (lat,lng,label) triple is unique enough for a 5-row list.
+              key={`${c.latitude}:${c.longitude}:${c.displayName}`}
+              style={styles.resultRow}
+              onPress={() => handlePickCandidate(c)}
+              accessibilityRole="button"
+              accessibilityLabel={`Select ${c.displayName}`}
+            >
+              <MapPin size={16} color={Colors.mutedForeground} strokeWidth={2} />
+              <View style={styles.resultTextWrap}>
+                <Text style={styles.resultTitle} numberOfLines={1}>
+                  {c.displayName}
+                </Text>
+                {c.wardName !== null && (
+                  <Text style={styles.resultMeta} numberOfLines={1}>
+                    {c.cityName !== null
+                      ? `${c.wardName}, ${c.cityName}`
+                      : c.wardName}
+                  </Text>
+                )}
+              </View>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+
+      <TouchableOpacity
+        style={styles.gpsButton}
+        onPress={handleUseCurrentLocation}
+        disabled={resolvingGps}
+        accessibilityRole="button"
+        accessibilityLabel="Use my current location"
+        accessibilityState={{ disabled: resolvingGps, busy: resolvingGps }}
+      >
+        {resolvingGps ? (
+          <ActivityIndicator size="small" color={Colors.primary} />
+        ) : (
+          <Navigation2 size={16} color={Colors.primary} strokeWidth={2} />
+        )}
+        <Text style={styles.gpsButtonText}>Use my current location</Text>
+      </TouchableOpacity>
+
+      {gpsError !== null && (
+        <Text style={styles.errorText} accessibilityRole="alert">
+          {gpsError}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { gap: Spacing.sm },
+  hint: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.destructive,
+  },
+  searchRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    borderWidth: 1.5,
+    borderColor: Colors.border,
+    borderRadius: Radius.md,
+    paddingHorizontal: Spacing.md,
+    backgroundColor: Colors.card,
+  },
+  searchInput: {
+    flex: 1,
+    paddingVertical: Spacing.md,
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.regular,
+    color: Colors.foreground,
+  },
+  resultList: {
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radius.md,
+    overflow: 'hidden',
+    backgroundColor: Colors.card,
+  },
+  resultRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+    paddingVertical: Spacing.md,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: Colors.border,
+  },
+  resultTextWrap: { flex: 1, gap: 2 },
+  resultTitle: {
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.medium,
+    color: Colors.foreground,
+  },
+  resultMeta: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+  },
+  gpsButton: {
+    alignSelf: 'flex-start',
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    backgroundColor: Colors.primarySubtle,
+    borderRadius: Radius.full,
+    paddingVertical: Spacing.sm,
+    paddingHorizontal: Spacing.md,
+  },
+  gpsButtonText: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.medium,
+    color: Colors.primary,
+  },
+  errorText: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.destructive,
+  },
+  selectedCard: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Spacing.sm,
+    borderWidth: 1,
+    borderColor: Colors.border,
+    borderRadius: Radius.md,
+    padding: Spacing.md,
+    backgroundColor: Colors.primarySubtle,
+  },
+  selectedTextWrap: { flex: 1, gap: 2 },
+  selectedLabel: {
+    fontSize: FontSize.body,
+    fontFamily: FontFamily.medium,
+    color: Colors.foreground,
+  },
+  selectedMeta: {
+    fontSize: FontSize.bodySmall,
+    fontFamily: FontFamily.regular,
+    color: Colors.mutedForeground,
+  },
+});

--- a/apps/citizen-mobile/src/components/compose/LocationFallbackPicker.tsx
+++ b/apps/citizen-mobile/src/components/compose/LocationFallbackPicker.tsx
@@ -39,13 +39,28 @@ import {
   Radius,
 } from '../../theme';
 
+/**
+ * UI-only record of which picker path produced the selected override.
+ * This is kept separate from {@link ComposerLocationOverride} because the
+ * wire `locationSource` enum is `'place_search'` for both paths (the label
+ * comes from the same backend geocoding service either way); `pickedVia`
+ * is purely for the selected-state subtitle copy and must not leak onto
+ * the wire.
+ */
+export type PickerPath = 'search' | 'current';
+
 export interface LocationFallbackPickerProps {
   /**
    * The picked override, if any. Rendering the "selected" state when
    * non-null so the user sees their choice and can change it.
    */
   selected: ComposerLocationOverride | null;
-  onPick: (override: ComposerLocationOverride) => void;
+  /**
+   * The UI-only path that produced {@link selected}. Controls the
+   * selected-state subtitle copy. Null when `selected` is null.
+   */
+  pickedVia: PickerPath | null;
+  onPick: (override: ComposerLocationOverride, pickedVia: PickerPath) => void;
   onClear: () => void;
 }
 
@@ -54,6 +69,7 @@ const MIN_QUERY_LENGTH = 2;
 
 export function LocationFallbackPicker({
   selected,
+  pickedVia,
   onPick,
   onClear,
 }: LocationFallbackPickerProps): React.ReactElement {
@@ -65,10 +81,25 @@ export function LocationFallbackPicker({
   const [resolvingGps, setResolvingGps] = useState(false);
   const [gpsError, setGpsError] = useState<string | null>(null);
 
+  // Unmount guard: searchPlaces / reverseGeocodePoint / expo-location
+  // calls can resolve after the picker is unmounted (component swapped
+  // out by the parent when the gate changes, or the user navigates
+  // back). Gating every async setState through this ref prevents
+  // "Can't perform a React state update on an unmounted component"
+  // warnings and ghost UI updates. The search-ticket counter below still
+  // handles stale responses *between* two different queries while the
+  // component is mounted.
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
   // Debounced search. Every effect registration schedules the search and
-  // clears the previous pending timer; the cleanup also cancels in-flight
-  // requests when a newer query fires. This keeps the list consistent with
-  // whatever the user last typed and prevents ghost results after unmount.
+  // clears the previous pending timer; a newer query's response wins
+  // thanks to the ticket counter.
   const searchCounter = useRef(0);
   useEffect(() => {
     const trimmed = query.trim();
@@ -85,7 +116,8 @@ export function LocationFallbackPicker({
 
     const handle = setTimeout(async () => {
       const res = await searchPlaces(trimmed);
-      // Stale response guard: a newer query has started, drop this one.
+      // Drop if: component unmounted OR a newer query has started.
+      if (!mountedRef.current) return;
       if (myTicket !== searchCounter.current) return;
       setSearching(false);
       if (res.ok) {
@@ -101,12 +133,15 @@ export function LocationFallbackPicker({
 
   const handlePickCandidate = useCallback(
     (c: PlaceCandidate) => {
-      onPick({
-        latitude: c.latitude,
-        longitude: c.longitude,
-        label: c.displayName,
-        source: 'place_search',
-      });
+      onPick(
+        {
+          latitude: c.latitude,
+          longitude: c.longitude,
+          label: c.displayName,
+          source: 'place_search',
+        },
+        'search',
+      );
       setQuery('');
       setCandidates([]);
     },
@@ -119,6 +154,7 @@ export function LocationFallbackPicker({
     setGpsError(null);
     try {
       const perm = await Location.requestForegroundPermissionsAsync();
+      if (!mountedRef.current) return;
       if (perm.status !== 'granted') {
         setGpsError('Location permission is required to use your current location.');
         return;
@@ -131,6 +167,7 @@ export function LocationFallbackPicker({
       } catch {
         point = await Location.getLastKnownPositionAsync();
       }
+      if (!mountedRef.current) return;
       if (!point) {
         setGpsError('Could not determine your current location.');
         return;
@@ -139,6 +176,7 @@ export function LocationFallbackPicker({
         point.coords.latitude,
         point.coords.longitude,
       );
+      if (!mountedRef.current) return;
       if (!reverse.ok) {
         if (reverse.error.status === 404) {
           setGpsError('Your current location is outside known wards.');
@@ -147,28 +185,36 @@ export function LocationFallbackPicker({
         }
         return;
       }
-      onPick({
-        latitude: reverse.value.latitude,
-        longitude: reverse.value.longitude,
-        label: reverse.value.displayName,
-        source: 'place_search',
-      });
+      onPick(
+        {
+          latitude: reverse.value.latitude,
+          longitude: reverse.value.longitude,
+          label: reverse.value.displayName,
+          source: 'place_search',
+        },
+        'current',
+      );
     } finally {
-      setResolvingGps(false);
+      if (mountedRef.current) setResolvingGps(false);
     }
   }, [onPick, resolvingGps]);
 
   if (selected !== null) {
+    // Subtitle copy is driven by the UI-only pickedVia flag, not the
+    // wire `source` (which is 'place_search' for both paths). pickedVia
+    // can be null when the parent restored a selection without an
+    // explicit path (e.g. after a remount) — fall back to the neutral
+    // "place search" copy in that case.
+    const subtitle =
+      pickedVia === 'current'
+        ? 'Current location'
+        : 'Selected from place search';
     return (
       <View style={styles.selectedCard} accessibilityLiveRegion="polite">
         <MapPin size={18} color={Colors.primary} strokeWidth={2} />
         <View style={styles.selectedTextWrap}>
           <Text style={styles.selectedLabel}>{selected.label}</Text>
-          <Text style={styles.selectedMeta}>
-            {selected.source === 'place_search'
-              ? 'Selected from place search'
-              : 'Current location'}
-          </Text>
+          <Text style={styles.selectedMeta}>{subtitle}</Text>
         </View>
         <TouchableOpacity
           onPress={onClear}

--- a/apps/citizen-mobile/src/context/ComposerContext.tsx
+++ b/apps/citizen-mobile/src/context/ComposerContext.tsx
@@ -24,17 +24,31 @@ export interface ComposerLocationOverride {
   source: SignalLocationSource;
 }
 
+/**
+ * UI-only record of which fallback-picker path produced the current
+ * `locationOverride`. Kept here (and not on the override itself) so the
+ * wire `locationSource` stays a single value ('place_search') for both
+ * paths — `pickedVia` only drives the composer's selected-state subtitle
+ * copy ("Current location" vs "Selected from place search") and never
+ * leaves the client.
+ */
+export type LocationOverridePickedVia = 'search' | 'current';
+
 interface ComposerContextValue {
   freeText: string;
   locationHint: string | undefined;
   preview: SignalPreviewResponse | null;
   deviceHash: string;
   locationOverride: ComposerLocationOverride | null;
+  locationOverridePickedVia: LocationOverridePickedVia | null;
   setFreeText: (v: string) => void;
   setLocationHint: (v: string | undefined) => void;
   setPreview: (p: SignalPreviewResponse | null) => void;
   setDeviceHash: (h: string) => void;
-  setLocationOverride: (o: ComposerLocationOverride | null) => void;
+  setLocationOverride: (
+    o: ComposerLocationOverride | null,
+    pickedVia?: LocationOverridePickedVia | null,
+  ) => void;
   reset: () => void;
 }
 
@@ -45,14 +59,28 @@ export function ComposerProvider({ children }: { children: React.ReactNode }) {
   const [locationHint, setLocationHint] = useState<string | undefined>();
   const [preview, setPreview] = useState<SignalPreviewResponse | null>(null);
   const [deviceHash, setDeviceHash] = useState('');
-  const [locationOverride, setLocationOverride] =
+  const [locationOverride, setLocationOverrideState] =
     useState<ComposerLocationOverride | null>(null);
+  const [locationOverridePickedVia, setLocationOverridePickedVia] =
+    useState<LocationOverridePickedVia | null>(null);
+
+  const setLocationOverride = useCallback(
+    (
+      o: ComposerLocationOverride | null,
+      pickedVia: LocationOverridePickedVia | null = null,
+    ) => {
+      setLocationOverrideState(o);
+      setLocationOverridePickedVia(o === null ? null : pickedVia);
+    },
+    [],
+  );
 
   const reset = useCallback(() => {
     setFreeText('');
     setLocationHint(undefined);
     setPreview(null);
-    setLocationOverride(null);
+    setLocationOverrideState(null);
+    setLocationOverridePickedVia(null);
   }, []);
 
   return (
@@ -63,6 +91,7 @@ export function ComposerProvider({ children }: { children: React.ReactNode }) {
         preview,
         deviceHash,
         locationOverride,
+        locationOverridePickedVia,
         setFreeText,
         setLocationHint,
         setPreview,

--- a/apps/citizen-mobile/src/context/ComposerContext.tsx
+++ b/apps/citizen-mobile/src/context/ComposerContext.tsx
@@ -1,15 +1,40 @@
 import React, { createContext, useContext, useState, useCallback } from 'react';
-import type { SignalPreviewResponse } from '../types/api';
+import type { SignalLocationSource, SignalPreviewResponse } from '../types/api';
+
+/**
+ * Authoritative coordinates + label produced by the C11 low-confidence
+ * location fallback picker. When present on the composer draft, the
+ * submit screen uses these values instead of the device-GPS coordinates
+ * and the NLP-derived label.
+ *
+ * Set when:
+ *   - the user picks a PlaceCandidate from /v1/places/search → source = 'place_search'
+ *   - the user taps "Use my current location" → source = 'place_search'
+ *     (the label comes from /v1/places/reverse, i.e. the same backend
+ *     geocoding service; the coordinates are device GPS but treated as
+ *     authoritative because the user deliberately chose them)
+ *
+ * NOT set when the user merely edits the text label inline — that path
+ * stays on source='user_edit' with device-GPS coordinates on submit.
+ */
+export interface ComposerLocationOverride {
+  latitude: number;
+  longitude: number;
+  label: string;
+  source: SignalLocationSource;
+}
 
 interface ComposerContextValue {
   freeText: string;
   locationHint: string | undefined;
   preview: SignalPreviewResponse | null;
   deviceHash: string;
+  locationOverride: ComposerLocationOverride | null;
   setFreeText: (v: string) => void;
   setLocationHint: (v: string | undefined) => void;
   setPreview: (p: SignalPreviewResponse | null) => void;
   setDeviceHash: (h: string) => void;
+  setLocationOverride: (o: ComposerLocationOverride | null) => void;
   reset: () => void;
 }
 
@@ -20,11 +45,14 @@ export function ComposerProvider({ children }: { children: React.ReactNode }) {
   const [locationHint, setLocationHint] = useState<string | undefined>();
   const [preview, setPreview] = useState<SignalPreviewResponse | null>(null);
   const [deviceHash, setDeviceHash] = useState('');
+  const [locationOverride, setLocationOverride] =
+    useState<ComposerLocationOverride | null>(null);
 
   const reset = useCallback(() => {
     setFreeText('');
     setLocationHint(undefined);
     setPreview(null);
+    setLocationOverride(null);
   }, []);
 
   return (
@@ -34,10 +62,12 @@ export function ComposerProvider({ children }: { children: React.ReactNode }) {
         locationHint,
         preview,
         deviceHash,
+        locationOverride,
         setFreeText,
         setLocationHint,
         setPreview,
         setDeviceHash,
+        setLocationOverride,
         reset,
       }}
     >

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -237,7 +237,10 @@ export interface SignalLocation {
   locationLabel: string | null;
   locationPrecisionType: string | null;
   locationConfidence: number;
-  locationSource: string;
+  // Narrowed to the canonical wire allowlist (C11). The backend
+  // normalizes any unknown NLP-emitted value to 'nlp' in
+  // SignalIngestionService.PreviewAsync, so this union is safe on read.
+  locationSource: SignalLocationSource;
 }
 
 export interface SignalPreviewRequest {

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -218,6 +218,16 @@ export type HomeSectionName =
 
 // ─── Signals ──────────────────────────────────────────────────────────────────
 
+/**
+ * Canonical LocationSource wire values (C11). Must stay in sync with
+ * Hali.Contracts.Signals.LocationSource (C#) and the LocationSource enum
+ * in 02_openapi.yaml.
+ *
+ * The draggable map-pin fallback ('map_pin') is intentionally deferred to
+ * a follow-up — do not add it to this union until that surface ships.
+ */
+export type SignalLocationSource = 'nlp' | 'user_edit' | 'place_search';
+
 export interface SignalLocation {
   areaName: string | null;
   roadName: string | null;
@@ -249,6 +259,13 @@ export interface SignalPreviewResponse {
   temporalType: string | null;
   neutralSummary: string | null;
   shouldSuggestJoin: boolean;
+  /**
+   * Server-authoritative flag: when true the composer MUST route the user
+   * into the low-confidence fallback picker (place search / current
+   * location) before allowing submit. See C11 and backend
+   * LocationFallbackPolicy.
+   */
+  requiresLocationFallback: boolean;
 }
 
 export interface SignalSubmitRequest {
@@ -264,10 +281,27 @@ export interface SignalSubmitRequest {
   locationLabel?: string;
   locationPrecisionType?: string;
   locationConfidence: number;
-  locationSource: string;
+  locationSource: SignalLocationSource;
   temporalType?: string;
   neutralSummary?: string;
   sourceLanguage?: string;
+}
+
+/**
+ * A single geocoding candidate returned by /v1/places/search and
+ * /v1/places/reverse. Matches Hali.Contracts.Signals.PlaceCandidateDto.
+ *
+ * When the user selects a PlaceCandidate in the composer's fallback
+ * picker, latitude/longitude become authoritative submit coordinates
+ * and displayName becomes the submitted locationLabel.
+ */
+export interface PlaceCandidate {
+  displayName: string;
+  latitude: number;
+  longitude: number;
+  localityId: string | null;
+  wardName: string | null;
+  cityName: string | null;
 }
 
 /**

--- a/apps/citizen-mobile/src/utils/composerGates.ts
+++ b/apps/citizen-mobile/src/utils/composerGates.ts
@@ -18,16 +18,76 @@ import {
 } from '../config/constants';
 
 /**
- * Three-tier confidence gate:
- *   'required' — confidence below WARN: user MUST take action
- *   'confirm'  — confidence between WARN and AMBER: user confirms or edits
- *   'accept'   — confidence at or above AMBER: no action required
+ * Four-tier location confidence gate.
+ *
+ * For location, 'fallback' replaces the old 'required' tier whenever the
+ * backend flags the preview as needing correction OR when a client-side
+ * derivation of the same rule fires (low numeric confidence OR blank label).
+ * Rendering 'fallback' should route the user into the place-search /
+ * current-location picker UX, not just display a plain text-input warning.
+ *
+ *   'fallback'  — correction required; render LocationFallbackPicker
+ *   'confirm'   — amber: user confirms or edits the pre-filled label
+ *   'accept'    — high-confidence; no action required
+ *
+ * 'required' is preserved in the type union for non-location gates (the
+ * condition gate below still uses it) and for backwards compatibility with
+ * tests that predate C11. classifyLocationGate never returns 'required' —
+ * what was previously 'required' is now 'fallback'.
  */
-export type ConfidenceGate = 'required' | 'confirm' | 'accept';
+export type ConfidenceGate = 'required' | 'confirm' | 'accept' | 'fallback';
 
-export function classifyLocationGate(confidence: number): ConfidenceGate {
-  if (confidence < LOCATION_CONFIDENCE_WARN_THRESHOLD) return 'required';
-  if (confidence < LOCATION_CONFIDENCE_AMBER_THRESHOLD) return 'confirm';
+export interface LocationGateInput {
+  confidence: number;
+  /** Server-authoritative flag from SignalPreviewResponse. When present it wins. */
+  requiresFallback?: boolean;
+  /** The NLP-extracted label (or current edited value). Blank/whitespace-only labels are treated as low-trust even at high numeric confidence. */
+  label?: string | null;
+}
+
+/**
+ * Classify a location-confidence score into a UI gate tier.
+ *
+ * The legacy single-number signature is preserved for existing tests:
+ *   classifyLocationGate(0.9)
+ *
+ * The C11 signature threads through the server flag and the current label:
+ *   classifyLocationGate({ confidence, requiresFallback, label })
+ *
+ * Rule (mirrors server-side LocationFallbackPolicy):
+ *   - If the server flag is true → 'fallback'
+ *   - Else if confidence < WARN → 'fallback'
+ *   - Else if label is blank/whitespace → 'fallback'
+ *   - Else if confidence < AMBER → 'confirm'
+ *   - Else → 'accept'
+ */
+export function classifyLocationGate(
+  input: number | LocationGateInput,
+): ConfidenceGate {
+  const normalized: LocationGateInput =
+    typeof input === 'number' ? { confidence: input } : input;
+
+  // Server wins when it has spoken.
+  if (normalized.requiresFallback === true) return 'fallback';
+
+  if (normalized.confidence < LOCATION_CONFIDENCE_WARN_THRESHOLD) {
+    return 'fallback';
+  }
+
+  // Only enforce the label check when the caller supplied a label argument
+  // at all — legacy callers that pass a bare number keep their existing
+  // behaviour (confidence-only tier selection).
+  if (
+    normalized.label !== undefined &&
+    (normalized.label === null || normalized.label.trim().length === 0)
+  ) {
+    return 'fallback';
+  }
+
+  if (normalized.confidence < LOCATION_CONFIDENCE_AMBER_THRESHOLD) {
+    return 'confirm';
+  }
+
   return 'accept';
 }
 

--- a/apps/citizen-mobile/src/utils/composerGates.ts
+++ b/apps/citizen-mobile/src/utils/composerGates.ts
@@ -103,3 +103,69 @@ export function classifyConditionGate(confidence: number): ConfidenceGate {
   if (confidence < CONDITION_CONFIDENCE_AMBER_THRESHOLD) return 'confirm';
   return 'accept';
 }
+
+/**
+ * Inputs to {@link canProceedFromLocationGate}. Mirrors the state the
+ * composer's Step 2 carries internally (text-input value + the original
+ * NLP label + whether the user tapped "Looks right" + whether the
+ * picker produced an override).
+ */
+export interface LocationProceedInput {
+  /** Gate currently classifying the location state. */
+  gate: ConfidenceGate;
+  /** True when an authoritative override has been picked via the fallback picker. */
+  hasOverride: boolean;
+  /** Current value of the text-input label (confirm / accept tiers only). */
+  label: string;
+  /** The NLP-extracted label the preview first showed; used to detect user edits. */
+  originalLabel: string | null | undefined;
+  /** True after the user taps "Looks right" on the amber 'confirm' tier. */
+  confirmed: boolean;
+}
+
+/**
+ * Whether the composer's "Next" button should be enabled given the
+ * current location state.
+ *
+ * Pure function — extracted from confirm.tsx so the fallback/override
+ * interaction can be unit-tested without loading React Native.
+ *
+ * Semantics:
+ *   - 'accept'   — no action needed, always proceed.
+ *   - 'confirm'  — user must tap "Looks right" OR edit the label to something
+ *                  non-empty and different from the NLP suggestion.
+ *   - 'fallback' — picker is the ONLY authoritative correction. An
+ *                  override MUST be present. The stale NLP label sitting in
+ *                  the text-input state (which is not even rendered in
+ *                  fallback mode) is explicitly NOT sufficient to proceed.
+ *   - 'required' — reserved for the condition gate; not emitted by
+ *                  classifyLocationGate, but the switch handles it
+ *                  defensively.
+ */
+export function canProceedFromLocationGate(input: LocationProceedInput): boolean {
+  // Override path: an authoritative pick from the fallback picker stands
+  // on its own regardless of gate.
+  if (input.hasOverride) return true;
+
+  const trimmed = input.label.trim();
+  const original = (input.originalLabel ?? '').trim();
+  const userEdited = trimmed !== original && trimmed.length > 0;
+
+  switch (input.gate) {
+    case 'accept':
+      return true;
+    case 'confirm':
+      return input.confirmed || userEdited;
+    case 'fallback':
+      // Correction is REQUIRED and the picker is the only valid correction
+      // surface — the text input is not rendered in this tier. The stale
+      // NLP label in `label` state must not be treated as user intent.
+      // (Without this guard, a preview with a non-empty NLP label and
+      // confidence < 0.5 silently bypasses the fallback gate.)
+      return false;
+    case 'required':
+      // Not emitted for the location gate today (kept in the union for
+      // the condition gate). Treat defensively as "requires a label".
+      return trimmed.length > 0;
+  }
+}

--- a/src/Hali.Api/Controllers/PlacesController.cs
+++ b/src/Hali.Api/Controllers/PlacesController.cs
@@ -191,52 +191,78 @@ public class PlacesController : ControllerBase
             return StatusCode(StatusCodes.Status429TooManyRequests, new { error = "Too many requests.", code = "rate_limited" });
         }
 
-        // Quantize the cache key so small GPS jitter hits the same cache entry
-        // (~11m at 4 decimal places near the equator). Nominatim TOS is also
-        // happier when we don't fan out unique keys per millidegree.
-        string cacheKey = string.Format(
-            System.Globalization.CultureInfo.InvariantCulture,
-            "places_reverse:{0:F4}:{1:F4}",
-            latitude,
-            longitude);
-        RedisValue cached = await _redis.StringGetAsync(cacheKey);
-        if (cached.HasValue)
-        {
-            try
-            {
-                var hit = JsonSerializer.Deserialize<PlaceCandidateDto>((string)cached!, _cacheJsonOptions);
-                if (hit is not null)
-                {
-                    return Ok(hit);
-                }
-            }
-            catch
-            {
-                // fall through to live fetch
-            }
-        }
-
+        // Spatial integrity: always resolve locality FRESH for the caller's
+        // coordinates before consulting the label cache. The previous design
+        // (cache the full PlaceCandidateDto keyed by {lat:F4}:{lng:F4})
+        // allowed two callers whose points rounded into the same 4dp bucket
+        // (~11m at the equator) to share a cached response — which, for a
+        // ward-boundary bucket or a bucket that straddled the edge of known
+        // coverage, could
+        //   (a) return a neighbor's locality to a caller whose point was
+        //       outside every Hali locality (bypass of the locality guard),
+        //   (b) return a neighbor's wardName / cityName / localityId across
+        //       a ward boundary, and
+        //   (c) return a neighbor's lat/lng instead of the caller's own.
+        // We now always call FindByPointAsync on the caller's coordinates
+        // and only cache the reverse-geocoded label string (the expensive
+        // Nominatim call). The response is rebuilt from the caller's
+        // coordinates + the caller's fresh locality every time.
         LocalitySummary? locality = await _localities.FindByPointAsync(latitude, longitude, ct);
         if (locality is null)
         {
             return NotFound(new { error = "No locality found for the given coordinates.", code = "locality_not_found" });
         }
 
-        GeocodingResult? reverse;
-        try
+        // Label-only cache. Keyed by quantized coords AND the resolved
+        // localityId so a same-bucket cross-locality hit cannot serve a
+        // neighbour's Nominatim label (which typically embeds the ward
+        // name in its free-form string). Value is the already-trimmed
+        // display name or null-sentinel when Nominatim returned nothing.
+        string labelCacheKey = string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "places_reverse_label:{0:F4}:{1:F4}:{2}",
+            latitude,
+            longitude,
+            locality.Id);
+
+        string? label = null;
+        RedisValue cachedLabel = await _redis.StringGetAsync(labelCacheKey);
+        if (cachedLabel.HasValue)
         {
-            reverse = await _geocoding.ReverseGeocodeAsync(latitude, longitude, ct);
+            string raw = (string)cachedLabel!;
+            if (!string.IsNullOrEmpty(raw))
+            {
+                label = raw;
+            }
         }
-        catch (Exception ex) when (ex is not OperationCanceledException)
+
+        if (label is null)
         {
-            _logger.LogWarning(ex, "Reverse geocode failed (coordinates redacted)");
-            reverse = null;
+            GeocodingResult? reverse;
+            try
+            {
+                reverse = await _geocoding.ReverseGeocodeAsync(latitude, longitude, ct);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "Reverse geocode failed (coordinates redacted)");
+                reverse = null;
+            }
+
+            label = TrimDisplayName(reverse?.DisplayName);
+            if (!string.IsNullOrEmpty(label))
+            {
+                // Only cache when we have a real Nominatim label. Skipping
+                // the write on a null/empty label avoids pinning a failed
+                // lookup for the full TTL; the fallback label is cheap to
+                // rebuild from the fresh locality each call.
+                await _redis.StringSetAsync(labelCacheKey, label, ReverseCacheTtl);
+            }
         }
 
         PlaceCandidateDto result = new PlaceCandidateDto
         {
-            DisplayName = TrimDisplayName(reverse?.DisplayName)
-                ?? BuildFallbackLabel(locality),
+            DisplayName = !string.IsNullOrEmpty(label) ? label : BuildFallbackLabel(locality),
             Latitude = latitude,
             Longitude = longitude,
             LocalityId = locality.Id,
@@ -244,7 +270,6 @@ public class PlacesController : ControllerBase
             CityName = locality.CityName,
         };
 
-        await _redis.StringSetAsync(cacheKey, JsonSerializer.Serialize(result, _cacheJsonOptions), ReverseCacheTtl);
         return Ok(result);
     }
 

--- a/src/Hali.Api/Controllers/PlacesController.cs
+++ b/src/Hali.Api/Controllers/PlacesController.cs
@@ -1,0 +1,275 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Auth;
+using Hali.Application.Signals;
+using Hali.Contracts.Signals;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Hali.Api.Controllers;
+
+/// <summary>
+/// Low-confidence location fallback endpoints backing the C11 place-search
+/// and current-location correction flows in the mobile composer.
+///
+/// These endpoints are anonymous because they run during signal composition
+/// (the user may not yet be authenticated) and because they only return
+/// information that is already public (OSM place data + Hali ward boundaries).
+/// They are rate-limited per client IP to bound DoS surface on the upstream
+/// Nominatim dependency and cached in Redis to keep hot queries cheap.
+///
+/// Spatial integrity: candidates whose coordinates fall outside any known
+/// Hali locality are filtered out here so that the composer cannot surface a
+/// selection the backend would later reject at <c>SubmitAsync</c>'s
+/// <c>validation.locality_unresolved</c> check.
+/// </summary>
+[ApiController]
+[Route("v1/places")]
+[AllowAnonymous]
+public class PlacesController : ControllerBase
+{
+    private readonly IGeocodingService _geocoding;
+    private readonly ILocalityLookupRepository _localities;
+    private readonly IDatabase _redis;
+    private readonly IRateLimiter _rateLimiter;
+    private readonly ILogger<PlacesController> _logger;
+
+    private readonly JsonSerializerOptions _cacheJsonOptions;
+
+    private const int MaxSearchQueryLength = 80;
+    private const int MaxResults = 5;
+    private const int RateLimitMaxRequests = 30;
+    private static readonly TimeSpan RateLimitWindow = TimeSpan.FromMinutes(1);
+    private static readonly TimeSpan SearchCacheTtl = TimeSpan.FromHours(1);
+    private static readonly TimeSpan ReverseCacheTtl = TimeSpan.FromDays(1);
+
+    public PlacesController(
+        IGeocodingService geocoding,
+        ILocalityLookupRepository localities,
+        IDatabase redis,
+        IRateLimiter rateLimiter,
+        IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> mvcJsonOptions,
+        ILogger<PlacesController> logger)
+    {
+        _geocoding = geocoding;
+        _localities = localities;
+        _redis = redis;
+        _rateLimiter = rateLimiter;
+        _cacheJsonOptions = mvcJsonOptions.Value.JsonSerializerOptions;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// GET /v1/places/search?q=...
+    /// Forward geocode a free-text place query into up to 5 candidate places,
+    /// each with coordinates and the Hali locality they fall inside. Used by
+    /// the composer's low-confidence fallback picker.
+    /// </summary>
+    [HttpGet("search")]
+    [ProducesResponseType(typeof(IEnumerable<PlaceCandidateDto>), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    public async Task<IActionResult> Search([FromQuery] string q, CancellationToken ct)
+    {
+        if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
+        {
+            return BadRequest(new { error = "Query must be at least 2 characters.", code = "query_too_short" });
+        }
+
+        string query = q.Trim();
+        if (query.Length > MaxSearchQueryLength)
+        {
+            return BadRequest(new { error = $"Query must be at most {MaxSearchQueryLength} characters.", code = "query_too_long" });
+        }
+
+        string clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        string rateKey = $"ratelimit:places_search:{clientIp}";
+        bool allowed = await _rateLimiter.IsAllowedAsync(rateKey, RateLimitMaxRequests, RateLimitWindow, ct);
+        if (!allowed)
+        {
+            return StatusCode(StatusCodes.Status429TooManyRequests, new { error = "Too many requests.", code = "rate_limited" });
+        }
+
+        string cacheKey = $"places_search:{query.ToLowerInvariant()}";
+        RedisValue cached = await _redis.StringGetAsync(cacheKey);
+        if (cached.HasValue)
+        {
+            try
+            {
+                var hit = JsonSerializer.Deserialize<List<PlaceCandidateDto>>((string)cached!, _cacheJsonOptions);
+                if (hit is not null)
+                {
+                    return Ok(hit);
+                }
+            }
+            catch
+            {
+                // fall through to live fetch
+            }
+        }
+
+        IReadOnlyList<GeocodingCandidate> candidates;
+        try
+        {
+            candidates = await _geocoding.SearchAsync(query, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Place search geocoding failed (query length={QueryLength})", query.Length);
+            return Ok(Array.Empty<PlaceCandidateDto>());
+        }
+
+        List<PlaceCandidateDto> results = new List<PlaceCandidateDto>(MaxResults);
+        foreach (GeocodingCandidate c in candidates)
+        {
+            LocalitySummary? locality = await _localities.FindByPointAsync(c.Latitude, c.Longitude, ct);
+            if (locality is null)
+            {
+                continue;
+            }
+
+            results.Add(new PlaceCandidateDto
+            {
+                // c.DisplayName is guaranteed non-null by the upstream
+                // NominatimGeocodingService parser (rows with missing
+                // display_name are dropped). TrimDisplayName only returns
+                // null for null input, so the coalesce is defensive.
+                DisplayName = TrimDisplayName(c.DisplayName) ?? c.DisplayName,
+                Latitude = c.Latitude,
+                Longitude = c.Longitude,
+                LocalityId = locality.Id,
+                WardName = locality.WardName,
+                CityName = locality.CityName,
+            });
+
+            if (results.Count >= MaxResults)
+            {
+                break;
+            }
+        }
+
+        await _redis.StringSetAsync(cacheKey, JsonSerializer.Serialize(results, _cacheJsonOptions), SearchCacheTtl);
+        return Ok(results);
+    }
+
+    /// <summary>
+    /// GET /v1/places/reverse?latitude=...&amp;longitude=...
+    /// Reverse geocode a coordinate pair into a single place candidate with
+    /// a human-readable label and the Hali locality the point falls inside.
+    /// Used by the composer's "use my current location" fallback action.
+    /// Returns 404 when the coordinates are outside any known locality —
+    /// the client should fall back to place-search in that case.
+    /// </summary>
+    [HttpGet("reverse")]
+    [ProducesResponseType(typeof(PlaceCandidateDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status404NotFound)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+    public async Task<IActionResult> Reverse(
+        [FromQuery] double latitude,
+        [FromQuery] double longitude,
+        CancellationToken ct)
+    {
+        if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)
+        {
+            return BadRequest(new { error = "Invalid coordinates.", code = "invalid_coordinates" });
+        }
+
+        string clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        string rateKey = $"ratelimit:places_reverse:{clientIp}";
+        bool allowed = await _rateLimiter.IsAllowedAsync(rateKey, RateLimitMaxRequests, RateLimitWindow, ct);
+        if (!allowed)
+        {
+            return StatusCode(StatusCodes.Status429TooManyRequests, new { error = "Too many requests.", code = "rate_limited" });
+        }
+
+        // Quantize the cache key so small GPS jitter hits the same cache entry
+        // (~11m at 4 decimal places near the equator). Nominatim TOS is also
+        // happier when we don't fan out unique keys per millidegree.
+        string cacheKey = string.Format(
+            System.Globalization.CultureInfo.InvariantCulture,
+            "places_reverse:{0:F4}:{1:F4}",
+            latitude,
+            longitude);
+        RedisValue cached = await _redis.StringGetAsync(cacheKey);
+        if (cached.HasValue)
+        {
+            try
+            {
+                var hit = JsonSerializer.Deserialize<PlaceCandidateDto>((string)cached!, _cacheJsonOptions);
+                if (hit is not null)
+                {
+                    return Ok(hit);
+                }
+            }
+            catch
+            {
+                // fall through to live fetch
+            }
+        }
+
+        LocalitySummary? locality = await _localities.FindByPointAsync(latitude, longitude, ct);
+        if (locality is null)
+        {
+            return NotFound(new { error = "No locality found for the given coordinates.", code = "locality_not_found" });
+        }
+
+        GeocodingResult? reverse;
+        try
+        {
+            reverse = await _geocoding.ReverseGeocodeAsync(latitude, longitude, ct);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Reverse geocode failed (coordinates redacted)");
+            reverse = null;
+        }
+
+        PlaceCandidateDto result = new PlaceCandidateDto
+        {
+            DisplayName = TrimDisplayName(reverse?.DisplayName)
+                ?? BuildFallbackLabel(locality),
+            Latitude = latitude,
+            Longitude = longitude,
+            LocalityId = locality.Id,
+            WardName = locality.WardName,
+            CityName = locality.CityName,
+        };
+
+        await _redis.StringSetAsync(cacheKey, JsonSerializer.Serialize(result, _cacheJsonOptions), ReverseCacheTtl);
+        return Ok(result);
+    }
+
+    // Nominatim display_name is a long comma-joined string. Keep the first
+    // two segments which give the area + city context. Mirrors the helper
+    // in LocalitiesController; kept locally to avoid coupling two controllers
+    // through a new shared utility for two call sites.
+    private static string? TrimDisplayName(string? raw)
+    {
+        if (string.IsNullOrEmpty(raw))
+        {
+            return null;
+        }
+
+        string[] parts = raw.Split(',', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+        return parts.Length <= 2 ? raw : string.Join(", ", parts.Take(2));
+    }
+
+    private static string BuildFallbackLabel(LocalitySummary locality)
+    {
+        if (!string.IsNullOrWhiteSpace(locality.CityName))
+        {
+            return $"{locality.WardName}, {locality.CityName}";
+        }
+
+        return locality.WardName;
+    }
+}

--- a/src/Hali.Application/Signals/LocationFallbackPolicy.cs
+++ b/src/Hali.Application/Signals/LocationFallbackPolicy.cs
@@ -1,0 +1,48 @@
+namespace Hali.Application.Signals;
+
+/// <summary>
+/// Single source of truth for whether an NLP-extracted location is too
+/// weak to proceed without user correction.
+///
+/// Historically the composer's three-tier gate (required / confirm / accept)
+/// lived only on the mobile client, which meant any second client would have
+/// to re-derive the same thresholds. C11 centralizes the decision here so
+/// that the <c>SignalPreviewResponseDto.RequiresLocationFallback</c> flag
+/// is authoritative — the client still has a defensive client-side mirror
+/// for offline / degraded network conditions, but the server decision wins
+/// when it is available.
+///
+/// The rule is intentionally conservative: a high numeric confidence
+/// paired with a blank label still fails the gate, because a label-less
+/// extraction is not usable as a human-readable civic label even if the
+/// model self-reports high confidence.
+/// </summary>
+public static class LocationFallbackPolicy
+{
+    /// <summary>
+    /// Confidence strictly below this threshold is treated as low-confidence
+    /// and triggers the fallback path. Mirrors the mobile
+    /// <c>LOCATION_CONFIDENCE_WARN_THRESHOLD</c>.
+    /// </summary>
+    public const double LowConfidenceThreshold = 0.5;
+
+    public static bool RequiresFallback(NlpLocationDto location)
+    {
+        if (location is null)
+        {
+            return true;
+        }
+
+        if (location.LocationConfidence < LowConfidenceThreshold)
+        {
+            return true;
+        }
+
+        if (string.IsNullOrWhiteSpace(location.LocationLabel))
+        {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Hali.Application/Signals/LocationFallbackPolicy.cs
+++ b/src/Hali.Application/Signals/LocationFallbackPolicy.cs
@@ -28,10 +28,9 @@ public static class LocationFallbackPolicy
 
     public static bool RequiresFallback(NlpLocationDto location)
     {
-        if (location is null)
-        {
-            return true;
-        }
+        // `location` is non-nullable on `NlpExtractionResultDto.Location`
+        // so we don't guard against null here — that would be a caller bug,
+        // not a fallback trigger.
 
         if (location.LocationConfidence < LowConfidenceThreshold)
         {

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -58,6 +58,15 @@ public class SignalIngestionService : ISignalIngestionService
             throw new ValidationException("NLP returned an unrecognised category.", code: "validation.invalid_category");
         }
         bool requiresLocationFallback = LocationFallbackPolicy.RequiresFallback(result.Location);
+        // C11: normalize the NLP-emitted locationSource through the
+        // LocationSource allowlist before exposing it on the wire. The
+        // OpenAPI `LocationSource` enum is tight, so an unexpected NLP
+        // value would break the contract for any client reading the
+        // preview response. Unknown values default to "nlp" — the NLP
+        // extraction is the only valid source for a preview response.
+        string previewLocationSource = LocationSource.IsValid(result.Location.LocationSource)
+            ? result.Location.LocationSource
+            : LocationSource.Nlp;
         return new SignalPreviewResponseDto(
             result.Category,
             result.Subcategory,
@@ -72,7 +81,7 @@ public class SignalIngestionService : ISignalIngestionService
                 result.Location.LocationLabel,
                 result.Location.LocationPrecisionType,
                 result.Location.LocationConfidence,
-                result.Location.LocationSource),
+                previewLocationSource),
             result.TemporalHint?.Type,
             result.Summary,
             result.ShouldSuggestJoin,

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -57,7 +57,26 @@ public class SignalIngestionService : ISignalIngestionService
         {
             throw new ValidationException("NLP returned an unrecognised category.", code: "validation.invalid_category");
         }
-        return new SignalPreviewResponseDto(result.Category, result.Subcategory, result.ConditionLevel, result.ConditionConfidence, new SignalLocationDto(result.Location.AreaName, result.Location.RoadName, result.Location.JunctionName, result.Location.LandmarkName, result.Location.FacilityName, result.Location.LocationLabel, result.Location.LocationPrecisionType, result.Location.LocationConfidence, result.Location.LocationSource), result.TemporalHint?.Type, result.Summary, result.ShouldSuggestJoin);
+        bool requiresLocationFallback = LocationFallbackPolicy.RequiresFallback(result.Location);
+        return new SignalPreviewResponseDto(
+            result.Category,
+            result.Subcategory,
+            result.ConditionLevel,
+            result.ConditionConfidence,
+            new SignalLocationDto(
+                result.Location.AreaName,
+                result.Location.RoadName,
+                result.Location.JunctionName,
+                result.Location.LandmarkName,
+                result.Location.FacilityName,
+                result.Location.LocationLabel,
+                result.Location.LocationPrecisionType,
+                result.Location.LocationConfidence,
+                result.Location.LocationSource),
+            result.TemporalHint?.Type,
+            result.Summary,
+            result.ShouldSuggestJoin,
+            requiresLocationFallback);
     }
 
     public async Task<SignalSubmitResponseDto> SubmitAsync(SignalSubmitRequestDto request, Guid? accountId, Guid? deviceId, CancellationToken ct = default(CancellationToken))
@@ -131,6 +150,29 @@ public class SignalIngestionService : ISignalIngestionService
                 throw new ValidationException(
                     $"Location label must not exceed {MaxLocationLabelLength} characters.",
                     code: "validation.location_label_too_long");
+            }
+
+            // C11: canonical LocationSource allowlist. Unknown values would
+            // otherwise land in the DB's varchar(20) column unvalidated and
+            // quietly degrade downstream analytics/source-attribution.
+            if (!LocationSource.IsValid(request.LocationSource))
+            {
+                throw new ValidationException(
+                    "locationSource must be one of: nlp, user_edit, place_search.",
+                    code: "validation.invalid_location_source");
+            }
+
+            // C11: when the user selected a place from the fallback picker,
+            // the label from the picker is authoritative and must be present.
+            // We deliberately do not require a label for the NLP / user_edit
+            // paths (the existing flow tolerates a null label; the cluster
+            // falls back to structural fields for its display).
+            if (string.Equals(request.LocationSource, LocationSource.PlaceSearch, StringComparison.Ordinal)
+                && string.IsNullOrWhiteSpace(request.LocationLabel))
+            {
+                throw new ValidationException(
+                    "locationLabel is required when locationSource is place_search.",
+                    code: "validation.location_label_required");
             }
 
             string temporalType = (AllowedTemporalTypes.Contains(request.TemporalType ?? "") ? request.TemporalType : "episodic_unknown");

--- a/src/Hali.Contracts/Signals/LocationSource.cs
+++ b/src/Hali.Contracts/Signals/LocationSource.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+
+namespace Hali.Contracts.Signals;
+
+/// <summary>
+/// Canonical wire values for <see cref="SignalLocationDto.LocationSource"/>
+/// and <see cref="SignalSubmitRequestDto.LocationSource"/>.
+///
+/// These values are persisted on <c>signal_events.location_source</c>
+/// (varchar 20) and must stay in sync with the OpenAPI LocationSource
+/// enum in <c>02_openapi.yaml</c>.
+///
+/// Phase 1 supports:
+///   <list type="bullet">
+///     <item><c>nlp</c> — derived from CSI-NLP extraction, unchanged by the user.</item>
+///     <item><c>user_edit</c> — user accepted the extraction and/or edited the
+///           human-readable label in the composer. Coordinates remain the device-GPS
+///           or NLP-suggested coordinates.</item>
+///     <item><c>place_search</c> — user picked a Nominatim-backed place search
+///           result from the low-confidence fallback picker. Both the label
+///           and the coordinates are authoritative from the picker.</item>
+///   </list>
+///
+/// The draggable map-pin fallback (<c>map_pin</c>) is intentionally deferred —
+/// see the C11.1 follow-up issue. Do not advertise <c>map_pin</c> here or in
+/// OpenAPI until that surface ships.
+/// </summary>
+public static class LocationSource
+{
+    public const string Nlp = "nlp";
+    public const string UserEdit = "user_edit";
+    public const string PlaceSearch = "place_search";
+
+    /// <summary>
+    /// Case-sensitive allowlist. Submit requests whose <c>LocationSource</c>
+    /// is not in this set are rejected with
+    /// <c>validation.invalid_location_source</c>.
+    /// </summary>
+    private static readonly HashSet<string> AllSet = new HashSet<string>(StringComparer.Ordinal)
+    {
+        Nlp,
+        UserEdit,
+        PlaceSearch,
+    };
+
+    public static IReadOnlyCollection<string> All => AllSet;
+
+    public static bool IsValid(string? value)
+        => value is not null && AllSet.Contains(value);
+}

--- a/src/Hali.Contracts/Signals/PlaceCandidateDto.cs
+++ b/src/Hali.Contracts/Signals/PlaceCandidateDto.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace Hali.Contracts.Signals;
+
+/// <summary>
+/// A single geocoding candidate returned by the low-confidence location
+/// fallback endpoints (<c>GET /v1/places/search</c> and
+/// <c>GET /v1/places/reverse</c>).
+///
+/// The composer treats this DTO as authoritative: when the user picks a
+/// candidate, <see cref="Latitude"/>/<see cref="Longitude"/> become the
+/// submitted coordinates and <see cref="DisplayName"/> becomes the
+/// submitted <c>locationLabel</c>. Callers MUST NOT synthesize candidates
+/// client-side without backing coordinates — the backend's spatial
+/// integrity rules still apply on submit.
+/// </summary>
+public class PlaceCandidateDto
+{
+    public string DisplayName { get; set; } = string.Empty;
+
+    public double Latitude { get; set; }
+
+    public double Longitude { get; set; }
+
+    /// <summary>
+    /// The Hali locality (ward) that contains <see cref="Latitude"/>/<see cref="Longitude"/>,
+    /// if the point falls inside a known boundary. Candidates outside known
+    /// localities are filtered out at the API boundary so the mobile client
+    /// never surfaces a place the user cannot actually submit.
+    /// </summary>
+    public Guid? LocalityId { get; set; }
+
+    public string? WardName { get; set; }
+
+    public string? CityName { get; set; }
+}

--- a/src/Hali.Contracts/Signals/SignalPreviewResponseDto.cs
+++ b/src/Hali.Contracts/Signals/SignalPreviewResponseDto.cs
@@ -1,3 +1,22 @@
 namespace Hali.Contracts.Signals;
 
-public record SignalPreviewResponseDto(string Category, string SubcategorySlug, string? ConditionSlug, double ConditionConfidence, SignalLocationDto Location, string? TemporalType, string? NeutralSummary, bool ShouldSuggestJoin);
+/// <summary>
+/// Response from <c>POST /v1/signals/preview</c>.
+///
+/// <c>RequiresLocationFallback</c> is the server-authoritative signal that
+/// the NLP-extracted location is too weak to submit as-is and the composer
+/// should route the user into the place-search / current-location fallback
+/// UX. See <c>LocationFallbackPolicy</c> for the exact rule. The mobile
+/// client maintains a defensive client-side mirror of the same rule for
+/// offline degradation, but when the server flag is present it wins.
+/// </summary>
+public record SignalPreviewResponseDto(
+    string Category,
+    string SubcategorySlug,
+    string? ConditionSlug,
+    double ConditionConfidence,
+    SignalLocationDto Location,
+    string? TemporalType,
+    string? NeutralSummary,
+    bool ShouldSuggestJoin,
+    bool RequiresLocationFallback);

--- a/tests/Hali.Tests.Integration/Clusters/ClusterIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Clusters/ClusterIntegrationTests.cs
@@ -41,7 +41,8 @@ public sealed class ClusterIntegrationTests : IntegrationTestBase
             latitude            = -1.2921,
             longitude           = 36.8219,
             locationConfidence  = 0.80,
-            locationSource      = "user",
+            // C11: wire allowlist is {"nlp","user_edit","place_search"}.
+            locationSource      = "user_edit",
             neutralSummary      = "Road flooding near bridge.",
         });
         submitResp.EnsureSuccessStatusCode();
@@ -82,7 +83,8 @@ public sealed class ClusterIntegrationTests : IntegrationTestBase
             latitude            = -1.2850,
             longitude           = 36.8300,
             locationConfidence  = 0.75,
-            locationSource      = "user",
+            // C11: wire allowlist is {"nlp","user_edit","place_search"}.
+            locationSource      = "user_edit",
         });
 
         var clusterId = await GetLatestClusterIdAsync();

--- a/tests/Hali.Tests.Integration/Signals/SignalIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Signals/SignalIntegrationTests.cs
@@ -96,7 +96,10 @@ public sealed class SignalIntegrationTests : IntegrationTestBase
             latitude = -1.2921,
             longitude = 36.8219,
             locationConfidence = 0.70,
-            locationSource = "user",
+            // C11: wire allowlist is {"nlp","user_edit","place_search"};
+            // "user" is no longer accepted and would return 400 with
+            // validation.invalid_location_source.
+            locationSource = "user_edit",
         };
 
         var first = await authClient.PostAsJsonAsync("/v1/signals/submit", payload);

--- a/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
+++ b/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
@@ -393,7 +393,7 @@ public class ContractDriftTests
         var dto = new SignalPreviewResponseDto(
             "water", "water_outage", null, 0.85,
             new SignalLocationDto(null, null, null, null, null, "Ngong Rd", null, 0.9, "nlp"),
-            null, "Water outage reported", true);
+            null, "Water outage reported", true, false);
 
         var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
         using var doc = JsonDocument.Parse(json);
@@ -404,6 +404,7 @@ public class ContractDriftTests
         Assert.True(root.TryGetProperty("conditionConfidence", out _));
         Assert.True(root.TryGetProperty("location", out var loc));
         Assert.True(root.TryGetProperty("shouldSuggestJoin", out _));
+        Assert.True(root.TryGetProperty("requiresLocationFallback", out _));
         Assert.True(loc.TryGetProperty("locationLabel", out _));
         Assert.True(loc.TryGetProperty("locationConfidence", out _));
         Assert.True(loc.TryGetProperty("locationSource", out _));
@@ -424,7 +425,8 @@ public class ContractDriftTests
             Location: new SignalLocationDto(null, null, null, null, null, null, null, 0.0, "nlp"),
             TemporalType: null,
             NeutralSummary: null,
-            ShouldSuggestJoin: false);
+            ShouldSuggestJoin: false,
+            RequiresLocationFallback: true);
 
         var json = JsonSerializer.Serialize(dto, ApiJsonOptions);
         using var doc = JsonDocument.Parse(json);

--- a/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
@@ -265,4 +265,193 @@ public class PlacesControllerTests
         ObjectResult obj = Assert.IsType<ObjectResult>(result);
         Assert.Equal(StatusCodes.Status429TooManyRequests, obj.StatusCode);
     }
+
+    // ---- reverse cache integrity (B-2 / Copilot #1) ----
+    //
+    // Previously the reverse cache was keyed only by quantized coords
+    // ({lat:F4}:{lng:F4}) and stored the full PlaceCandidateDto. Two
+    // callers whose points rounded into the same 4dp bucket could share
+    // a response, which across ward boundaries — or across the edge of
+    // known coverage — leaked a neighbor's localityId / wardName / coords
+    // and could bypass the locality guard entirely.
+    //
+    // The fix: always call FindByPointAsync for the caller's coordinates;
+    // the cache now holds ONLY the expensive Nominatim label, keyed by
+    // {lat:F4}:{lng:F4}:{localityId} so a same-bucket cross-locality
+    // request cannot reuse a neighbour's label.
+    //
+    // These tests prove the two integrity invariants without relying on
+    // NSubstitute's StringSetAsync overload resolution (which is brittle
+    // across SE.Redis 2.12.x's multiple default-arg overloads of
+    // StringSetAsync): we simulate "a prior call has populated the
+    // cache" by pre-seeding `StringGetAsync` with a payload that the old
+    // design would have returned, and assert that the new design ignores
+    // it and re-resolves the caller's locality + rebuilds the response.
+
+    [Fact]
+    public async Task Reverse_OutsideLocality_IsNotServedFromCachedNeighborPayload()
+    {
+        // Simulate: a prior same-bucket call populated the cache with a
+        // valid candidate in LocalityA. Now a caller whose point is
+        // OUTSIDE any known locality hits the same bucket.
+        //
+        // Old design: StringGetAsync would have returned the cached DTO
+        // and the endpoint would have skipped FindByPointAsync entirely,
+        // returning LocalityA's data → locality guard bypassed.
+        //
+        // New design: FindByPointAsync is always called first; when it
+        // returns null the cache is never consulted and 404 is returned.
+        PlaceCandidateDto seededNeighbour = new PlaceCandidateDto
+        {
+            DisplayName = "Ngong Road, Nairobi West",
+            Latitude = -1.30001,
+            Longitude = 36.80001,
+            LocalityId = LocalityA,
+            WardName = "Nairobi West",
+            CityName = "Nairobi",
+        };
+        string seededJson = JsonSerializer.Serialize(seededNeighbour);
+        _localities.FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>())
+            .Returns((LocalitySummary?)null);
+
+        PlacesController controller = CreateController();
+        // Seed StringGetAsync AFTER CreateController so this setup wins
+        // over the default "always return RedisValue.Null" setup.
+        _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(seededJson);
+
+        IActionResult result = await controller.Reverse(-1.30004, 36.80004, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+        // The key integrity assertions: FindByPointAsync ran for the
+        // caller's coords, and the upstream geocoder was never touched
+        // (we short-circuit at the locality guard).
+        await _localities.Received(1)
+            .FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>());
+        await _geocoding.DidNotReceive()
+            .ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reverse_CrossLocalitySameBucket_DoesNotReturnNeighborLocality()
+    {
+        // Simulate: a prior same-bucket call in LocalityA populated the
+        // cache. Now a caller whose point is inside LocalityB (different
+        // ward, same 4dp bucket) arrives.
+        //
+        // Old design: StringGetAsync returned LocalityA's DTO verbatim,
+        // so callerB saw LocalityA's wardName/cityName/localityId + caller
+        // A's coords.
+        //
+        // New design: the cache key is partitioned by localityId, so a
+        // seeded entry written under LocalityA's key is not visible to a
+        // lookup under LocalityB's key. The controller calls Nominatim
+        // fresh for callerB and returns callerB's own locality.
+        PlaceCandidateDto seededLocalityA = new PlaceCandidateDto
+        {
+            DisplayName = "Ngong Road, Nairobi West",
+            Latitude = -1.30001,
+            Longitude = 36.80001,
+            LocalityId = LocalityA,
+            WardName = "Nairobi West",
+            CityName = "Nairobi",
+        };
+        string seededJson = JsonSerializer.Serialize(seededLocalityA);
+
+        _localities.FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityB, "Dagoretti", "Nairobi", "Nairobi"));
+        _geocoding.ReverseGeocodeAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>())
+            .Returns(new GeocodingResult("Ngong Road, Dagoretti, Nairobi, Kenya",
+                "Ngong Road", "Dagoretti", "Nairobi", "Kenya"));
+
+        PlacesController controller = CreateController();
+        // Seed StringGetAsync to return the LocalityA payload only when
+        // an old-style key (no localityId in the key) is queried — to
+        // prove that the new code never uses that key. Any key the
+        // new controller asks for (which includes localityId) returns
+        // RedisValue.Null → cache miss → live Nominatim call.
+        _redis.StringGetAsync(
+                Arg.Is<RedisKey>(k =>
+                    k.ToString().StartsWith("places_reverse:", StringComparison.Ordinal)
+                    && !k.ToString().StartsWith("places_reverse_label:", StringComparison.Ordinal)),
+                Arg.Any<CommandFlags>())
+            .Returns(seededJson);
+
+        IActionResult result = await controller.Reverse(-1.30004, 36.80004, CancellationToken.None);
+
+        PlaceCandidateDto payload = Assert.IsType<PlaceCandidateDto>(Assert.IsType<OkObjectResult>(result).Value);
+        // CallerB's response reflects CallerB's own locality + coords,
+        // NOT LocalityA from the seeded neighbour payload.
+        Assert.Equal(LocalityB, payload.LocalityId);
+        Assert.Equal("Dagoretti", payload.WardName);
+        Assert.Equal(-1.30004, payload.Latitude);
+        Assert.Equal(36.80004, payload.Longitude);
+        Assert.Equal("Ngong Road, Dagoretti", payload.DisplayName);
+
+        await _localities.Received(1)
+            .FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reverse_CacheKey_IncludesLocalityId()
+    {
+        // Proves the cache partitioning: the controller's cache read uses
+        // a key that contains the resolved localityId. This is the
+        // structural guarantee that a cross-locality same-bucket request
+        // cannot reuse a neighbour's cache entry.
+        _localities.FindByPointAsync(-1.30001, 36.80001, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityA, "Nairobi West", "Nairobi", "Nairobi"));
+        _geocoding.ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns((GeocodingResult?)null);
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Reverse(-1.30001, 36.80001, CancellationToken.None);
+
+        Assert.IsType<OkObjectResult>(result);
+        // At least one StringGetAsync call must have used a key that
+        // contains the resolved localityId, anchoring the cache to the
+        // caller's actual locality rather than coords alone.
+        await _redis.Received().StringGetAsync(
+            Arg.Is<RedisKey>(k =>
+                k.ToString().StartsWith("places_reverse_label:", StringComparison.Ordinal)
+                && k.ToString().Contains(LocalityA.ToString())),
+            Arg.Any<CommandFlags>());
+    }
+
+    [Fact]
+    public async Task Reverse_AlwaysResolvesCallerLocality_EvenWhenSomethingIsCached()
+    {
+        // Strongest invariant: FindByPointAsync runs for the caller's
+        // coords BEFORE any cached payload can affect the response. Pre-
+        // seed a cache hit that would satisfy any key, and assert the
+        // locality repository was still consulted with the caller's coords.
+        PlaceCandidateDto seeded = new PlaceCandidateDto
+        {
+            DisplayName = "Seeded Label",
+            Latitude = 0.0,
+            Longitude = 0.0,
+            LocalityId = LocalityA,
+            WardName = "Seeded Ward",
+            CityName = "Seeded City",
+        };
+        string seededJson = JsonSerializer.Serialize(seeded);
+        _localities.FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityB, "Dagoretti", "Nairobi", "Nairobi"));
+        _geocoding.ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns((GeocodingResult?)null);
+
+        PlacesController controller = CreateController();
+        _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(seededJson);
+
+        IActionResult result = await controller.Reverse(-1.30004, 36.80004, CancellationToken.None);
+
+        PlaceCandidateDto payload = Assert.IsType<PlaceCandidateDto>(Assert.IsType<OkObjectResult>(result).Value);
+        // Locality came from the fresh lookup, not the seeded cache entry.
+        Assert.Equal(LocalityB, payload.LocalityId);
+        Assert.Equal(-1.30004, payload.Latitude);
+        Assert.Equal(36.80004, payload.Longitude);
+        await _localities.Received(1)
+            .FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
@@ -1,0 +1,268 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Auth;
+using Hali.Application.Signals;
+using Hali.Contracts.Signals;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Hali.Tests.Unit.Signals;
+
+public class PlacesControllerTests
+{
+    private readonly IGeocodingService _geocoding = Substitute.For<IGeocodingService>();
+    private readonly ILocalityLookupRepository _localities = Substitute.For<ILocalityLookupRepository>();
+    private readonly IDatabase _redis = Substitute.For<IDatabase>();
+    private readonly IRateLimiter _rateLimiter = Substitute.For<IRateLimiter>();
+
+    private static readonly Guid LocalityA = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid LocalityB = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    private PlacesController CreateController(string clientIp = "203.0.113.1")
+    {
+        _rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>()).Returns(RedisValue.Null);
+        _redis.StringSetAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>())
+            .Returns(true);
+
+        IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> mvcOptions =
+            Options.Create(new Microsoft.AspNetCore.Mvc.JsonOptions());
+
+        var controller = new PlacesController(
+            _geocoding,
+            _localities,
+            _redis,
+            _rateLimiter,
+            mvcOptions,
+            NullLogger<PlacesController>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = IPAddress.Parse(clientIp);
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        return controller;
+    }
+
+    // ---- search ----
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData(" ")]
+    [InlineData("a")]
+    public async Task Search_QueryTooShort_ReturnsBadRequest(string? q)
+    {
+        PlacesController controller = CreateController();
+
+        IActionResult result = await controller.Search(q!, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Search_OversizedQuery_ReturnsBadRequest()
+    {
+        PlacesController controller = CreateController();
+        string overlong = new string('x', 81);
+
+        IActionResult result = await controller.Search(overlong, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Search_HappyPath_ReturnsResolvedCandidates()
+    {
+        _geocoding.SearchAsync("Ngong Road", Arg.Any<CancellationToken>())
+            .Returns(new List<GeocodingCandidate>
+            {
+                new GeocodingCandidate("Ngong Road, Nairobi, Kenya", -1.30, 36.78),
+                new GeocodingCandidate("Ngong Forest, Nairobi, Kenya", -1.31, 36.77),
+            });
+        _localities.FindByPointAsync(-1.30, 36.78, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityA, "Nairobi West", "Nairobi", "Nairobi"));
+        _localities.FindByPointAsync(-1.31, 36.77, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityB, "Dagoretti", "Nairobi", "Nairobi"));
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Search("Ngong Road", CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        List<PlaceCandidateDto> payload = Assert.IsAssignableFrom<IEnumerable<PlaceCandidateDto>>(ok.Value).ToList();
+        Assert.Equal(2, payload.Count);
+        Assert.Equal(LocalityA, payload[0].LocalityId);
+        Assert.Equal("Nairobi West", payload[0].WardName);
+        Assert.Equal(-1.30, payload[0].Latitude);
+        Assert.Equal(36.78, payload[0].Longitude);
+        // Display-name is trimmed to first two comma-separated segments.
+        Assert.Equal("Ngong Road, Nairobi", payload[0].DisplayName);
+    }
+
+    [Fact]
+    public async Task Search_CandidatesOutsideKnownLocalities_AreFilteredOut()
+    {
+        _geocoding.SearchAsync("Somewhere", Arg.Any<CancellationToken>())
+            .Returns(new List<GeocodingCandidate>
+            {
+                new GeocodingCandidate("Ocean, International Waters", 0.0, 0.0),
+                new GeocodingCandidate("Ngong Road, Nairobi", -1.30, 36.78),
+            });
+        _localities.FindByPointAsync(0.0, 0.0, Arg.Any<CancellationToken>())
+            .Returns((LocalitySummary?)null);
+        _localities.FindByPointAsync(-1.30, 36.78, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityA, "Nairobi West", "Nairobi", "Nairobi"));
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Search("Somewhere", CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        List<PlaceCandidateDto> payload = Assert.IsAssignableFrom<IEnumerable<PlaceCandidateDto>>(ok.Value).ToList();
+        PlaceCandidateDto only = Assert.Single(payload);
+        Assert.Equal(LocalityA, only.LocalityId);
+    }
+
+    [Fact]
+    public async Task Search_GeocodingThrows_FailsClosedWithEmptyList()
+    {
+        _geocoding.SearchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<GeocodingCandidate>>(_ => throw new InvalidOperationException("boom"));
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Search("Ngong Road", CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        List<PlaceCandidateDto> payload = Assert.IsAssignableFrom<IEnumerable<PlaceCandidateDto>>(ok.Value).ToList();
+        Assert.Empty(payload);
+    }
+
+    [Fact]
+    public async Task Search_RateLimited_Returns429()
+    {
+        PlacesController controller = CreateController();
+        // Override the default (allowed=true) *after* controller construction
+        // so this per-test setup wins.
+        _rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        IActionResult result = await controller.Search("Ngong Road", CancellationToken.None);
+
+        ObjectResult obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, obj.StatusCode);
+        // Must not fan out to the upstream geocoder once we've decided to throttle.
+        await _geocoding.DidNotReceive().SearchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
+    }
+
+    // ---- reverse ----
+
+    [Theory]
+    [InlineData(-91.0, 36.8)]
+    [InlineData(91.0, 36.8)]
+    [InlineData(-1.3, -181.0)]
+    [InlineData(-1.3, 181.0)]
+    public async Task Reverse_InvalidCoordinates_ReturnsBadRequest(double lat, double lng)
+    {
+        PlacesController controller = CreateController();
+
+        IActionResult result = await controller.Reverse(lat, lng, CancellationToken.None);
+
+        Assert.IsType<BadRequestObjectResult>(result);
+    }
+
+    [Fact]
+    public async Task Reverse_PointOutsideKnownLocality_Returns404()
+    {
+        _localities.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns((LocalitySummary?)null);
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
+
+        Assert.IsType<NotFoundObjectResult>(result);
+        await _geocoding.DidNotReceive().ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Reverse_HappyPath_ReturnsCandidateWithNominatimLabel()
+    {
+        _localities.FindByPointAsync(-1.3, 36.8, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityA, "Nairobi West", "Nairobi", "Nairobi"));
+        _geocoding.ReverseGeocodeAsync(-1.3, 36.8, Arg.Any<CancellationToken>())
+            .Returns(new GeocodingResult("Ngong Road, Nairobi West, Nairobi, Kenya", "Ngong Road", "Nairobi West", "Nairobi", "Kenya"));
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        PlaceCandidateDto payload = Assert.IsType<PlaceCandidateDto>(ok.Value);
+        Assert.Equal("Ngong Road, Nairobi West", payload.DisplayName);
+        Assert.Equal(LocalityA, payload.LocalityId);
+        Assert.Equal(-1.3, payload.Latitude);
+        Assert.Equal(36.8, payload.Longitude);
+    }
+
+    [Fact]
+    public async Task Reverse_ReverseGeocodeReturnsNull_FallsBackToWardLabel()
+    {
+        _localities.FindByPointAsync(-1.3, 36.8, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityA, "Nairobi West", "Nairobi", "Nairobi"));
+        _geocoding.ReverseGeocodeAsync(-1.3, 36.8, Arg.Any<CancellationToken>())
+            .Returns((GeocodingResult?)null);
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        PlaceCandidateDto payload = Assert.IsType<PlaceCandidateDto>(ok.Value);
+        // Fallback label is "WardName, CityName" when reverse geocoding is
+        // unavailable — keeps the label civic-friendly even on Nominatim failure.
+        Assert.Equal("Nairobi West, Nairobi", payload.DisplayName);
+    }
+
+    [Fact]
+    public async Task Reverse_ReverseGeocodeThrows_FallsBackToWardLabel()
+    {
+        _localities.FindByPointAsync(-1.3, 36.8, Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(LocalityA, "Nairobi West", "Nairobi", "Nairobi"));
+        _geocoding.ReverseGeocodeAsync(-1.3, 36.8, Arg.Any<CancellationToken>())
+            .Returns<GeocodingResult?>(_ => throw new InvalidOperationException("nominatim down"));
+
+        PlacesController controller = CreateController();
+        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        PlaceCandidateDto payload = Assert.IsType<PlaceCandidateDto>(ok.Value);
+        Assert.Equal("Nairobi West, Nairobi", payload.DisplayName);
+    }
+
+    [Fact]
+    public async Task Reverse_RateLimited_Returns429()
+    {
+        PlacesController controller = CreateController();
+        _rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(false);
+
+        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
+
+        ObjectResult obj = Assert.IsType<ObjectResult>(result);
+        Assert.Equal(StatusCodes.Status429TooManyRequests, obj.StatusCode);
+    }
+}

--- a/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
@@ -15,425 +15,537 @@ namespace Hali.Tests.Unit.Signals;
 
 public class SignalIngestionServiceTests
 {
-	private readonly INlpExtractionService _nlp = Substitute.For<INlpExtractionService>();
+    private readonly INlpExtractionService _nlp = Substitute.For<INlpExtractionService>();
 
-	private readonly ISignalRepository _repo = Substitute.For<ISignalRepository>();
+    private readonly ISignalRepository _repo = Substitute.For<ISignalRepository>();
 
-	private readonly IClusteringService _clustering = Substitute.For<IClusteringService>();
+    private readonly IClusteringService _clustering = Substitute.For<IClusteringService>();
 
-	private readonly IH3CellService _h3 = Substitute.For<IH3CellService>();
+    private readonly IH3CellService _h3 = Substitute.For<IH3CellService>();
 
-	private readonly ILocalityLookupRepository _localityLookup = Substitute.For<ILocalityLookupRepository>();
+    private readonly ILocalityLookupRepository _localityLookup = Substitute.For<ILocalityLookupRepository>();
 
-	private SignalIngestionService CreateService()
-	{
-		return new SignalIngestionService(_nlp, _repo, _clustering, _h3, _localityLookup);
-	}
+    private SignalIngestionService CreateService()
+    {
+        return new SignalIngestionService(_nlp, _repo, _clustering, _h3, _localityLookup);
+    }
 
-	private static NlpExtractionResultDto MakeNlpResult(string category = "roads")
-	{
-		return new NlpExtractionResultDto(category, "potholes", "difficult", 0.85, new NlpLocationDto("Nairobi West", "Lusaka Road", null, null, null, "Potholes on Lusaka Road, Nairobi West", "road", 0.8, "nlp"), new NlpTemporalHintDto("temporary", 0.7), "Potholes on Lusaka Road.", ShouldSuggestJoin: true, null);
-	}
+    private static NlpExtractionResultDto MakeNlpResult(string category = "roads")
+    {
+        return new NlpExtractionResultDto(category, "potholes", "difficult", 0.85, new NlpLocationDto("Nairobi West", "Lusaka Road", null, null, null, "Potholes on Lusaka Road, Nairobi West", "road", 0.8, "nlp"), new NlpTemporalHintDto("temporary", 0.7), "Potholes on Lusaka Road.", ShouldSuggestJoin: true, null);
+    }
 
-	private static SignalSubmitRequestDto MakeSubmitRequest(string idempKey = "key-abc")
-	{
-		return new SignalSubmitRequestDto(idempKey, "device-hash-1", "Big potholes on Lusaka Road", "roads", "potholes", "difficult", 0.85, -1.3, 36.8, "Potholes on Lusaka Road", "road", 0.8, "nlp", "temporary", "Potholes on Lusaka Road.", "en");
-	}
+    private static SignalSubmitRequestDto MakeSubmitRequest(string idempKey = "key-abc")
+    {
+        return new SignalSubmitRequestDto(idempKey, "device-hash-1", "Big potholes on Lusaka Road", "roads", "potholes", "difficult", 0.85, -1.3, 36.8, "Potholes on Lusaka Road", "road", 0.8, "nlp", "temporary", "Potholes on Lusaka Road.", "en");
+    }
 
-	private static readonly Guid DefaultLocalityId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
+    private static readonly Guid DefaultLocalityId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
 
-	private void SetupDefaultH3()
-	{
-		_h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("892a1008003ffff");
-	}
+    private void SetupDefaultH3()
+    {
+        _h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("892a1008003ffff");
+    }
 
-	private void SetupDefaultLocality()
-	{
-		_localityLookup.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
-			.Returns(new LocalitySummary(DefaultLocalityId, "Nairobi West", "Nairobi", "Nairobi"));
-	}
+    private void SetupDefaultLocality()
+    {
+        _localityLookup.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns(new LocalitySummary(DefaultLocalityId, "Nairobi West", "Nairobi", "Nairobi"));
+    }
 
-	private static readonly Guid DefaultClusterId = Guid.Parse("cccccccc-dddd-eeee-ffff-000000000000");
+    private static readonly Guid DefaultClusterId = Guid.Parse("cccccccc-dddd-eeee-ffff-000000000000");
 
-	private void SetupDefaultRepo()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		_repo.PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>()).Returns(ci =>
-		{
-			var s = ci.ArgAt<SignalEvent>(0);
-			return new SignalEvent
-			{
-				Id = s.Id,
-				CreatedAt = s.CreatedAt,
-				OccurredAt = s.OccurredAt,
-				Category = s.Category,
-				SpatialCellId = s.SpatialCellId,
-				LocalityId = s.LocalityId
-			};
-		});
-		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
-			.Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
-	}
+    private void SetupDefaultRepo()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _repo.PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>()).Returns(ci =>
+        {
+            var s = ci.ArgAt<SignalEvent>(0);
+            return new SignalEvent
+            {
+                Id = s.Id,
+                CreatedAt = s.CreatedAt,
+                OccurredAt = s.OccurredAt,
+                Category = s.Category,
+                SpatialCellId = s.SpatialCellId,
+                LocalityId = s.LocalityId
+            };
+        });
+        _clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+            .Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
+    }
 
-	[Fact]
-	public async Task PreviewAsync_HappyPath_ReturnsPreviewDto()
-	{
-		_repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
-		_nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(MakeNlpResult());
-		SignalIngestionService svc = CreateService();
-		SignalPreviewResponseDto result = await svc.PreviewAsync(new SignalPreviewRequestDto("Big potholes on Lusaka Road", null, null, null, null, "Nairobi", "KE"));
-		Assert.Equal("roads", result.Category);
-		Assert.Equal("potholes", result.SubcategorySlug);
-		Assert.Equal("difficult", result.ConditionSlug);
-		Assert.True(result.ShouldSuggestJoin);
-	}
+    [Fact]
+    public async Task PreviewAsync_HappyPath_ReturnsPreviewDto()
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(MakeNlpResult());
+        SignalIngestionService svc = CreateService();
+        SignalPreviewResponseDto result = await svc.PreviewAsync(new SignalPreviewRequestDto("Big potholes on Lusaka Road", null, null, null, null, "Nairobi", "KE"));
+        Assert.Equal("roads", result.Category);
+        Assert.Equal("potholes", result.SubcategorySlug);
+        Assert.Equal("difficult", result.ConditionSlug);
+        Assert.True(result.ShouldSuggestJoin);
+    }
 
-	[Fact]
-	public async Task PreviewAsync_NlpReturnsNull_ThrowsExtractionFailed()
-	{
-		_repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
-		_nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns((NlpExtractionResultDto)null!);
-		SignalIngestionService svc = CreateService();
-		var ex = await Assert.ThrowsAsync<DependencyException>(() => svc.PreviewAsync(new SignalPreviewRequestDto("test", null, null, null, null, null, null)));
-		Assert.Equal("dependency.nlp_unavailable", ex.Code);
-	}
+    // --- C11: requiresLocationFallback server-authoritative flag ---
 
-	[Fact]
-	public async Task PreviewAsync_NlpReturnsUnknownCategory_ThrowsInvalidCategory()
-	{
-		_repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
-		_nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(MakeNlpResult("aliens"));
-		SignalIngestionService svc = CreateService();
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.PreviewAsync(new SignalPreviewRequestDto("test", null, null, null, null, null, null)));
-		Assert.Equal("validation.invalid_category", ex.Code);
-	}
+    [Fact]
+    public async Task PreviewAsync_HighConfidenceWithLabel_DoesNotRequireFallback()
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(MakeNlpResult());
+        SignalIngestionService svc = CreateService();
 
-	[Fact]
-	public async Task SubmitAsync_DuplicateIdempotencyKey_ThrowsDuplicate()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SignalIngestionService svc = CreateService();
-		var ex = await Assert.ThrowsAsync<ConflictException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
-		Assert.Equal("signal.duplicate", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+        SignalPreviewResponseDto result = await svc.PreviewAsync(
+            new SignalPreviewRequestDto("Big potholes on Lusaka Road", null, null, null, null, "Nairobi", "KE"));
 
-	[Fact]
-	public async Task SubmitAsync_SameKeyTwice_SecondCallThrowsDuplicate()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false, true);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		_repo.PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>()).Returns(new SignalEvent
-		{
-			Id = Guid.NewGuid(),
-			CreatedAt = DateTime.UtcNow,
-			OccurredAt = DateTime.UtcNow,
-			Category = CivicCategory.Roads,
-			SpatialCellId = "892a1008003ffff",
-			LocalityId = DefaultLocalityId
-		});
-		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
-			.Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
-		SignalIngestionService svc = CreateService();
-		Assert.NotNull(await svc.SubmitAsync(MakeSubmitRequest("key-dup"), null, null));
-		var ex = await Assert.ThrowsAsync<ConflictException>(() => svc.SubmitAsync(MakeSubmitRequest("key-dup"), null, null));
-		Assert.Equal("signal.duplicate", ex.Code);
-	}
+        Assert.False(result.RequiresLocationFallback);
+    }
 
-	[Fact]
-	public async Task SubmitAsync_RateLimited_ThrowsRateLimited()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		SignalIngestionService svc = CreateService();
-		var ex = await Assert.ThrowsAsync<RateLimitException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
-		Assert.Equal("integrity.rate_limited", ex.Code);
-	}
+    [Fact]
+    public async Task PreviewAsync_LowConfidence_RequiresFallback()
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        NlpExtractionResultDto lowConf = new NlpExtractionResultDto(
+            "roads", "potholes", "difficult", 0.85,
+            new NlpLocationDto("Nairobi West", null, null, null, null, "somewhere in Nairobi West", "area", 0.3, "nlp"),
+            new NlpTemporalHintDto("temporary", 0.7), "Potholes.", ShouldSuggestJoin: false, null);
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(lowConf);
+        SignalIngestionService svc = CreateService();
 
-	[Fact]
-	public async Task SubmitAsync_InvalidCategory_ThrowsInvalidCategory()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { Category = "unknown_category" };
-		SignalIngestionService svc = CreateService();
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
-		Assert.Equal("validation.invalid_category", ex.Code);
-	}
+        SignalPreviewResponseDto result = await svc.PreviewAsync(
+            new SignalPreviewRequestDto("Potholes somewhere", null, null, null, null, "Nairobi", "KE"));
 
-	[Fact]
-	public async Task SubmitAsync_ValidRequest_PersistsAndReturnsId()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalIngestionService svc = CreateService();
-		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
-		Assert.NotEqual(Guid.Empty, result.SignalEventId);
-		await _repo.Received(1).PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-		await _repo.Received(1).SetIdempotencyKeyAsync(Arg.Is((string k) => k.StartsWith("idem:signal-submit:")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
-	}
+        Assert.True(result.RequiresLocationFallback);
+    }
 
-	[Theory]
-	[InlineData("roads", true)]
-	[InlineData("water", true)]
-	[InlineData("electricity", true)]
-	[InlineData("environment", true)]
-	[InlineData("ROADS", true)]
-	[InlineData("garbage", false)]
-	[InlineData("", false)]
-	[InlineData("road", false)]
-	public async Task SubmitAsync_CategoryValidation(string category, bool shouldSucceed)
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { Category = category };
-		SignalIngestionService svc = CreateService();
-		if (shouldSucceed)
-		{
-			Assert.NotNull(await svc.SubmitAsync(request, null, null));
-			return;
-		}
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
-		Assert.Equal("validation.invalid_category", ex.Code);
-	}
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task PreviewAsync_HighConfidenceButBlankLabel_RequiresFallback(string? label)
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        NlpExtractionResultDto blankLabel = new NlpExtractionResultDto(
+            "roads", "potholes", "difficult", 0.85,
+            new NlpLocationDto(null, null, null, null, null, label, null, 0.9, "nlp"),
+            new NlpTemporalHintDto("temporary", 0.7), "Potholes.", ShouldSuggestJoin: false, null);
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(blankLabel);
+        SignalIngestionService svc = CreateService();
 
-	// --- Phase A1: Spatial cell derivation tests ---
+        SignalPreviewResponseDto result = await svc.PreviewAsync(
+            new SignalPreviewRequestDto("Potholes", null, null, null, null, "Nairobi", "KE"));
 
-	[Fact]
-	public async Task SubmitAsync_MissingCoordinates_ThrowsMissingCoordinates()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { Latitude = null, Longitude = null };
-		SignalIngestionService svc = CreateService();
+        Assert.True(result.RequiresLocationFallback);
+    }
 
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
-		Assert.Equal("validation.missing_coordinates", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+    [Fact]
+    public async Task PreviewAsync_NlpReturnsNull_ThrowsExtractionFailed()
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns((NlpExtractionResultDto)null!);
+        SignalIngestionService svc = CreateService();
+        var ex = await Assert.ThrowsAsync<DependencyException>(() => svc.PreviewAsync(new SignalPreviewRequestDto("test", null, null, null, null, null, null)));
+        Assert.Equal("dependency.nlp_unavailable", ex.Code);
+    }
+
+    [Fact]
+    public async Task PreviewAsync_NlpReturnsUnknownCategory_ThrowsInvalidCategory()
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(MakeNlpResult("aliens"));
+        SignalIngestionService svc = CreateService();
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.PreviewAsync(new SignalPreviewRequestDto("test", null, null, null, null, null, null)));
+        Assert.Equal("validation.invalid_category", ex.Code);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_DuplicateIdempotencyKey_ThrowsDuplicate()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SignalIngestionService svc = CreateService();
+        var ex = await Assert.ThrowsAsync<ConflictException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+        Assert.Equal("signal.duplicate", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task SubmitAsync_SameKeyTwice_SecondCallThrowsDuplicate()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false, true);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        _repo.PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>()).Returns(new SignalEvent
+        {
+            Id = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            OccurredAt = DateTime.UtcNow,
+            Category = CivicCategory.Roads,
+            SpatialCellId = "892a1008003ffff",
+            LocalityId = DefaultLocalityId
+        });
+        _clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+            .Returns(new ClusterRoutingResult(DefaultClusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
+        SignalIngestionService svc = CreateService();
+        Assert.NotNull(await svc.SubmitAsync(MakeSubmitRequest("key-dup"), null, null));
+        var ex = await Assert.ThrowsAsync<ConflictException>(() => svc.SubmitAsync(MakeSubmitRequest("key-dup"), null, null));
+        Assert.Equal("signal.duplicate", ex.Code);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_RateLimited_ThrowsRateLimited()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        SignalIngestionService svc = CreateService();
+        var ex = await Assert.ThrowsAsync<RateLimitException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+        Assert.Equal("integrity.rate_limited", ex.Code);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_InvalidCategory_ThrowsInvalidCategory()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { Category = "unknown_category" };
+        SignalIngestionService svc = CreateService();
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.invalid_category", ex.Code);
+    }
+
+    [Fact]
+    public async Task SubmitAsync_ValidRequest_PersistsAndReturnsId()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalIngestionService svc = CreateService();
+        var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+        Assert.NotEqual(Guid.Empty, result.SignalEventId);
+        await _repo.Received(1).PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+        await _repo.Received(1).SetIdempotencyKeyAsync(Arg.Is((string k) => k.StartsWith("idem:signal-submit:")), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("roads", true)]
+    [InlineData("water", true)]
+    [InlineData("electricity", true)]
+    [InlineData("environment", true)]
+    [InlineData("ROADS", true)]
+    [InlineData("garbage", false)]
+    [InlineData("", false)]
+    [InlineData("road", false)]
+    public async Task SubmitAsync_CategoryValidation(string category, bool shouldSucceed)
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { Category = category };
+        SignalIngestionService svc = CreateService();
+        if (shouldSucceed)
+        {
+            Assert.NotNull(await svc.SubmitAsync(request, null, null));
+            return;
+        }
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.invalid_category", ex.Code);
+    }
+
+    // --- Phase A1: Spatial cell derivation tests ---
+
+    [Fact]
+    public async Task SubmitAsync_MissingCoordinates_ThrowsMissingCoordinates()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { Latitude = null, Longitude = null };
+        SignalIngestionService svc = CreateService();
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.missing_coordinates", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 
 
-	[Fact]
-	public async Task SubmitAsync_ValidCoordinates_DerivesSpatialCellId()
-	{
-		SetupDefaultRepo();
-		_h3.LatLngToCell(-1.3, 36.8, 9).Returns("892a1008003ffff");
-		SetupDefaultLocality();
-		SignalIngestionService svc = CreateService();
-		await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+    [Fact]
+    public async Task SubmitAsync_ValidCoordinates_DerivesSpatialCellId()
+    {
+        SetupDefaultRepo();
+        _h3.LatLngToCell(-1.3, 36.8, 9).Returns("892a1008003ffff");
+        SetupDefaultLocality();
+        SignalIngestionService svc = CreateService();
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		await _repo.Received(1).PersistSignalAsync(
-			Arg.Is<SignalEvent>(s => s.SpatialCellId == "892a1008003ffff"),
-			Arg.Any<CancellationToken>());
-	}
+        await _repo.Received(1).PersistSignalAsync(
+            Arg.Is<SignalEvent>(s => s.SpatialCellId == "892a1008003ffff"),
+            Arg.Any<CancellationToken>());
+    }
 
-	[Fact]
-	public async Task SubmitAsync_ValidSubmission_ReachesClusteringWithNonNullSpatialCellId()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalIngestionService svc = CreateService();
-		await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+    [Fact]
+    public async Task SubmitAsync_ValidSubmission_ReachesClusteringWithNonNullSpatialCellId()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalIngestionService svc = CreateService();
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		await _clustering.Received(1).RouteSignalAsync(
-			Arg.Is<SignalEvent>(s => s.SpatialCellId != null),
-			Arg.Any<CancellationToken>());
-	}
+        await _clustering.Received(1).RouteSignalAsync(
+            Arg.Is<SignalEvent>(s => s.SpatialCellId != null),
+            Arg.Any<CancellationToken>());
+    }
 
-	[Theory]
-	[InlineData(-91.0, 36.8)]
-	[InlineData(91.0, 36.8)]
-	[InlineData(-1.3, -181.0)]
-	[InlineData(-1.3, 181.0)]
-	public async Task SubmitAsync_InvalidCoordinates_ThrowsInvalidCoordinates(double lat, double lng)
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { Latitude = lat, Longitude = lng };
-		SignalIngestionService svc = CreateService();
+    [Theory]
+    [InlineData(-91.0, 36.8)]
+    [InlineData(91.0, 36.8)]
+    [InlineData(-1.3, -181.0)]
+    [InlineData(-1.3, 181.0)]
+    public async Task SubmitAsync_InvalidCoordinates_ThrowsInvalidCoordinates(double lat, double lng)
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { Latitude = lat, Longitude = lng };
+        SignalIngestionService svc = CreateService();
 
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
-		Assert.Equal("validation.invalid_coordinates", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.invalid_coordinates", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 
-	[Fact]
-	public async Task SubmitAsync_SpatialDerivationFails_ThrowsAndDoesNotPersist()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		_h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Throws(new ArgumentException("Invalid coordinates"));
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_SpatialDerivationFails_ThrowsAndDoesNotPersist()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Throws(new ArgumentException("Invalid coordinates"));
+        SignalIngestionService svc = CreateService();
 
-		var ex = await Assert.ThrowsAsync<DependencyException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
-		Assert.Equal("dependency.spatial_derivation_failed", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+        var ex = await Assert.ThrowsAsync<DependencyException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+        Assert.Equal("dependency.spatial_derivation_failed", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 
-	[Fact]
-	public async Task SubmitAsync_SpatialDerivationReturnsEmpty_ThrowsAndDoesNotPersist()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		_h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("");
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_SpatialDerivationReturnsEmpty_ThrowsAndDoesNotPersist()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        _h3.LatLngToCell(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<int>()).Returns("");
+        SignalIngestionService svc = CreateService();
 
-		var ex = await Assert.ThrowsAsync<DependencyException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
-		Assert.Equal("dependency.spatial_derivation_failed", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+        var ex = await Assert.ThrowsAsync<DependencyException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+        Assert.Equal("dependency.spatial_derivation_failed", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 
-	// --- Phase A2: Locality resolution tests ---
+    // --- Phase A2: Locality resolution tests ---
 
-	[Fact]
-	public async Task SubmitAsync_ValidCoordinates_ResolvesLocalityAndPersistsLocalityId()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_ValidCoordinates_ResolvesLocalityAndPersistsLocalityId()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalIngestionService svc = CreateService();
 
-		await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		await _repo.Received(1).PersistSignalAsync(
-			Arg.Is<SignalEvent>(s => s.LocalityId == DefaultLocalityId),
-			Arg.Any<CancellationToken>());
-	}
+        await _repo.Received(1).PersistSignalAsync(
+            Arg.Is<SignalEvent>(s => s.LocalityId == DefaultLocalityId),
+            Arg.Any<CancellationToken>());
+    }
 
-	[Fact]
-	public async Task SubmitAsync_LocalityUnresolved_ThrowsAndDoesNotPersist()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SetupDefaultH3();
-		_localityLookup.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
-			.Returns((LocalitySummary?)null);
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_LocalityUnresolved_ThrowsAndDoesNotPersist()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SetupDefaultH3();
+        _localityLookup.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
+            .Returns((LocalitySummary?)null);
+        SignalIngestionService svc = CreateService();
 
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
-		Assert.Equal("validation.locality_unresolved", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
+        Assert.Equal("validation.locality_unresolved", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 
-	[Fact]
-	public async Task SubmitAsync_ValidSubmissionWithLocality_ReachesClusteringWithLocalityId()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_ValidSubmissionWithLocality_ReachesClusteringWithLocalityId()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalIngestionService svc = CreateService();
 
-		await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+        await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		await _clustering.Received(1).RouteSignalAsync(
-			Arg.Is<SignalEvent>(s => s.LocalityId == DefaultLocalityId),
-			Arg.Any<CancellationToken>());
-	}
+        await _clustering.Received(1).RouteSignalAsync(
+            Arg.Is<SignalEvent>(s => s.LocalityId == DefaultLocalityId),
+            Arg.Any<CancellationToken>());
+    }
 
-	// --- Phase A3: Cluster routing result in submit response ---
+    // --- Phase A3: Cluster routing result in submit response ---
 
-	[Fact]
-	public async Task SubmitAsync_NewClusterCreated_ResponseIncludesClusterIdAndIsNewCluster()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		var clusterId = Guid.NewGuid();
-		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
-			.Returns(new ClusterRoutingResult(clusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_NewClusterCreated_ResponseIncludesClusterIdAndIsNewCluster()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        var clusterId = Guid.NewGuid();
+        _clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+            .Returns(new ClusterRoutingResult(clusterId, WasCreated: true, WasJoined: false, "unconfirmed", DefaultLocalityId));
+        SignalIngestionService svc = CreateService();
 
-		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+        var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		Assert.Equal(clusterId, result.ClusterId);
-		Assert.True(result.IsNewCluster);
-		Assert.Equal("unconfirmed", result.ClusterState);
-		Assert.Equal(DefaultLocalityId, result.LocalityId);
-	}
+        Assert.Equal(clusterId, result.ClusterId);
+        Assert.True(result.IsNewCluster);
+        Assert.Equal("unconfirmed", result.ClusterState);
+        Assert.Equal(DefaultLocalityId, result.LocalityId);
+    }
 
-	[Fact]
-	public async Task SubmitAsync_JoinedExistingCluster_ResponseIncludesClusterIdAndIsNotNew()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		var clusterId = Guid.NewGuid();
-		_clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
-			.Returns(new ClusterRoutingResult(clusterId, WasCreated: false, WasJoined: true, "active", DefaultLocalityId));
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_JoinedExistingCluster_ResponseIncludesClusterIdAndIsNotNew()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        var clusterId = Guid.NewGuid();
+        _clustering.RouteSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>())
+            .Returns(new ClusterRoutingResult(clusterId, WasCreated: false, WasJoined: true, "active", DefaultLocalityId));
+        SignalIngestionService svc = CreateService();
 
-		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+        var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		Assert.Equal(clusterId, result.ClusterId);
-		Assert.False(result.IsNewCluster);
-		Assert.Equal("active", result.ClusterState);
-	}
+        Assert.Equal(clusterId, result.ClusterId);
+        Assert.False(result.IsNewCluster);
+        Assert.Equal("active", result.ClusterState);
+    }
 
-	[Fact]
-	public async Task SubmitAsync_ResponseAlwaysIncludesSignalEventIdAndCreatedAt()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_ResponseAlwaysIncludesSignalEventIdAndCreatedAt()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalIngestionService svc = CreateService();
 
-		var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
+        var result = await svc.SubmitAsync(MakeSubmitRequest(), null, null);
 
-		Assert.NotEqual(Guid.Empty, result.SignalEventId);
-		Assert.NotEqual(Guid.Empty, result.ClusterId);
-		Assert.NotEqual(default, result.CreatedAt);
-	}
+        Assert.NotEqual(Guid.Empty, result.SignalEventId);
+        Assert.NotEqual(Guid.Empty, result.ClusterId);
+        Assert.NotEqual(default, result.CreatedAt);
+    }
 
-	// --- B9: Location label length validation ---
+    // --- B9: Location label length validation ---
 
-	[Fact]
-	public async Task SubmitAsync_LocationLabelExceedsMaxLength_ThrowsValidation()
-	{
-		_repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
-		_repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		string oversized = new string('x', 401);
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = oversized };
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_LocationLabelExceedsMaxLength_ThrowsValidation()
+    {
+        _repo.IdempotencyKeyExistsAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
+        _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(true);
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        string oversized = new string('x', 401);
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = oversized };
+        SignalIngestionService svc = CreateService();
 
-		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
-		Assert.Equal("validation.location_label_too_long", ex.Code);
-		await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
-	}
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.location_label_too_long", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 
-	[Fact]
-	public async Task SubmitAsync_LocationLabelAtMaxLength_Succeeds()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		string atLimit = new string('x', 400);
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = atLimit };
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_LocationLabelAtMaxLength_Succeeds()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        string atLimit = new string('x', 400);
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = atLimit };
+        SignalIngestionService svc = CreateService();
 
-		var result = await svc.SubmitAsync(request, null, null);
+        var result = await svc.SubmitAsync(request, null, null);
 
-		Assert.NotEqual(Guid.Empty, result.SignalEventId);
-	}
+        Assert.NotEqual(Guid.Empty, result.SignalEventId);
+    }
 
-	[Fact]
-	public async Task SubmitAsync_NullLocationLabel_Succeeds()
-	{
-		SetupDefaultRepo();
-		SetupDefaultH3();
-		SetupDefaultLocality();
-		SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = null };
-		SignalIngestionService svc = CreateService();
+    [Fact]
+    public async Task SubmitAsync_NullLocationLabel_Succeeds()
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationLabel = null };
+        SignalIngestionService svc = CreateService();
 
-		var result = await svc.SubmitAsync(request, null, null);
+        var result = await svc.SubmitAsync(request, null, null);
 
-		Assert.NotEqual(Guid.Empty, result.SignalEventId);
-	}
+        Assert.NotEqual(Guid.Empty, result.SignalEventId);
+    }
+
+    // --- C11: location source allowlist + place_search label requirement ---
+
+    [Theory]
+    [InlineData("nlp")]
+    [InlineData("user_edit")]
+    [InlineData("place_search")]
+    public async Task SubmitAsync_ValidLocationSource_Succeeds(string source)
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        // place_search requires a label; the default request already has one.
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationSource = source };
+        SignalIngestionService svc = CreateService();
+
+        var result = await svc.SubmitAsync(request, null, null);
+
+        Assert.NotEqual(Guid.Empty, result.SignalEventId);
+    }
+
+    [Theory]
+    [InlineData("map_pin")]        // deferred to C11.1 — not yet in the allowlist
+    [InlineData("NLP")]            // wire allowlist is case-sensitive
+    [InlineData("place-search")]   // dash vs underscore
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SubmitAsync_UnknownLocationSource_ThrowsInvalidLocationSource(string source)
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalSubmitRequestDto request = MakeSubmitRequest() with { LocationSource = source };
+        SignalIngestionService svc = CreateService();
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.invalid_location_source", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task SubmitAsync_PlaceSearchWithoutLabel_ThrowsLocationLabelRequired(string? label)
+    {
+        SetupDefaultRepo();
+        SetupDefaultH3();
+        SetupDefaultLocality();
+        SignalSubmitRequestDto request = MakeSubmitRequest() with
+        {
+            LocationSource = "place_search",
+            LocationLabel = label,
+        };
+        SignalIngestionService svc = CreateService();
+
+        var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.SubmitAsync(request, null, null));
+        Assert.Equal("validation.location_label_required", ex.Code);
+        await _repo.DidNotReceive().PersistSignalAsync(Arg.Any<SignalEvent>(), Arg.Any<CancellationToken>());
+    }
 }

--- a/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
@@ -122,6 +122,40 @@ public class SignalIngestionServiceTests
     }
 
     [Theory]
+    [InlineData("garbage")]
+    [InlineData("NLP")]            // wire allowlist is case-sensitive
+    [InlineData("user")]           // legacy value no longer in the allowlist
+    [InlineData("")]
+    public async Task PreviewAsync_UnknownNlpLocationSource_NormalizedToNlp(string rawFromNlp)
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        NlpExtractionResultDto weirdSource = new NlpExtractionResultDto(
+            "roads", "potholes", "difficult", 0.85,
+            new NlpLocationDto("Nairobi West", null, null, null, null, "Ngong Rd", "road", 0.9, rawFromNlp),
+            new NlpTemporalHintDto("temporary", 0.7), "Potholes.", ShouldSuggestJoin: false, null);
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(weirdSource);
+        SignalIngestionService svc = CreateService();
+
+        SignalPreviewResponseDto result = await svc.PreviewAsync(
+            new SignalPreviewRequestDto("Potholes", null, null, null, null, "Nairobi", "KE"));
+
+        Assert.Equal("nlp", result.Location.LocationSource);
+    }
+
+    [Fact]
+    public async Task PreviewAsync_ValidNlpLocationSource_Preserved()
+    {
+        _repo.BuildTaxonomyBlockAsync(Arg.Any<CancellationToken>()).Returns("roads: potholes");
+        _nlp.ExtractAsync(Arg.Any<NlpExtractionRequest>(), Arg.Any<CancellationToken>()).Returns(MakeNlpResult());
+        SignalIngestionService svc = CreateService();
+
+        SignalPreviewResponseDto result = await svc.PreviewAsync(
+            new SignalPreviewRequestDto("Big potholes on Lusaka Road", null, null, null, null, "Nairobi", "KE"));
+
+        Assert.Equal("nlp", result.Location.LocationSource);
+    }
+
+    [Theory]
     [InlineData(null)]
     [InlineData("")]
     [InlineData("   ")]


### PR DESCRIPTION
## Summary

C11 implements the low-confidence location fallback path for the signal
composer. When CSI-NLP cannot confidently place a report, the composer
now routes the user into a deliberate correction UX (place search +
current-location reverse-geocode) instead of accepting a weak label or
silently dropping to device GPS. Free-text-first reporting stays intact;
the map is a fallback, not a primary surface.

## Problem

Before this PR, the composer's handling of low-confidence NLP output was:

- The decision was client-only (three-tier \`classifyLocationGate\`
  keyed on confidence threshold).
- A blank but high-confidence label silently passed the gate.
- The only correction path was a plain text input — no help finding
  the place, no authoritative coordinates beyond device GPS.
- \`locationSource\` on the wire was a free-form string with no
  allowlist. Unknown values could reach the DB unvalidated.
- There was no server signal for \"this extraction needs correction\",
  so a second client would have to re-derive the same thresholds.

## Approach

**Centralize the decision.** \`LocationFallbackPolicy.RequiresFallback\`
in \`Hali.Application\` is the single source of truth. Rule: confidence
< 0.5 OR locationLabel blank. \`SignalPreviewResponse\` now carries
\`requiresLocationFallback\` — the composer respects the server flag
first and falls back to a client mirror of the same rule offline.

**Tighten the contract.** \`LocationSource\` becomes a typed allowlist
(\`nlp | user_edit | place_search\`) in both C# (\`Hali.Contracts.Signals.LocationSource\`)
and OpenAPI. Submit rejects unknown values with
\`validation.invalid_location_source\`. When source is \`place_search\`,
\`locationLabel\` is required (\`validation.location_label_required\`).
The draggable \`map_pin\` source is intentionally deferred to
#129 — we only advertise what we can produce.

**Add the fallback surface, not a map-first UX.** New
\`PlacesController\` exposes \`GET /v1/places/search\` and
\`GET /v1/places/reverse\`, both wrapping the existing
\`IGeocodingService\` (Nominatim, already DI-wired and Redis-cached).
Candidates whose coordinates fall outside known Hali localities are
filtered at the API boundary so the composer never surfaces a pick
that submit would later reject for \`validation.locality_unresolved\`.

**Mobile picker.** \`LocationFallbackPicker\` renders for the
\`fallback\` tier only: debounced place search + \"Use my current
location\". Selection produces a \`ComposerLocationOverride\`
(authoritative coords + label + source) carried through
\`ComposerContext\` to submit, where it wins over device GPS.

## Spatial integrity

Every fallback path lands back at the same guards that already protect
the non-fallback path:

- Coord range check (-90..90 / -180..180)
- H3 cell derivation (resolution 9)
- PostGIS ward resolution (\`validation.locality_unresolved\`)

No partial / degraded persistence. A fallback pick outside known wards
is rejected by the existing guards just like any other submit.

## Files changed (19)

**Backend**
- \`src/Hali.Contracts/Signals/LocationSource.cs\` (new) — wire allowlist
- \`src/Hali.Contracts/Signals/PlaceCandidateDto.cs\` (new) — places wire DTO
- \`src/Hali.Contracts/Signals/SignalPreviewResponseDto.cs\` — \`RequiresLocationFallback\`
- \`src/Hali.Application/Signals/LocationFallbackPolicy.cs\` (new) — decision rule
- \`src/Hali.Application/Signals/SignalIngestionService.cs\` — preview flag + submit allowlist + place_search label requirement
- \`src/Hali.Api/Controllers/PlacesController.cs\` (new) — \`/v1/places/search\` + \`/v1/places/reverse\`

**Mobile**
- \`apps/citizen-mobile/src/utils/composerGates.ts\` — \`fallback\` tier + server-flag-wins
- \`apps/citizen-mobile/src/types/api.ts\` — \`SignalLocationSource\` union, \`PlaceCandidate\`, \`requiresLocationFallback\`
- \`apps/citizen-mobile/src/api/places.ts\` (new) — client
- \`apps/citizen-mobile/src/context/ComposerContext.tsx\` — \`locationOverride\`
- \`apps/citizen-mobile/src/components/compose/LocationFallbackPicker.tsx\` (new) — UI
- \`apps/citizen-mobile/app/(app)/compose/confirm.tsx\` — renders picker for fallback tier
- \`apps/citizen-mobile/app/(app)/compose/submit.tsx\` — honors override coords + source

**Contract**
- \`02_openapi.yaml\` — \`LocationSource\` enum, \`requiresLocationFallback\`, \`PlaceCandidate\`, \`/v1/places/*\`

**Tests** — see below

## Tests added / updated

- \`tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs\` — 3
  preview tests (high-confidence-no-fallback, low-confidence,
  blank-label), 3 submit tests (source allowlist, unknown source
  rejected, place_search-without-label rejected).
- \`tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs\` (new) — 18
  tests covering search/reverse happy paths, validation, rate-limit,
  spatial filtering, reverse-geocode failure fallback label.
- \`tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs\` —
  \`requiresLocationFallback\` assertion on wire.
- \`apps/citizen-mobile/__tests__/composer/locationGate.test.ts\` —
  migrated 'required' → 'fallback' tier; +8 cases for server flag and
  blank label semantics.
- \`apps/citizen-mobile/__tests__/api/places.test.ts\` (new) — URL
  shape + error pass-through for \`searchPlaces\` / \`reverseGeocodePoint\`.

## Rules / gates applied

- CODING_STANDARDS: LocationSource enum serialization strict, no
  hardcoded hex, no Animated, no \`any\`, no request-derived values in
  logs, AllowAnonymous explicit on new endpoints, XML \`<exception>\`
  docs match new throws, URL-encoding via \`Uri.EscapeDataString\` in
  tests only.
- PR_QUALITY_GATES G1–G7 run; G3 diffed (\`tests/\` additions only,
  no silent drops).
- COPILOT_LESSONS #4 (tests-lost-in-merge) explicitly checked;
  COPILOT_LESSONS #1 / #2 (log forging, OperationCanceledException)
  observed in new \`PlacesController\` + ingestion paths.

## Validation

- \`dotnet build\` — 0 errors.
- \`dotnet format --verify-no-changes\` — clean on C11 files. (Pre-
  existing violations remain in \`tests/Hali.Tests.Integration/**\`;
  out of scope for this PR.)
- \`dotnet test tests/Hali.Tests.Unit\` — **334/334 passing**.
- \`npx tsc --noEmit\` — 0 errors.
- \`jest\` — **218/218 passing**.

## Risks

- **Redis cache format**: new endpoints write through MVC \`JsonOptions\`
  (camelCase, Web preset) — matches the #127 alignment pattern already
  merged for Localities. Cache keys are namespaced (\`places_search:\`,
  \`places_reverse:\`); no collision with existing keys.
- **Nominatim rate/budget**: the new endpoints share the same upstream
  as \`/v1/localities/search\`. Per-IP rate-limit (30/min) and Redis
  TTL (1h search, 1d reverse) keep the fan-out bounded.
- **Wire enum lock-in**: \`LocationSource\` is now a typed enum. Any
  future source (\`map_pin\`, etc.) requires coordinated OpenAPI + C#
  + TS updates; see #129.

## Deferred

- **Draggable map-pin correction** — filed as #129. Keeps this PR
  reviewable and avoids adding \`react-native-maps\` as a native
  dependency in a feature PR.

## Test plan

- [ ] \`dotnet build\` completes clean.
- [ ] \`dotnet test tests/Hali.Tests.Unit\` — 334 passing.
- [ ] \`apps/citizen-mobile\`: \`npx tsc --noEmit\` clean; \`jest\` 218 passing.
- [ ] Manually verify on a running API: \`GET /v1/places/search?q=Ngong+Road\`
  returns candidates with coords + localityId.
- [ ] Manually verify: \`GET /v1/places/reverse?latitude=-1.3&longitude=36.8\`
  returns a candidate with a human-readable label.
- [ ] Submit with \`locationSource=\"map_pin\"\` is rejected with
  \`validation.invalid_location_source\` (confirms allowlist).
- [ ] Submit with \`locationSource=\"place_search\"\` and blank label
  is rejected with \`validation.location_label_required\`.
- [ ] Manual mobile walkthrough of the fallback tier once dev build
  is rebuilt (place search list renders; \"Use my current location\"
  resolves and locks in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)