### PR TITLE
refactor(h2): unify result/response semantics at the H1 boundary

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -50,12 +50,9 @@ paths:
           description: OTP sent
           content:
             application/json:
-              schema:
-                type: object
-                properties:
-                  message: { type: string, example: "OTP sent" }
+              schema: { $ref: '#/components/schemas/OtpRequestedResponse' }
         '429':
-          description: OTP rate limited
+          description: OTP rate limited (auth.otp_rate_limited)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -85,7 +82,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenResponse'
         '400':
-          description: Invalid or expired OTP
+          description: Invalid or expired OTP (auth.otp_invalid)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -110,7 +107,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/TokenResponse'
         '401':
-          description: Invalid or expired refresh token
+          description: Invalid or expired refresh token (auth.refresh_token_invalid)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -151,12 +148,17 @@ paths:
       responses:
         '202': { description: OTP sent to phone }
         '400':
-          description: Invalid, expired, or already-accepted invite
+          description: Invalid or expired invite (invite.invalid, invite.expired)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '409':
+          description: Invite already accepted (invite.already_accepted)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         '429':
-          description: OTP rate limited
+          description: OTP rate limited (auth.otp_rate_limited)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -252,15 +254,7 @@ paths:
             application/json:
               schema:
                 type: array
-                items:
-                  type: object
-                  required: [localityId, wardName, cityName]
-                  properties:
-                    localityId: { type: string, format: uuid }
-                    wardName: { type: string }
-                    cityName:
-                      type: string
-                      nullable: true
+                items: { $ref: '#/components/schemas/LocalitySummary' }
 
   /v1/localities/search:
     get:
@@ -299,7 +293,12 @@ paths:
                       type: string
                       nullable: true
         '400':
-          description: Query too short
+          description: Query too short or too long (locality.query_too_short, locality.query_too_long)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: Rate limit exceeded (locality.search_rate_limited)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -327,15 +326,14 @@ paths:
           description: Nearest matched locality
           content:
             application/json:
-              schema:
-                type: object
-                required: [localityId, wardName, cityName]
-                properties:
-                  localityId: { type: string, format: uuid }
-                  wardName: { type: string }
-                  cityName: { type: string, nullable: true }
+              schema: { $ref: '#/components/schemas/LocalitySummary' }
+        '400':
+          description: Coordinates out of range (locality.invalid_coordinates)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
         '404':
-          description: No locality found for coordinates
+          description: No locality found for coordinates (locality.not_found)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -665,17 +663,18 @@ paths:
               schema:
                 $ref: '#/components/schemas/OfficialPostResponse'
         '400':
-          description: type, category, title, or body missing
+          description: |
+            Missing fields (official_post.missing_fields),
+            invalid post type (official_post.invalid_type), or
+            invalid category (official_post.invalid_category).
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         '403':
-          description: Outside institution jurisdiction (code=outside_jurisdiction)
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ErrorResponse' }
-        '422':
-          description: invalid_post_type, invalid_category, or institution_required
+          description: |
+            Outside institution jurisdiction
+            (official_post.outside_jurisdiction) or missing/malformed
+            institution_id claim on the JWT (auth.institution_id_missing).
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -787,12 +786,15 @@ paths:
       responses:
         '204': { description: Updated }
         '400':
-          description: device_hash or expo_push_token missing
+          description: device_hash or expo_push_token missing (device.missing_fields)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
-        '422':
-          description: device_not_found
+        '404':
+          description: |
+            Device not recognised (device.not_found). Previously 422 —
+            re-typed as NotFound (H2) since "no matching device" is
+            semantically a missing resource.
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -898,15 +900,52 @@ components:
     ErrorResponse:
       type: object
       description: |
-        Standard error envelope. Most endpoints return `{ error }`; some 422
-        responses additionally include a stable `code` for programmatic
-        handling. When `code` is `policy_blocked`, an optional `reason` field
-        carries the specific sub-reason (e.g.
-        `context_edit_window_expired`).
+        Canonical error envelope emitted by the API's centralized exception
+        middleware (H1). Every non-2xx response from every endpoint returns
+        this shape.
+
+          * `error.code` — stable, snake_case_with_dot-namespacing identifier
+            for programmatic handling (e.g. `auth.otp_invalid`,
+            `validation.locality_unresolved`, `signal.duplicate`).
+          * `error.message` — short human-readable summary safe to surface
+            in UI. Not localized; treat wording as unstable between versions.
+          * `error.details` — optional. When present on 400 responses it
+            carries `{ fields: { fieldName: ["error msg", ...] } }` for
+            per-field validation errors. Other codes may include additional
+            structured metadata.
+          * `error.traceId` — sanitized correlation ID for support/log
+            correlation. Not a security boundary.
+      required: [error]
       properties:
-        error: { type: string }
-        code: { type: string, nullable: true }
-        reason: { type: string, nullable: true }
+        error:
+          type: object
+          required: [code, message, traceId]
+          properties:
+            code: { type: string }
+            message: { type: string }
+            details: { type: object, nullable: true, additionalProperties: true }
+            traceId: { type: string }
+
+    OtpRequestedResponse:
+      type: object
+      description: |
+        Success body for POST /v1/auth/otp. The `message` field is a short
+        human-readable status; clients should not depend on its exact wording.
+      required: [message]
+      properties:
+        message: { type: string, example: "OTP sent" }
+
+    LocalitySummary:
+      type: object
+      description: |
+        Minimal ward/locality summary. Used both by the canonical ward list
+        and by single-ward coordinate-resolution responses. Mirrors
+        `Hali.Contracts.Notifications.LocalitySummaryDto`.
+      required: [localityId, wardName, cityName]
+      properties:
+        localityId: { type: string, format: uuid }
+        wardName: { type: string }
+        cityName: { type: string, nullable: true }
 
     TokenResponse:
       type: object

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -901,8 +901,15 @@ components:
       type: object
       description: |
         Canonical error envelope emitted by the API's centralized exception
-        middleware (H1). Every non-2xx response from every endpoint returns
-        this shape.
+        middleware (H1) and used by every documented application-level error
+        response in this spec.
+
+        Framework-generated authentication/authorization failures (e.g. 401
+        from the JwtBearer challenge or 403 from policy denial) short-circuit
+        before the exception middleware runs and therefore may return an
+        empty body instead of this envelope. Documented `401`/`403` entries
+        that reference this schema describe failures surfaced as typed
+        `UnauthorizedException`/`ForbiddenException` from application code.
 
           * `error.code` — stable, snake_case_with_dot-namespacing identifier
             for programmatic handling (e.g. `auth.otp_invalid`,

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -901,8 +901,10 @@ components:
       type: object
       description: |
         Canonical error envelope emitted by the API's centralized exception
-        middleware (H1) and used by every documented application-level error
-        response in this spec.
+        middleware (H1) and referenced by most documented application-level
+        error responses in this spec. A small number of legacy endpoints
+        still document body-less 4xx responses; those are tracked for
+        migration but are intentionally not referenced to this schema.
 
         Framework-generated authentication/authorization failures (e.g. 401
         from the JwtBearer challenge or 403 from policy denial) short-circuit

--- a/src/Hali.Api/Controllers/AdminController.cs
+++ b/src/Hali.Api/Controllers/AdminController.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Contracts.Auth;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -27,7 +29,12 @@ public class AdminController : ControllerBase
         CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(dto.Name))
