### PR TITLE
fix(c11): flip locationSource to user_edit on meaningful label edit

### DIFF
--- a/apps/citizen-mobile/__tests__/composer/canProceed.test.ts
+++ b/apps/citizen-mobile/__tests__/composer/canProceed.test.ts
@@ -10,6 +10,7 @@
 
 import {
   canProceedFromLocationGate,
+  isMeaningfulLabelEdit,
   type LocationProceedInput,
 } from '../../src/utils/composerGates';
 
@@ -161,6 +162,15 @@ describe('canProceedFromLocationGate', () => {
     });
   });
 
+  // Shared rule — the 'confirm' tier here and the submit-source flip
+  // in confirm.tsx's handleNext both read isMeaningfulLabelEdit. This
+  // suite pins the behavior so the two paths cannot drift.
+  //
+  // Kept alongside canProceed tests because the helper lives in the
+  // same file and the semantics are coupled: if the gate says "this
+  // is an edit" for 'confirm', the submit path MUST submit the label
+  // as user_edit, and vice-versa.
+
   describe("required tier (not emitted by location gate today)", () => {
     // Defensive coverage: classifyLocationGate never returns 'required'
     // for location, but the union still contains it because the
@@ -187,5 +197,79 @@ describe('canProceedFromLocationGate', () => {
         }),
       ).toBe(false);
     });
+  });
+});
+
+describe('isMeaningfulLabelEdit', () => {
+  // This rule is read by two places:
+  //   - canProceedFromLocationGate's 'confirm' tier, and
+  //   - confirm.tsx's handleNext (C11 follow-up #131) to decide
+  //     whether to flip the submit wire source from 'nlp' to 'user_edit'.
+  // A drift between those two paths would silently submit user-authored
+  // text under source='nlp' (or vice-versa). These cases pin the
+  // semantics.
+
+  it('is false when the label matches the original verbatim', () => {
+    expect(
+      isMeaningfulLabelEdit({ label: 'Ngong Road', originalLabel: 'Ngong Road' }),
+    ).toBe(false);
+  });
+
+  it('is false when the label matches the original modulo whitespace', () => {
+    expect(
+      isMeaningfulLabelEdit({
+        label: '  Ngong Road  ',
+        originalLabel: 'Ngong Road',
+      }),
+    ).toBe(false);
+    expect(
+      isMeaningfulLabelEdit({
+        label: 'Ngong Road',
+        originalLabel: '  Ngong Road\n',
+      }),
+    ).toBe(false);
+  });
+
+  it('is false when the label has been blanked', () => {
+    // Blanking yields no new user-authored content — backend would
+    // reject anyway via the fallback gate / label-required guards,
+    // but we must not flip the source to 'user_edit' on the way out.
+    expect(
+      isMeaningfulLabelEdit({ label: '', originalLabel: 'Ngong Road' }),
+    ).toBe(false);
+    expect(
+      isMeaningfulLabelEdit({ label: '   ', originalLabel: 'Ngong Road' }),
+    ).toBe(false);
+  });
+
+  it('is true when trimmed edited text differs from trimmed original', () => {
+    expect(
+      isMeaningfulLabelEdit({
+        label: 'Lusaka Road',
+        originalLabel: 'Ngong Road',
+      }),
+    ).toBe(true);
+    // Minor textual tightening (adding neighborhood context) counts.
+    expect(
+      isMeaningfulLabelEdit({
+        label: 'Ngong Road, near Adams Arcade',
+        originalLabel: 'Ngong Road',
+      }),
+    ).toBe(true);
+  });
+
+  it('is true when originalLabel is null/undefined and the user typed something', () => {
+    expect(
+      isMeaningfulLabelEdit({ label: 'Ngong Road', originalLabel: null }),
+    ).toBe(true);
+    expect(
+      isMeaningfulLabelEdit({ label: 'Ngong Road', originalLabel: undefined }),
+    ).toBe(true);
+  });
+
+  it('is false when both sides are blank regardless of representation', () => {
+    expect(isMeaningfulLabelEdit({ label: '', originalLabel: null })).toBe(false);
+    expect(isMeaningfulLabelEdit({ label: '   ', originalLabel: '' })).toBe(false);
+    expect(isMeaningfulLabelEdit({ label: '', originalLabel: '   ' })).toBe(false);
   });
 });

--- a/apps/citizen-mobile/app/(app)/compose/confirm.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/confirm.tsx
@@ -19,6 +19,7 @@ import { formatCategoryLabel } from '../../../src/utils/formatters';
 import {
   canProceedFromLocationGate,
   classifyLocationGate,
+  isMeaningfulLabelEdit,
   type ConfidenceGate,
 } from '../../../src/utils/composerGates';
 import { Colors, FontFamily, FontSize, Spacing, Radius, ScreenPaddingH } from '../../../src/theme';
