### PR TITLE
fix(openapi): remove undeliverable 429 from POST /v1/feedback (#136)

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -423,7 +423,7 @@ paths:
   /v1/feedback:
     post:
       tags: [Feedback]
-      summary: Submit anonymous in-app feedback (public, rate-limited)
+      summary: Submit anonymous in-app feedback (public)
       description: |
         No auth required. Returns 202 immediately — fire and forget from client.
         account_id captured server-side if request is authenticated, otherwise null.

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -437,7 +437,6 @@ paths:
               $ref: '#/components/schemas/FeedbackRequest'
       responses:
         '202': { description: Feedback received }
-        '429': { description: Rate limit exceeded }
 
   # ── Signals ─────────────────────────────────────────────────────────
   /v1/signals/preview:


### PR DESCRIPTION
## Closes

- Closes #136

## Problem

`02_openapi.yaml` advertised a `429: Rate limit exceeded` response on `POST /v1/feedback`, but `FeedbackController` is a stub with no rate limiter wired — the code cannot actually produce that status. `docs/arch/CODING_STANDARDS.md` requires every documented response to correspond to deliverable code, and this is a direct violation.

The drift pre-dates H2 (PR #134); H2 scope covered six specifically audited controllers and correctly left this outside.

## Change

One-line deletion in `02_openapi.yaml` under the `POST /v1/feedback` responses block:

```diff
       responses:
         '202': { description: Feedback received }
-        '429': { description: Rate limit exceeded }
```

Zero code changes. No other 429 entry in the file is touched — the seven legitimate 429 entries elsewhere (paths that actually have rate limiting wired) remain intact.

## When the 429 should come back

When feedback persistence and rate limiting are implemented together (future session), the `429` entry is re-added alongside the code that emits it — referencing `#/components/schemas/ErrorResponse` like every other rate-limited path post-H2.

## Verification

- `npx swagger-cli validate 02_openapi.yaml` → `02_openapi.yaml is valid`
- `dotnet build` → 0 errors, 132 pre-existing warnings (unchanged from base).
- `dotnet test` → Unit 348/348, Integration 25/25, zero failures.

## Quality gates

- [x] G1 — build clean, tests green.
- [x] G2 — every `[ProducesResponseType]` / documented response has a code path that returns it. (This PR is the fix for a G2 violation.)
- [x] G3 — no test regressions (no tests touched).
- [x] G4 — no security surface change.
- [x] G6 — docs align: spec now matches reality.

Branch based on `origin/develop@d8d2fa5`, no rebase required.