-            return BadRequest(new { error = "name is required." });
+        {
+            throw new ValidationException(
+                "name is required.",
+                code: "institution.missing_fields",
+                fieldErrors: new Dictionary<string, string[]> { ["name"] = new[] { "name is required" } });
+        }
 
         Guid adminAccountId = Guid.Empty;
         if (Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var parsed))

--- a/src/Hali.Api/Controllers/AuthController.cs
+++ b/src/Hali.Api/Controllers/AuthController.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
@@ -27,53 +26,22 @@ public class AuthController : ControllerBase
     [HttpPost("otp")]
     public async Task<IActionResult> RequestOtp([FromBody] OtpRequestDto dto, CancellationToken ct)
     {
-        try
-        {
-            await _otpService.RequestOtpAsync(dto.Destination, dto.AuthMethod, ct);
-            return Ok(new
-            {
-                message = "OTP sent"
-            });
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "OTP_RATE_LIMITED")
-        {
-            return StatusCode(429, new
-            {
-                error = "Too many OTP requests. Please try again later."
-            });
-        }
+        await _otpService.RequestOtpAsync(dto.Destination, dto.AuthMethod, ct);
+        // Success payload is still an anonymous {message} shape at this commit;
+        // Commit 5 replaces it with the typed OtpRequestedResponseDto.
+        return Ok(new { message = "OTP sent" });
     }
 
     [HttpPost("verify")]
     public async Task<IActionResult> Verify([FromBody] VerifyOtpRequestDto dto, CancellationToken ct)
     {
-        try
-        {
-            return Ok(await _authService.AuthenticateAsync(dto, ct));
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "OTP_INVALID")
-        {
-            return BadRequest(new
-            {
-                error = "Invalid or expired OTP."
-            });
-        }
+        return Ok(await _authService.AuthenticateAsync(dto, ct));
     }
 
     [HttpPost("refresh")]
     public async Task<IActionResult> Refresh([FromBody] RefreshRequestDto dto, CancellationToken ct)
     {
-        try
-        {
-            return Ok(await _authService.RefreshAsync(dto.RefreshToken, ct));
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "REFRESH_TOKEN_INVALID")
-        {
-            return Unauthorized(new
-            {
-                error = "Invalid or expired refresh token."
-            });
-        }
+        return Ok(await _authService.RefreshAsync(dto.RefreshToken, ct));
     }
 
     [HttpPost("logout")]
@@ -86,26 +54,7 @@ public class AuthController : ControllerBase
     [HttpPost("institution/setup")]
     public async Task<IActionResult> InstitutionSetup([FromBody] InstitutionSetupRequestDto dto, CancellationToken ct)
     {
-        try
-        {
-            await _institutionService.SetupInstitutionAccountAsync(dto, ct);
-            return Accepted();
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "INVITE_INVALID")
-        {
-            return BadRequest(new { error = "Invalid invite token." });
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "INVITE_EXPIRED")
-        {
-            return BadRequest(new { error = "Invite token has expired." });
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "INVITE_ALREADY_ACCEPTED")
-        {
-            return BadRequest(new { error = "Invite has already been accepted." });
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "OTP_RATE_LIMITED")
-        {
-            return StatusCode(429, new { error = "Too many OTP requests. Please try again later." });
-        }
+        await _institutionService.SetupInstitutionAccountAsync(dto, ct);
+        return Accepted();
     }
 }

--- a/src/Hali.Api/Controllers/AuthController.cs
+++ b/src/Hali.Api/Controllers/AuthController.cs
@@ -27,9 +27,7 @@ public class AuthController : ControllerBase
     public async Task<IActionResult> RequestOtp([FromBody] OtpRequestDto dto, CancellationToken ct)
     {
         await _otpService.RequestOtpAsync(dto.Destination, dto.AuthMethod, ct);
-        // Success payload is still an anonymous {message} shape at this commit;
-        // Commit 5 replaces it with the typed OtpRequestedResponseDto.
-        return Ok(new { message = "OTP sent" });
+        return Ok(new OtpRequestedResponseDto("OTP sent"));
     }
 
     [HttpPost("verify")]

--- a/src/Hali.Api/Controllers/DevicesController.cs
+++ b/src/Hali.Api/Controllers/DevicesController.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Contracts.Notifications;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -29,15 +31,27 @@ public class DevicesController : ControllerBase
         [FromBody] RegisterPushTokenRequestDto dto,
         CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(dto.ExpoPushToken))
-            return BadRequest(new { error = "expo_push_token is required." });
-
-        if (string.IsNullOrWhiteSpace(dto.DeviceHash))
-            return BadRequest(new { error = "device_hash is required." });
+        var missing = new Dictionary<string, string[]>();
+        if (string.IsNullOrWhiteSpace(dto.ExpoPushToken)) missing["expoPushToken"] = new[] { "expo_push_token is required" };
+        if (string.IsNullOrWhiteSpace(dto.DeviceHash)) missing["deviceHash"] = new[] { "device_hash is required" };
+        if (missing.Count > 0)
+        {
+            throw new ValidationException(
+                "expo_push_token and device_hash are required.",
+                code: "device.missing_fields",
+                fieldErrors: missing);
+        }
 
         var device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
         if (device == null)
-            return UnprocessableEntity(new { error = "Device not recognised.", code = "device_not_found" });
+        {
+            // Previously returned 422. Re-typed to NotFound (404) because
+            // "no matching device" is semantically a missing resource. The
+            // client is expected to re-register the device before retrying.
+            throw new NotFoundException(
+                code: "device.not_found",
+                message: "Device not recognised.");
+        }
 
         var start = DateTime.UtcNow;
         await _auth.UpdateExpoPushTokenAsync(device.Id, dto.ExpoPushToken, ct);

--- a/src/Hali.Api/Controllers/LocalitiesController.cs
+++ b/src/Hali.Api/Controllers/LocalitiesController.cs
@@ -163,11 +163,11 @@ public class LocalitiesController : ControllerBase
     public async Task<IActionResult> Search([FromQuery] string q, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
-            return BadRequest(new { error = "Query must be at least 2 characters.", code = "query_too_short" });
+            throw new ValidationException("Query must be at least 2 characters.", code: "locality.query_too_short");
 
         var query = q.Trim();
         if (query.Length > MaxSearchQueryLength)
-            return BadRequest(new { error = $"Query must be at most {MaxSearchQueryLength} characters.", code = "query_too_long" });
+            throw new ValidationException($"Query must be at most {MaxSearchQueryLength} characters.", code: "locality.query_too_long");
 
         // Anonymous endpoint — rate limit per client IP to bound DoS surface
         // (each call may trigger an upstream Nominatim request + PostGIS lookup).
@@ -176,7 +176,9 @@ public class LocalitiesController : ControllerBase
         var allowed = await _rateLimiter.IsAllowedAsync(rateKey, SearchRateLimitMaxRequests, SearchRateLimitWindow, ct);
         if (!allowed)
         {
-            return StatusCode(429, new { error = "Too many requests.", code = "rate_limited" });
+            throw new RateLimitException(
+                code: "locality.search_rate_limited",
+                message: "Too many requests.");
         }
 
         var cacheKey = $"locality_search:{query.ToLowerInvariant()}";
@@ -255,17 +257,17 @@ public class LocalitiesController : ControllerBase
         CancellationToken ct)
     {
         if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)