@@ -117,9 +118,31 @@ function ConfirmScreenContent({
     // we don't need to mutate preview.location.locationLabel — submit.tsx
     // reads the override directly and overrides both coords and label.
     if (locationOverride === null) {
+      // C11 follow-up (#131): a meaningful edit to the text-input label
+      // means the wire source must flip from 'nlp' to 'user_edit' so
+      // downstream source-attribution matches the label's provenance.
+      // "Meaningful" mirrors the 'confirm' tier gate rule — trimmed,
+      // non-empty, and different from the trimmed original (see
+      // isMeaningfulLabelEdit in composerGates.ts). Whitespace-only
+      // and blanking edits do NOT flip source.
+      //
+      // Once flipped, the source stays 'user_edit' even if the user
+      // navigates back and re-edits; that's the correct outcome because
+      // the persisted label is already user-authored content, and there
+      // is no "un-edit" path back to the original NLP label from the
+      // UI.
+      const edited = isMeaningfulLabelEdit({
+        label: locationLabel,
+        originalLabel: preview.location.locationLabel,
+      });
+      const trimmed = locationLabel.trim();
       setPreview({
         ...preview,
-        location: { ...preview.location, locationLabel: locationLabel.trim() || preview.location.locationLabel },
+        location: {
+          ...preview.location,
+          locationLabel: trimmed || preview.location.locationLabel,
+          locationSource: edited ? 'user_edit' : preview.location.locationSource,
+        },
       });
     }
     router.push('/(app)/compose/submit');

--- a/apps/citizen-mobile/src/utils/composerGates.ts
+++ b/apps/citizen-mobile/src/utils/composerGates.ts
@@ -105,6 +105,37 @@ export function classifyConditionGate(confidence: number): ConfidenceGate {
 }
 
 /**
+ * Did the user *meaningfully* edit the composer's location label?
+ *
+ * Semantics — both sides are trimmed before comparison:
+ *   - whitespace-only edits don't count
+ *   - blanking the field doesn't count (no new user-authored content)
+ *   - any non-empty text that differs from the trimmed original counts
+ *
+ * Used in two places:
+ *   - {@link canProceedFromLocationGate}'s 'confirm' tier uses this to
+ *     decide whether to unlock Next without the explicit "Looks right"
+ *     chip, and
+ *   - the composer's `handleNext` uses it to flip the submit wire
+ *     `locationSource` from `'nlp'` to `'user_edit'` so source
+ *     attribution matches the label's provenance (C11 follow-up #131).
+ *
+ * Keeping a single helper prevents the two paths from drifting — if
+ * the gate thinks "you edited this" but the submit path thinks "you
+ * didn't", we'd submit user-authored text under `source='nlp'`.
+ */
+export interface MeaningfulEditInput {
+  label: string;
+  originalLabel: string | null | undefined;
+}
+
+export function isMeaningfulLabelEdit(input: MeaningfulEditInput): boolean {
+  const trimmed = input.label.trim();
+  const original = (input.originalLabel ?? '').trim();
+  return trimmed.length > 0 && trimmed !== original;
+}
+
+/**
  * Inputs to {@link canProceedFromLocationGate}. Mirrors the state the
  * composer's Step 2 carries internally (text-input value + the original
  * NLP label + whether the user tapped "Looks right" + whether the
@@ -147,9 +178,10 @@ export function canProceedFromLocationGate(input: LocationProceedInput): boolean
   // on its own regardless of gate.
   if (input.hasOverride) return true;
 
-  const trimmed = input.label.trim();
-  const original = (input.originalLabel ?? '').trim();
-  const userEdited = trimmed !== original && trimmed.length > 0;
+  const userEdited = isMeaningfulLabelEdit({
+    label: input.label,
+    originalLabel: input.originalLabel,
+  });
 
   switch (input.gate) {
     case 'accept':
@@ -166,6 +198,6 @@ export function canProceedFromLocationGate(input: LocationProceedInput): boolean
     case 'required':
       // Not emitted for the location gate today (kept in the union for
       // the condition gate). Treat defensively as "requires a label".
-      return trimmed.length > 0;
+      return input.label.trim().length > 0;
   }
 }


### PR DESCRIPTION
Closes irvinesunday/Hali#131.

## Problem

When the user edits the composer's location label in the non-override path (the \`'confirm'\` / \`'accept'\` tiers that render the text input), \`handleNext\` writes the edited text back into \`preview.location.locationLabel\` but leaves \`preview.location.locationSource\` untouched at \`'nlp'\`. Submit then sends user-authored text under \`locationSource='nlp'\`.

This is not a security or integrity failure — the backend \`LocationSource\` allowlist accepts both values, and every spatial guard (bounds, H3, locality, label-length) still runs on submit. But downstream source-attribution analytics, and any future CIVIS logic that weights NLP-derived vs user-edited signals differently, would be silently wrong.

Identified during the C11 focused diff review as **N-2** and intentionally deferred to keep the C11 submit-path diff tight (#130).

## Root cause

The \"did the user edit?\" check exists twice in the composer today — inline inside \`canProceedFromLocationGate\`'s \`'confirm'\` tier (where it unlocks Next) and inline inside \`handleNext\`'s mutation (where it writes the edited label back). The gate check drove UI readiness; the \`handleNext\` check only updated the label. Source attribution was never wired to either.

## Implementation approach

Centralise the rule in one helper and have both the gate and the source-flip read from it, so they cannot drift.

**New pure helper in \`composerGates.ts\`:**
\`\`\`ts
export function isMeaningfulLabelEdit({ label, originalLabel }): boolean
\`\`\`
- trims both sides,
- requires non-empty new text,
- requires it to differ from the trimmed original.

**\`canProceedFromLocationGate\`** — the \`'confirm'\` tier now calls \`isMeaningfulLabelEdit\` instead of an inline duplicate. Zero behavior change.

**\`confirm.tsx\` \`handleNext\`** — on the non-override branch, calls \`isMeaningfulLabelEdit\` and flips \`preview.location.locationSource\` to \`'user_edit'\` when true; otherwise leaves it untouched (keeping \`'nlp'\` or whatever was previously set).

**Override path** — untouched. When \`locationOverride\` is non-null, \`handleNext\`'s mutation branch is skipped entirely and \`submit.tsx\` reads \`locationOverride.source\` directly. \`place_search\` / \`map_pin\` pass through verbatim.

**Idempotence on back-navigation** — once flipped, the source stays \`'user_edit'\` even if the user goes back and re-edits. That's the correct outcome: the persisted label is already user-authored, and there is no UI path back to the original NLP string to \"un-edit.\"

## Decision points called out

- **Whitespace / blanking edges**: whitespace-only edits and fully-blanking the field do NOT flip source. The gate would block submit anyway in the fallback case, and in the \`'confirm'\` / \`'accept'\` cases blanking is not user-authored content.
- **Helper location**: \`composerGates.ts\`, alongside \`canProceedFromLocationGate\`, because both consumers already live there conceptually and the gate's \`userEdited\` was already reading the same rule inline. Avoids a third file.
- **No backend / OpenAPI changes**: \`'user_edit'\` has been in the \`LocationSource\` allowlist + OpenAPI enum since C11 shipped. The fix is purely a mobile attribution correction.

## Files changed

- \`apps/citizen-mobile/src/utils/composerGates.ts\` — new \`isMeaningfulLabelEdit\` export + \`MeaningfulEditInput\` interface; \`canProceedFromLocationGate\` refactored to call it.
- \`apps/citizen-mobile/app/(app)/compose/confirm.tsx\` — \`handleNext\` calls the helper and flips \`locationSource\` to \`'user_edit'\` on meaningful edit; comment block explains the idempotence trade-off.
- \`apps/citizen-mobile/__tests__/composer/canProceed.test.ts\` — new \`isMeaningfulLabelEdit\` describe block (+6 cases).

## Validation performed

- \`npx tsc --noEmit\` — 0 errors.
- \`jest\` — **252/252 passing** (+6 over the C11.1 baseline 246).
- No backend changes; backend tests (348/348) remain green unchanged.
- Pre-commit grep checks on touched TS/TSX files: no hardcoded hex (the one flagged line is \`#131\` as a GitHub issue reference in a JSDoc comment), no forbidden icon libs, no \`Animated\` from \`react-native\`, no \`any\` types.

## Risks

- **Idempotence after back-navigation.** Documented above and in the code comment. The only scenario where the caller might expect a different outcome would be \"user edits, navigates back, un-edits to match the NLP original exactly\" — but that's a paste-the-exact-string-back contortion, and even then the source flip is semantically defensible (the label crossed user-authored territory).
- **No changes to the override path.** Explicitly verified: \`handleNext\`'s new logic runs only when \`locationOverride === null\`. \`place_search\` and \`map_pin\` overrides are untouched.

## Test plan

- [ ] \`apps/citizen-mobile\`: \`npx tsc --noEmit\` clean; \`jest\` 252 passing.
- [ ] Exercise in a dev build:
  - accept tier, no edit → submit with \`locationSource='nlp'\`;
  - confirm tier, tap \"Looks right\" without editing → submit with \`locationSource='nlp'\`;
  - confirm tier, edit label then Next → submit with \`locationSource='user_edit'\`;
  - edit, navigate back, add whitespace only → still \`'user_edit'\` (already flipped, correctly sticky);
  - fallback tier, pick via place_search → submit with \`locationSource='place_search'\` (unchanged);
  - fallback tier, drop pin → submit with \`locationSource='map_pin'\` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)