-            return BadRequest(new { error = "Invalid coordinates.", code = "invalid_coordinates" });
+            throw new ValidationException("Invalid coordinates.", code: "locality.invalid_coordinates");
 
         var locality = await _localities.FindByPointAsync(latitude, longitude, ct);
         if (locality is null)
-            return NotFound(new { error = "No locality found for the given coordinates.", code = "locality_not_found" });
+            throw new NotFoundException(code: "locality.not_found", message: "No locality found for the given coordinates.");
 
-        return Ok(new
+        return Ok(new LocalitySummaryDto
         {
-            localityId = locality.Id,
-            wardName = locality.WardName,
-            cityName = locality.CityName,
+            LocalityId = locality.Id,
+            WardName = locality.WardName,
+            CityName = locality.CityName,
         });
     }
 }

--- a/src/Hali.Api/Controllers/OfficialPostsController.cs
+++ b/src/Hali.Api/Controllers/OfficialPostsController.cs
@@ -1,8 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Advisories;
+using Hali.Application.Errors;
 using Hali.Contracts.Advisories;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -24,43 +26,36 @@ public class OfficialPostsController : ControllerBase
     [Authorize(Roles = "institution")]
     public async Task<IActionResult> CreatePost([FromBody] CreateOfficialPostRequestDto dto, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(dto.Type) || string.IsNullOrWhiteSpace(dto.Category)
-            || string.IsNullOrWhiteSpace(dto.Title) || string.IsNullOrWhiteSpace(dto.Body))
+        var missing = new Dictionary<string, string[]>();
+        if (string.IsNullOrWhiteSpace(dto.Type)) missing["type"] = new[] { "type is required" };
+        if (string.IsNullOrWhiteSpace(dto.Category)) missing["category"] = new[] { "category is required" };
+        if (string.IsNullOrWhiteSpace(dto.Title)) missing["title"] = new[] { "title is required" };
+        if (string.IsNullOrWhiteSpace(dto.Body)) missing["body"] = new[] { "body is required" };
+        if (missing.Count > 0)
         {
-            return BadRequest(new { error = "type, category, title, and body are required." });
+            throw new ValidationException(
+                "type, category, title, and body are required.",
+                code: "official_post.missing_fields",
+                fieldErrors: missing);
         }
 
-        // In MVP, institution_id is carried via a custom claim or query param.
-        // Parse from "institution_id" claim, fallback to X-Institution-Id header.
-        Guid institutionId;
+        // institution_id must come from the JWT — no header fallback. A missing
+        // or malformed claim means the caller is not authorized to act on any
+        // institution's behalf, so surface as Forbidden (403) rather than a
+        // bare MVC Forbid() response (which can also trigger a re-auth challenge).
         var institutionClaim = User.FindFirstValue("institution_id");
-        if (string.IsNullOrEmpty(institutionClaim))
-            return Forbid(); // institution_id must come from JWT — no header fallback
-        if (!Guid.TryParse(institutionClaim, out institutionId))
+        if (string.IsNullOrEmpty(institutionClaim) || !Guid.TryParse(institutionClaim, out var institutionId))
         {
-            return UnprocessableEntity(new { error = "Institution identity required.", code = "institution_required" });
+            throw new ForbiddenException(
+                code: "auth.institution_id_missing",
+                message: "Institution identity required.");
         }
 
         Guid? authorAccountId = null;
         if (Guid.TryParse(User.FindFirstValue(ClaimTypes.NameIdentifier), out var parsed))
             authorAccountId = parsed;
 
-        try
-        {
-            var result = await _service.CreatePostAsync(institutionId, authorAccountId, dto, ct);
-            return Created($"/v1/official-posts/{result.Id}", result);
-        }
-        catch (ArgumentException ex) when (ex.Message == "INVALID_POST_TYPE")
-        {
-            return UnprocessableEntity(new { error = "Invalid post type.", code = "invalid_post_type" });
-        }
-        catch (ArgumentException ex) when (ex.Message == "INVALID_CATEGORY")
-        {
-            return UnprocessableEntity(new { error = "Invalid category.", code = "invalid_category" });
-        }
-        catch (InvalidOperationException ex) when (ex.Message == "OUTSIDE_JURISDICTION")
-        {
-            return StatusCode(403, new { error = "Post scope is outside institution jurisdiction.", code = "outside_jurisdiction" });
-        }
+        var result = await _service.CreatePostAsync(institutionId, authorAccountId, dto, ct);
+        return Created($"/v1/official-posts/{result.Id}", result);
     }
 }

--- a/src/Hali.Api/Controllers/PlacesController.cs
+++ b/src/Hali.Api/Controllers/PlacesController.cs
@@ -5,6 +5,7 @@ using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Application.Signals;
 using Hali.Contracts.Signals;
 using Microsoft.AspNetCore.Authorization;
@@ -81,13 +82,13 @@ public class PlacesController : ControllerBase
     {
         if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
         {
-            return BadRequest(new { error = "Query must be at least 2 characters.", code = "query_too_short" });
+            throw new ValidationException("Query must be at least 2 characters.", code: "places.query_too_short");
         }
 
         string query = q.Trim();
         if (query.Length > MaxSearchQueryLength)
         {
-            return BadRequest(new { error = $"Query must be at most {MaxSearchQueryLength} characters.", code = "query_too_long" });
+            throw new ValidationException($"Query must be at most {MaxSearchQueryLength} characters.", code: "places.query_too_long");
         }
 
         string clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
@@ -95,7 +96,9 @@ public class PlacesController : ControllerBase
         bool allowed = await _rateLimiter.IsAllowedAsync(rateKey, RateLimitMaxRequests, RateLimitWindow, ct);
         if (!allowed)
         {
-            return StatusCode(StatusCodes.Status429TooManyRequests, new { error = "Too many requests.", code = "rate_limited" });
+            throw new RateLimitException(
+                code: "places.search_rate_limited",
+                message: "Too many requests.");
         }
 
         string cacheKey = $"places_search:{query.ToLowerInvariant()}";
@@ -180,7 +183,7 @@ public class PlacesController : ControllerBase
     {
         if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)
         {
-            return BadRequest(new { error = "Invalid coordinates.", code = "invalid_coordinates" });
+            throw new ValidationException("Invalid coordinates.", code: "places.invalid_coordinates");
         }
 
         string clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
@@ -188,7 +191,9 @@ public class PlacesController : ControllerBase
         bool allowed = await _rateLimiter.IsAllowedAsync(rateKey, RateLimitMaxRequests, RateLimitWindow, ct);
         if (!allowed)
         {
-            return StatusCode(StatusCodes.Status429TooManyRequests, new { error = "Too many requests.", code = "rate_limited" });
+            throw new RateLimitException(
+                code: "places.reverse_rate_limited",
+                message: "Too many requests.");
         }
 
         // Spatial integrity: always resolve locality FRESH for the caller's
@@ -210,7 +215,7 @@ public class PlacesController : ControllerBase
         LocalitySummary? locality = await _localities.FindByPointAsync(latitude, longitude, ct);
         if (locality is null)
         {
-            return NotFound(new { error = "No locality found for the given coordinates.", code = "locality_not_found" });
+            throw new NotFoundException(code: "places.locality_not_found", message: "No locality found for the given coordinates.");
         }
 
         // Label-only cache. Keyed by quantized coords AND the resolved

--- a/src/Hali.Application/Advisories/OfficialPostsService.cs
+++ b/src/Hali.Application/Advisories/OfficialPostsService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
+using Hali.Application.Errors;
 using Hali.Contracts.Advisories;
 using Hali.Domain.Entities.Advisories;
 using Hali.Domain.Entities.Clusters;
@@ -29,15 +30,17 @@ public class OfficialPostsService : IOfficialPostsService
         CancellationToken ct)
     {
         if (!Enum.TryParse<OfficialPostType>(dto.Type.Replace("_", ""), ignoreCase: true, out var postType))
-            throw new ArgumentException("INVALID_POST_TYPE");
+            throw new ValidationException("Invalid post type.", code: "official_post.invalid_type");
 
         if (!Enum.TryParse<CivicCategory>(dto.Category.Replace("_", ""), ignoreCase: true, out var category))
-            throw new ArgumentException("INVALID_CATEGORY");
+            throw new ValidationException("Invalid category.", code: "official_post.invalid_category");
 
         // Geo-scope enforcement BEFORE insert — no out-of-jurisdiction row ever lands in the DB
         bool allowed = await _repo.CheckJurisdictionForLocalityAsync(institutionId, dto.LocalityId, ct);
         if (!allowed)
-            throw new InvalidOperationException("OUTSIDE_JURISDICTION");
+            throw new ForbiddenException(
+                code: "official_post.outside_jurisdiction",
+                message: "Post scope is outside institution jurisdiction.");
 
         var post = new OfficialPost
         {

--- a/src/Hali.Application/Auth/AuthService.cs
+++ b/src/Hali.Application/Auth/AuthService.cs
@@ -6,6 +6,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Errors;
 using Hali.Contracts.Auth;
 using Hali.Domain.Entities.Auth;
 using Hali.Domain.Enums;
@@ -33,7 +34,7 @@ public class AuthService : IAuthService
     {
         if (!(await _otpService.ConsumeOtpAsync(request.Destination, request.Otp, ct)))
         {
-            throw new InvalidOperationException("OTP_INVALID");
+            throw new ValidationException("Invalid or expired OTP.", code: "auth.otp_invalid");
         }
         DateTime now = DateTime.UtcNow;
         Account account = await _repo.FindAccountByPhoneAsync(request.Destination, ct);
@@ -59,7 +60,9 @@ public class AuthService : IAuthService
         RefreshToken stored = await _repo.FindActiveRefreshTokenAsync(tokenHash, now, ct);
         if (stored == null)
         {
-            throw new InvalidOperationException("REFRESH_TOKEN_INVALID");
+            throw new UnauthorizedException(
+                code: "auth.refresh_token_invalid",
+                message: "Invalid or expired refresh token.");
         }
         await _repo.RevokeRefreshTokenAsync(stored, now, ct);
         return await IssueTokenPairAsync(stored.AccountId, stored.DeviceId ?? Guid.Empty, now, ct);

--- a/src/Hali.Application/Auth/InstitutionService.cs
+++ b/src/Hali.Application/Auth/InstitutionService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Errors;
 using Hali.Contracts.Auth;
 using Hali.Domain.Entities.Advisories;
 using Hali.Domain.Entities.Auth;
@@ -75,13 +76,13 @@ public class InstitutionService : IInstitutionService
         DateTime now = DateTime.UtcNow;
 
         if (invite == null)
-            throw new InvalidOperationException("INVITE_INVALID");
+            throw new ValidationException("Invalid invite token.", code: "invite.invalid");
 
         if (invite.ExpiresAt <= now)
-            throw new InvalidOperationException("INVITE_EXPIRED");
+            throw new ValidationException("Invite token has expired.", code: "invite.expired");
 
         if (invite.AcceptedAt != null)
-            throw new InvalidOperationException("INVITE_ALREADY_ACCEPTED");
+            throw new ConflictException("invite.already_accepted", "Invite has already been accepted.");
 
         // Create account with institution role
         Account? existing = await _authRepo.FindAccountByPhoneAsync(request.PhoneNumber, ct);

--- a/src/Hali.Application/Auth/OtpService.cs
+++ b/src/Hali.Application/Auth/OtpService.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Errors;
 using Hali.Domain.Entities.Auth;
 using Hali.Domain.Enums;
 using Microsoft.Extensions.Options;
@@ -32,7 +33,9 @@ public class OtpService : IOtpService
         string key = "rl:otp:" + destination;
         if (!(await _rateLimiter.IsAllowedAsync(key, _opts.MaxRequestsPerWindow, TimeSpan.FromMinutes(_opts.WindowMinutes), ct)))
         {
-            throw new InvalidOperationException("OTP_RATE_LIMITED");
+            throw new RateLimitException(
+                code: "auth.otp_rate_limited",
+                message: "Too many OTP requests. Please try again later.");
         }
         string otp = GenerateOtp(_opts.Length);
         DateTime now = DateTime.UtcNow;

--- a/src/Hali.Application/Errors/ForbiddenException.cs
+++ b/src/Hali.Application/Errors/ForbiddenException.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Hali.Domain.Errors;
+
+namespace Hali.Application.Errors;
+
+public class ForbiddenException : AppException
+{
+    public ForbiddenException(
+        string code = "auth.forbidden",
+        string message = "This action is not permitted.",
+        IReadOnlyDictionary<string, object?>? metadata = null)
+        : base(code, message, ErrorCategory.Forbidden, metadata: metadata)
+    {
+    }
+}

--- a/src/Hali.Contracts/Auth/OtpRequestedResponseDto.cs
+++ b/src/Hali.Contracts/Auth/OtpRequestedResponseDto.cs
@@ -1,0 +1,7 @@
+namespace Hali.Contracts.Auth;
+
+/// <summary>
+/// Success body for POST /v1/auth/otp. Carries a short human-readable
+/// status message; clients should not depend on its exact wording.
+/// </summary>
+public sealed record OtpRequestedResponseDto(string Message);

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -1,0 +1,120 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Hali.Tests.Integration.Infrastructure;
+using Xunit;
+
+namespace Hali.Tests.Integration.Errors;
+
+/// <summary>
+/// Cross-cutting integration coverage for the H2 refactor: proves that the
+/// previously-seam-specific ad-hoc error payloads now land on the canonical
+/// ApiErrorResponse envelope emitted by the H1 exception middleware.
+///
+/// One representative path per retyped seam is asserted here — enough to
+/// catch regressions where a controller reintroduces a local try/catch or
+/// an ad-hoc {error: "..."} shape without re-breaking every pre-existing
+/// endpoint-specific test.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    public StandardizedErrorEnvelopeTests(HaliWebApplicationFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task VerifyOtp_WrongCode_EmitsStandardErrorEnvelope()
+    {
+        const string phone = "+254711900001";
+        await SeedOtpAsync(phone, "111111");
+
+        var response = await Client.PostAsJsonAsync("/v1/auth/verify", new
+        {
+            destination = phone,
+            otp = "000000",
+            deviceFingerprintHash = "h2-env-verify-wrong",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "auth.otp_invalid");
+    }
+
+    [Fact]
+    public async Task Refresh_InvalidToken_EmitsStandardErrorEnvelope()
+    {
+        var response = await Client.PostAsJsonAsync("/v1/auth/refresh", new
+        {
+            refreshToken = "definitely-not-a-real-refresh-token",
+        });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "auth.refresh_token_invalid");
+    }
+
+    [Fact]
+    public async Task LocalitySearch_QueryTooShort_EmitsStandardErrorEnvelope()
+    {
+        var response = await Client.GetAsync("/v1/localities/search?q=a");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "locality.query_too_short");
+    }
+
+    [Fact]
+    public async Task ResolveCoordinates_OutOfRange_EmitsStandardErrorEnvelope()
+    {
+        var response = await Client.GetAsync("/v1/localities/resolve-by-coordinates?latitude=999&longitude=0");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "locality.invalid_coordinates");
+    }
+
+    [Fact]
+    public async Task PlacesSearch_QueryTooShort_EmitsStandardErrorEnvelope()
+    {
+        var response = await Client.GetAsync("/v1/places/search?q=a");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "places.query_too_short");
+    }
+
+    [Fact]
+    public async Task OtpRequested_Success_EmitsTypedSuccessDto()
+    {
+        // Proves the Commit 5 DTO-ification preserves the body shape the mobile
+        // client consumes: {"message":"OTP sent"} on 200 OK.
+        var response = await Client.PostAsJsonAsync("/v1/auth/otp", new
+        {
+            destination = "+254711900002",
+            authMethod = "phone_otp",
+        });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>(_json);
+        Assert.Equal("OTP sent", body.GetProperty("message").GetString());
+    }
+
+    /// <summary>
+    /// Every H2-touched error path must land on the canonical envelope:
+    /// { error: { code, message, traceId, details? } }.
+    /// </summary>
+    private static void AssertErrorEnvelope(JsonElement body, string expectedCode)
+    {
+        Assert.Equal(JsonValueKind.Object, body.ValueKind);
+        Assert.True(body.TryGetProperty("error", out var error),
+            "response body must have a top-level `error` property");
+        Assert.Equal(JsonValueKind.Object, error.ValueKind);
+
+        Assert.True(error.TryGetProperty("code", out var code));
+        Assert.Equal(expectedCode, code.GetString());
+
+        Assert.True(error.TryGetProperty("message", out var message));
+        Assert.False(string.IsNullOrWhiteSpace(message.GetString()));
+
+        Assert.True(error.TryGetProperty("traceId", out _),
+            "error envelope must include a traceId for support/log correlation");
+    }
+}

--- a/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Advisories;
 using Hali.Application.Clusters;
+using Hali.Application.Errors;
 using Hali.Contracts.Advisories;
 using Hali.Domain.Entities.Advisories;
 using Hali.Domain.Entities.Clusters;
@@ -126,15 +127,15 @@ public class OfficialPostsServiceTests
     }
 
     [Fact]
-    public async Task CreatePost_WhenOutsideJurisdiction_ThrowsOutsideJurisdiction()
+    public async Task CreatePost_WhenOutsideJurisdiction_ThrowsForbiddenWithCode()
     {
         var repo = new FakeOfficialPostRepo { IntersectsResult = false };
         var svc = new OfficialPostsService(repo, new FakeClusterRepo());
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ForbiddenException>(
             () => svc.CreatePostAsync(Guid.NewGuid(), null, ValidDto(), CancellationToken.None));
 
-        Assert.Equal("OUTSIDE_JURISDICTION", ex.Message);
+        Assert.Equal("official_post.outside_jurisdiction", ex.Code);
     }
 
     // B-4: Jurisdiction check must run BEFORE the DB insert.
@@ -145,7 +146,7 @@ public class OfficialPostsServiceTests
         var repo = new FakeOfficialPostRepo { IntersectsResult = false };
         var svc = new OfficialPostsService(repo, new FakeClusterRepo());
 
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<ForbiddenException>(
             () => svc.CreatePostAsync(Guid.NewGuid(), null, ValidDto(), CancellationToken.None));
 
         Assert.Null(repo.Created); // CreateAsync was never called — no row in DB

--- a/tests/Hali.Tests.Unit/Auth/AuthServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/AuthServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Contracts.Auth;
 using Hali.Domain.Entities.Auth;
 using Microsoft.Extensions.Options;
@@ -40,7 +41,8 @@ public class AuthServiceTests
 	{
 		_otpService.ConsumeOtpAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
 		AuthService svc = CreateService();
-		Assert.Equal("OTP_INVALID", (await Assert.ThrowsAsync<InvalidOperationException>(() => svc.AuthenticateAsync(MakeVerifyRequest()))).Message);
+		var ex = await Assert.ThrowsAsync<ValidationException>(() => svc.AuthenticateAsync(MakeVerifyRequest()));
+		Assert.Equal("auth.otp_invalid", ex.Code);
 	}
 
 	[Fact]
@@ -124,7 +126,8 @@ public class AuthServiceTests
 	{
 		_repo.FindActiveRefreshTokenAsync(Arg.Any<string>(), Arg.Any<DateTime>(), Arg.Any<CancellationToken>()).Returns(null, Array.Empty<RefreshToken>());
 		AuthService svc = CreateService();
-		Assert.Equal("REFRESH_TOKEN_INVALID", (await Assert.ThrowsAsync<InvalidOperationException>(() => svc.RefreshAsync("bad-token"))).Message);
+		var ex = await Assert.ThrowsAsync<UnauthorizedException>(() => svc.RefreshAsync("bad-token"));
+		Assert.Equal("auth.refresh_token_invalid", ex.Code);
 	}
 
 	[Fact]

--- a/tests/Hali.Tests.Unit/Auth/InstitutionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/InstitutionServiceTests.cs
@@ -6,6 +6,7 @@ using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Contracts.Auth;
 using Hali.Domain.Entities.Auth;
 using Hali.Domain.Enums;
@@ -89,7 +90,7 @@ public class InstitutionServiceTests
     }
 
     [Fact]
-    public async Task InstitutionSetup_ExpiredInvite_Returns400()
+    public async Task InstitutionSetup_ExpiredInvite_Throws400WithCode()
     {
         string rawToken = "expired-token";
         string tokenHash = AuthService.HashToken(rawToken);
@@ -106,13 +107,13 @@ public class InstitutionServiceTests
             });
 
         var svc = CreateService();
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ValidationException>(
             () => svc.SetupInstitutionAccountAsync(new InstitutionSetupRequestDto(rawToken, "+254700000002")));
-        Assert.Equal("INVITE_EXPIRED", ex.Message);
+        Assert.Equal("invite.expired", ex.Code);
     }
 
     [Fact]
-    public async Task InstitutionSetup_AlreadyAcceptedInvite_Returns400()
+    public async Task InstitutionSetup_AlreadyAcceptedInvite_Throws409WithCode()
     {
         string rawToken = "accepted-token";
         string tokenHash = AuthService.HashToken(rawToken);
@@ -129,21 +130,21 @@ public class InstitutionServiceTests
             });
 
         var svc = CreateService();
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ConflictException>(
             () => svc.SetupInstitutionAccountAsync(new InstitutionSetupRequestDto(rawToken, "+254700000002")));
-        Assert.Equal("INVITE_ALREADY_ACCEPTED", ex.Message);
+        Assert.Equal("invite.already_accepted", ex.Code);
     }
 
     [Fact]
-    public async Task InstitutionSetup_InvalidToken_Returns400()
+    public async Task InstitutionSetup_InvalidToken_Throws400WithCode()
     {
         _repo.FindInviteByTokenHashAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((InstitutionInvite?)null);
 
         var svc = CreateService();
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ValidationException>(
             () => svc.SetupInstitutionAccountAsync(new InstitutionSetupRequestDto("bogus", "+254700000002")));
-        Assert.Equal("INVITE_INVALID", ex.Message);
+        Assert.Equal("invite.invalid", ex.Code);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Auth/InstitutionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/InstitutionServiceTests.cs
@@ -90,7 +90,7 @@ public class InstitutionServiceTests
     }
 
     [Fact]
-    public async Task InstitutionSetup_ExpiredInvite_Throws400WithCode()
+    public async Task InstitutionSetup_ExpiredInvite_ThrowsValidationExceptionWithCode()
     {
         string rawToken = "expired-token";
         string tokenHash = AuthService.HashToken(rawToken);
@@ -113,7 +113,7 @@ public class InstitutionServiceTests
     }
 
     [Fact]
-    public async Task InstitutionSetup_AlreadyAcceptedInvite_Throws409WithCode()
+    public async Task InstitutionSetup_AlreadyAcceptedInvite_ThrowsConflictExceptionWithCode()
     {
         string rawToken = "accepted-token";
         string tokenHash = AuthService.HashToken(rawToken);
@@ -136,7 +136,7 @@ public class InstitutionServiceTests
     }
 
     [Fact]
-    public async Task InstitutionSetup_InvalidToken_Throws400WithCode()
+    public async Task InstitutionSetup_InvalidToken_ThrowsValidationExceptionWithCode()
     {
         _repo.FindInviteByTokenHashAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
             .Returns((InstitutionInvite?)null);

--- a/tests/Hali.Tests.Unit/Auth/OtpServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/OtpServiceTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Domain.Entities.Auth;
 using Hali.Domain.Enums;
 using Microsoft.Extensions.Options;
@@ -35,7 +36,8 @@ public class OtpServiceTests
 	{
 		_rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>()).Returns(false);
 		OtpService svc = CreateService();
-		Assert.Equal("OTP_RATE_LIMITED", (await Assert.ThrowsAsync<InvalidOperationException>(() => svc.RequestOtpAsync("+254712345678", AuthMethod.PhoneOtp))).Message);
+		var ex = await Assert.ThrowsAsync<RateLimitException>(() => svc.RequestOtpAsync("+254712345678", AuthMethod.PhoneOtp));
+		Assert.Equal("auth.otp_rate_limited", ex.Code);
 		await _sms.DidNotReceive().SendAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<CancellationToken>());
 	}
 

--- a/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
@@ -321,11 +321,20 @@ public class PlacesControllerTests
 
         await Assert.ThrowsAsync<NotFoundException>(
             () => controller.Reverse(-1.30004, 36.80004, CancellationToken.None));
-        // The key integrity assertions: FindByPointAsync ran for the
-        // caller's coords, and the upstream geocoder was never touched
-        // (we short-circuit at the locality guard).
+        // Integrity assertions: FindByPointAsync ran for the caller's
+        // coords, and BOTH downstream dependencies (cache + upstream
+        // geocoder) were never touched — we short-circuit at the locality
+        // guard. The Redis seeding above is a trap: if the controller
+        // ever consulted the cache for an outside-locality request, it
+        // would receive the seeded payload and behave incorrectly. The
+        // `DidNotReceive` assertion on `StringGetAsync` is what closes
+        // the trap; without it this test would still pass even if the
+        // controller were silently reading the cache before the locality
+        // check.
         await _localities.Received(1)
             .FindByPointAsync(-1.30004, 36.80004, Arg.Any<CancellationToken>());
+        await _redis.DidNotReceive()
+            .StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>());
         await _geocoding.DidNotReceive()
             .ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
     }

--- a/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
@@ -7,6 +7,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hali.Api.Controllers;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Application.Signals;
 using Hali.Contracts.Signals;
 using Microsoft.AspNetCore.Http;
@@ -69,24 +70,24 @@ public class PlacesControllerTests
     [InlineData("")]
     [InlineData(" ")]
     [InlineData("a")]
-    public async Task Search_QueryTooShort_ReturnsBadRequest(string? q)
+    public async Task Search_QueryTooShort_ThrowsValidationException(string? q)
     {
         PlacesController controller = CreateController();
 
-        IActionResult result = await controller.Search(q!, CancellationToken.None);
-
-        Assert.IsType<BadRequestObjectResult>(result);
+        var ex = await Assert.ThrowsAsync<ValidationException>(
+            () => controller.Search(q!, CancellationToken.None));
+        Assert.Equal("places.query_too_short", ex.Code);
     }
 
     [Fact]
-    public async Task Search_OversizedQuery_ReturnsBadRequest()
+    public async Task Search_OversizedQuery_ThrowsValidationException()
     {
         PlacesController controller = CreateController();
         string overlong = new string('x', 81);
 
-        IActionResult result = await controller.Search(overlong, CancellationToken.None);
-
-        Assert.IsType<BadRequestObjectResult>(result);
+        var ex = await Assert.ThrowsAsync<ValidationException>(
+            () => controller.Search(overlong, CancellationToken.None));
+        Assert.Equal("places.query_too_long", ex.Code);
     }
 
     [Fact]
@@ -155,7 +156,7 @@ public class PlacesControllerTests
     }
 
     [Fact]
-    public async Task Search_RateLimited_Returns429()
+    public async Task Search_RateLimited_ThrowsRateLimitException()
     {
         PlacesController controller = CreateController();
         // Override the default (allowed=true) *after* controller construction
@@ -163,10 +164,9 @@ public class PlacesControllerTests
         _rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
-        IActionResult result = await controller.Search("Ngong Road", CancellationToken.None);
-
-        ObjectResult obj = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(StatusCodes.Status429TooManyRequests, obj.StatusCode);
+        var ex = await Assert.ThrowsAsync<RateLimitException>(
+            () => controller.Search("Ngong Road", CancellationToken.None));
+        Assert.Equal("places.search_rate_limited", ex.Code);
         // Must not fan out to the upstream geocoder once we've decided to throttle.
         await _geocoding.DidNotReceive().SearchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>());
     }
@@ -178,25 +178,25 @@ public class PlacesControllerTests
     [InlineData(91.0, 36.8)]
     [InlineData(-1.3, -181.0)]
     [InlineData(-1.3, 181.0)]
-    public async Task Reverse_InvalidCoordinates_ReturnsBadRequest(double lat, double lng)
+    public async Task Reverse_InvalidCoordinates_ThrowsValidationException(double lat, double lng)
     {
         PlacesController controller = CreateController();
 
-        IActionResult result = await controller.Reverse(lat, lng, CancellationToken.None);
-
-        Assert.IsType<BadRequestObjectResult>(result);
+        var ex = await Assert.ThrowsAsync<ValidationException>(
+            () => controller.Reverse(lat, lng, CancellationToken.None));
+        Assert.Equal("places.invalid_coordinates", ex.Code);
     }
 
     [Fact]
-    public async Task Reverse_PointOutsideKnownLocality_Returns404()
+    public async Task Reverse_PointOutsideKnownLocality_ThrowsNotFoundException()
     {
         _localities.FindByPointAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>())
             .Returns((LocalitySummary?)null);
 
         PlacesController controller = CreateController();
-        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
-
-        Assert.IsType<NotFoundObjectResult>(result);
+        var ex = await Assert.ThrowsAsync<NotFoundException>(
+            () => controller.Reverse(-1.3, 36.8, CancellationToken.None));
+        Assert.Equal("places.locality_not_found", ex.Code);
         await _geocoding.DidNotReceive().ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
     }
 
@@ -254,16 +254,15 @@ public class PlacesControllerTests
     }
 
     [Fact]
-    public async Task Reverse_RateLimited_Returns429()
+    public async Task Reverse_RateLimited_ThrowsRateLimitException()
     {
         PlacesController controller = CreateController();
         _rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
             .Returns(false);
 
-        IActionResult result = await controller.Reverse(-1.3, 36.8, CancellationToken.None);
-
-        ObjectResult obj = Assert.IsType<ObjectResult>(result);
-        Assert.Equal(StatusCodes.Status429TooManyRequests, obj.StatusCode);
+        var ex = await Assert.ThrowsAsync<RateLimitException>(
+            () => controller.Reverse(-1.3, 36.8, CancellationToken.None));
+        Assert.Equal("places.reverse_rate_limited", ex.Code);
     }
 
     // ---- reverse cache integrity (B-2 / Copilot #1) ----
@@ -289,7 +288,7 @@ public class PlacesControllerTests
     // it and re-resolves the caller's locality + rebuilds the response.
 
     [Fact]
-    public async Task Reverse_OutsideLocality_IsNotServedFromCachedNeighborPayload()
+    public async Task Reverse_OutsideLocality_DoesNotConsultCacheOrUpstream()
     {
         // Simulate: a prior same-bucket call populated the cache with a
         // valid candidate in LocalityA. Now a caller whose point is
@@ -320,9 +319,8 @@ public class PlacesControllerTests
         _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
             .Returns(seededJson);
 
-        IActionResult result = await controller.Reverse(-1.30004, 36.80004, CancellationToken.None);
-
-        Assert.IsType<NotFoundObjectResult>(result);
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => controller.Reverse(-1.30004, 36.80004, CancellationToken.None));
         // The key integrity assertions: FindByPointAsync ran for the
         // caller's coords, and the upstream geocoder was never touched
         // (we short-circuit at the locality guard).


### PR DESCRIPTION
## Closes

- Closes #107 — Migrate LocalitiesController.ResolveByCoordinates to H1 typed error envelope
- Closes #120 — Ad hoc error responses bypass H1 centralized exception mapping

## Follow-ups surfaced but deferred (tracked)

- #135 — Complete H2 migration for UsersController body-less Unauthorized()/NotFound() responses
- #136 — Remove undocumented-but-undeliverable 429 from POST /v1/feedback OpenAPI until rate limiting is implemented

---

## Problem

After H1 landed typed exceptions + centralized exception-to-HTTP mapping, **two parallel error contracts** continued to live on the wire simultaneously:

1. The H1 canonical envelope — `{ error: { code, message, details?, traceId } }` — emitted by every endpoint that let exceptions bubble to middleware.
2. A pre-H1 ad-hoc shape — `{ error: "string", code?, reason? }` — emitted inline by auth, official-posts, localities, places, devices, and admin endpoints that still caught exceptions locally or constructed their own `BadRequest(new { ... })` / `StatusCode(429, new { ... })` responses.

Additionally, the OpenAPI `ErrorResponse` schema described shape #2 — the one the API hadn't actually emitted since H1 merged. Spec and reality had diverged silently.

## Why this was confusing and risky

- Two shapes on the same wire forced every mobile-side error handler to branch on `typeof(body.error) === "string"` vs `"object"`. Any missed branch silently shows the raw code to end users.
- Services threw bare `InvalidOperationException("OTP_INVALID")` / `ArgumentException("INVALID_CATEGORY")` — untyped, uncategorized, metadata-free. Callers had to `catch ... when (ex.Message == "STRING")` to distinguish business outcomes, and a refactor of the string would silently break error handling.
- OpenAPI consumers (client SDK generators, contract tests) were generating against a schema that did not match production output.

## Refactor approach

Strict scope: finish the H1 migration at the three seams identified in the audit. No new abstractions, no mapper framework, no `Result<T>` type.

Six logically-grouped commits:

| # | Commit | What |
|---|---|---|
| 1 | `refactor(h2): retype Auth/Otp/Institution throws to typed AppException` | 6 bare `InvalidOperationException`s in `AuthService`, `OtpService`, `InstitutionService` retyped to `ValidationException`, `UnauthorizedException`, `RateLimitException`, `ConflictException`. Adds `ForbiddenException` for Commit 2. Unit tests assert typed exception + `Code`. |
| 2 | `refactor(h2): retype OfficialPostsService throws to typed AppException` | 3 `ArgumentException`/`InvalidOperationException`s retyped. `OUTSIDE_JURISDICTION` becomes the new `ForbiddenException` (routes to 403 via `ErrorCategory.Forbidden`). |
| 3 | `refactor(h2): strip AuthController/OfficialPostsController catch blocks` | 7 catch blocks removed — middleware handles translation. `OfficialPostsController` manual field checks become a `ValidationException` with `fieldErrors` so the H1 envelope's `details.fields` surfaces which fields were missing. |
| 4 | `refactor(h2): convert ad-hoc validation responses to typed exceptions` | 13 inline `BadRequest/NotFound/StatusCode` ad-hoc responses across `AdminController`, `DevicesController`, `LocalitiesController`, `PlacesController` converted to typed throws. `PlacesControllerTests` rewritten to assert `Assert.ThrowsAsync<T>` + `ex.Code` (correct H1 posture for controller-unit tests). |
| 5 | `refactor(h2): type the OTP-requested success response` | `{message: "OTP sent"}` now a typed `OtpRequestedResponseDto`; wire shape preserved. |
| 6 | `refactor(h2): sync OpenAPI to H1 envelope + add cross-cutting integration coverage` | `ErrorResponse` schema rewritten to match reality. New `OtpRequestedResponse` and `LocalitySummary` named schemas. New `StandardizedErrorEnvelopeTests` asserts the envelope end-to-end on one representative path per retyped seam. |

## Architectural decisions

1. **No new abstractions, one addition.** The only new type is `ForbiddenException` (15 lines, mirrors `UnauthorizedException`) — completes the hierarchy for the 403 cases. No `Result<T>`, no mapper framework, no new envelope types.
2. **`CLUSTERING_NO_SPATIAL_CELL` deliberately preserved.** It's an internal server-side invariant guard in `ClusteringService`. It already routes to the 500 fallthrough (`server.internal_error`) via the mapper's catch-all — no stringly-typed code ever leaks to the wire. Retyping it would require a new exception class for a single defensive branch.
3. **Error code convention.** All new codes follow the existing `namespace.reason` snake_case style already in use (`signal.duplicate`, `auth.unauthorized`). No central catalog file — that's H3.
4. **Wire-shape unification is the point.** Accepted: the 7 catch-block endpoints move from `{error: "string"}` to `{error: {code, message, traceId}}`. Message text preserved verbatim.

## Backward-compatibility / contract notes

**Error wire shape unified** at these endpoints (all previously emitted `{error: "string"}`):

Before:
```json
{ "error": "Invalid or expired OTP." }
```

After (same shape every other endpoint already emitted):
```json
{
  "error": {
    "code": "auth.otp_invalid",
    "message": "Invalid or expired OTP.",
    "traceId": "abc123..."
  }
}
```

**HTTP status parity** (deviations listed — all justified):

| Flow | Before | After | Notes |
|---|---|---|---|
| POST `/v1/auth/otp` 429  | 429 | 429 | preserved |
| POST `/v1/auth/verify` 400 (bad OTP) | 400 | 400 | preserved |
| POST `/v1/auth/refresh` 401 | 401 | 401 | preserved |
| POST `/v1/auth/institution/setup` (invite invalid) | 400 | 400 | preserved |
| POST `/v1/auth/institution/setup` (invite expired) | 400 | 400 | preserved |
| POST `/v1/auth/institution/setup` (invite already accepted) | **400** | **409** | "already accepted" is a state conflict; 409 is the correct REST status. |
| POST `/v1/official-posts` invalid type/category | **422** | **400** | Malformed enum input is a client validation error. Preserving 422 would require a new exception class for a single code path. |
| POST `/v1/official-posts` outside jurisdiction | 403 | 403 | preserved (now `ForbiddenException`) |
| POST `/v1/official-posts` institution_id_missing | **403/422** | **403** | Unified — the missing-claim (403) and malformed-claim (422) branches collapse into one `ForbiddenException`. Semantically identical: caller is not authorized to act on any institution here. |
| POST `/v1/devices/push-token` device_not_found | **422** | **404** | `NotFound` is the REST-conventional status for a missing resource. Preserving 422 would require a new exception class for a single case. |
| `/v1/localities/search` rate-limit | 429 | 429 | preserved (now documented in OpenAPI — was emitted but not specified) |
| `/v1/localities/resolve-by-coordinates` 400 | **—** | **400** | Previously emitted but not documented in OpenAPI. |
| `/v1/places/*` 400/404/429 | 400/404/429 | 400/404/429 | preserved |

No production client compatibility burden exists (mobile app still in greenfield).

## Tests run

- `dotnet build` — 0 errors (132 warnings, all pre-existing on `develop`, none in touched files).
- `dotnet test tests/Hali.Tests.Unit` — **348 passed / 0 failed** (includes `PlacesControllerTests` rewritten to assert typed exceptions + codes, and the typed-exception rewrites of `AuthService`/`OtpService`/`InstitutionService`/`OfficialPostsService` tests).
- `dotnet test tests/Hali.Tests.Integration` — **25 passed / 0 failed** (includes the 6 new `StandardizedErrorEnvelopeTests`).

## Risks / reviewer focus areas

1. **Status-code deviations table above.** Every deviation is a judgment call — please check I've chosen correct REST semantics for each, especially `422 -> 404` on `device_not_found`.
2. **`ValidationException` FieldErrors structure.** `OfficialPostsController.CreatePost` and `DevicesController.RegisterPushToken` now populate `fieldErrors` for missing-field validation. The middleware serializes this as `details.fields.{fieldName}: [...]`. Confirm that shape matches the mobile-side error UI expectation.
3. **OpenAPI `ErrorResponse` rewrite.** This was a spec/code drift fix — verify the new schema matches the `ApiErrorResponse` / `ApiErrorBody` C# types in `src/Hali.Api/Errors/`.
4. **Test method preservation (PR_QUALITY_GATES G3).** No test methods were removed. `PlacesControllerTests` retains all 13 scenarios; the asserts moved from `Assert.IsType<BadRequestObjectResult>` to `Assert.ThrowsAsync<T> + ex.Code`, which is a strictly stronger assertion.
5. **Pre-existing `dotnet format` drift** on `develop` (several test files use tabs; project policy wants spaces). My edits preserved each file's existing indentation. Not introduced by this PR; flagged for future cleanup.

## Follow-up items (out of scope for H2)

None requiring GitHub issues. Noted for future work:
- **H3 — structured reason codes catalog.** New codes in this PR (`auth.otp_invalid`, `invite.expired`, `official_post.outside_jurisdiction`, etc.) follow the existing `namespace.reason` convention but are not centralized. When H3 lands a catalog file, this PR's codes should be the first entries.
- **Pre-existing `dotnet format` drift** on `develop` test files (tabs vs spaces policy). A dedicated formatting pass should sweep the repo.
- **`ClusteringService.CLUSTERING_NO_SPATIAL_CELL`** is still a bare `InvalidOperationException("STRING_CODE")` — internal invariant guard, never leaks to the wire. Could be retyped in a future consistency pass but doesn't earn its keep today.

## Acceptance checklist

- [x] Result vs response semantics cleaner and more consistent — one error envelope on the wire, one mechanism (typed `AppException` + H1 middleware) for producing it.
- [x] Layer boundaries clearer — no HTTP types in Application/Domain, no service catches in controllers.
- [x] Touched flows still behave correctly — 25/25 integration tests green.
- [x] Tests cover the changed behavior — 6 new integration asserts + 13 rewritten controller-unit asserts + 8 rewritten service-unit asserts.
- [x] PR reviewable and disciplined — 6 logical commits averaging ~65 lines each.
- [x] OpenAPI updated in the same PR — `ErrorResponse` schema fixed + per-endpoint error descriptions enriched with typed codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
