### PR TITLE
test(home): deterministic HomeFeedConcurrencyTests synchronization (#103)

### DIFF
--- a/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
@@ -21,23 +21,61 @@ namespace Hali.Tests.Unit.Home;
 public class HomeFeedConcurrencyTests
 {
     // ── Fake IHomeFeedQueryService that tracks concurrent calls ──────────────
+    //
+    // Determinism note (issue #103):
+    // This fake previously used Task.Delay(10) to simulate DB latency and relied
+    // on time-based overlap to prove the fire-then-await pattern was concurrent.
+    // That proof is flaky on slow CI runners where the delay can complete before
+    // all tasks are scheduled. We now use a TaskCompletionSource release gate:
+    // each in-flight call arrives at the gate and only proceeds once
+    // _expectedConcurrency callers are simultaneously present. If fewer callers
+    // arrive, the gate's CancellationToken timeout fires and the test fails
+    // loudly rather than racing. When _expectedConcurrency is 1 (single-call
+    // tests) the gate opens immediately, so no coordination is required.
 
     private sealed class TrackingFeedQueryService : IHomeFeedQueryService
     {
         private int _activeCalls;
         private int _peakConcurrency;
+        private int _arrivedCount;
         private readonly object _lock = new();
+        private readonly int _expectedConcurrency;
+        private readonly TaskCompletionSource _gate =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        private readonly TimeSpan _gateTimeout;
 
-        public int PeakConcurrency => _peakConcurrency;
+        public TrackingFeedQueryService(int expectedConcurrency = 1, TimeSpan? gateTimeout = null)
+        {
+            if (expectedConcurrency < 1)
+                throw new ArgumentOutOfRangeException(nameof(expectedConcurrency));
+            _expectedConcurrency = expectedConcurrency;
+            _gateTimeout = gateTimeout ?? TimeSpan.FromSeconds(5);
 
-        private void Enter()
+            // For single-caller scenarios, release the gate up front so Enter()
+            // does not block on itself.
+            if (expectedConcurrency == 1)
+                _gate.TrySetResult();
+        }
+
+        public int PeakConcurrency => Volatile.Read(ref _peakConcurrency);
+
+        private async Task EnterAsync(CancellationToken ct)
         {
             lock (_lock)
             {
                 _activeCalls++;
                 if (_activeCalls > _peakConcurrency)
                     _peakConcurrency = _activeCalls;
+                _arrivedCount++;
+                if (_arrivedCount >= _expectedConcurrency)
+                    _gate.TrySetResult();
             }
+
+            // Wait until the expected number of callers are all present, so every
+            // task is provably in-flight simultaneously. Fail fast on timeout.
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            linked.CancelAfter(_gateTimeout);
+            await _gate.Task.WaitAsync(linked.Token).ConfigureAwait(false);
         }
 
         private void Exit()
@@ -49,10 +87,9 @@ public class HomeFeedConcurrencyTests
             IEnumerable<Guid> localityIds, bool? recurringOnly, int limit,
             DateTime? cursorBefore, CancellationToken ct)
         {
-            Enter();
+            await EnterAsync(ct);
             try
             {
-                await Task.Delay(10, ct); // simulate DB latency
                 var ids = localityIds.ToList();
                 if (ids.Count == 0)
                     return new List<SignalCluster>();
@@ -68,10 +105,9 @@ public class HomeFeedConcurrencyTests
             IEnumerable<Guid> excludeLocalityIds, int limit,
             DateTime? cursorBefore, CancellationToken ct)
         {
-            Enter();
+            await EnterAsync(ct);
             try
             {
-                await Task.Delay(10, ct);
                 return new List<SignalCluster> { MakeCluster(Guid.NewGuid()) };
             }
             finally { Exit(); }
@@ -80,10 +116,9 @@ public class HomeFeedConcurrencyTests
         public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
             Guid localityId, CancellationToken ct)
         {
-            Enter();
+            await EnterAsync(ct);
             try
             {
-                await Task.Delay(10, ct);
                 return new List<OfficialPostResponseDto>();
             }
             finally { Exit(); }
@@ -109,7 +144,10 @@ public class HomeFeedConcurrencyTests
     [Fact]
     public async Task ConcurrentSections_ExecuteInParallel()
     {
-        var svc = new TrackingFeedQueryService();
+        // The gate only releases once all four callers are simultaneously
+        // in-flight, so observing the WhenAll completing is itself proof of
+        // concurrent execution — no time-based race.
+        var svc = new TrackingFeedQueryService(expectedConcurrency: 4);
         var localityIds = new List<Guid> { Guid.NewGuid() };
 
         // Mirror BuildFullResponseAsync pattern
@@ -120,9 +158,9 @@ public class HomeFeedConcurrencyTests
 
         await Task.WhenAll(t1, t2, t3, t4);
 
-        // At least 2 of the 4 tasks should have overlapped
-        Assert.True(svc.PeakConcurrency >= 2,
-            $"Expected concurrent execution but peak was {svc.PeakConcurrency}");
+        // All four tasks must have been in-flight together for the gate to
+        // release. Peak concurrency is therefore exactly the expected count.
+        Assert.Equal(4, svc.PeakConcurrency);
     }
 
     // ── Test 2: all four sections return results under concurrency ────────────
@@ -130,7 +168,7 @@ public class HomeFeedConcurrencyTests
     [Fact]
     public async Task ConcurrentSections_AllReturnResults()
     {
-        var svc = new TrackingFeedQueryService();
+        var svc = new TrackingFeedQueryService(expectedConcurrency: 4);
         var localityIds = new List<Guid> { Guid.NewGuid() };
 
         var t1 = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);
@@ -182,7 +220,7 @@ public class HomeFeedConcurrencyTests
     [Fact]
     public async Task ConcurrentExecution_PreservesSectionFiltering()
     {
-        var svc = new TrackingFeedQueryService();
+        var svc = new TrackingFeedQueryService(expectedConcurrency: 2);
         var localityIds = new List<Guid> { Guid.NewGuid() };
 
         var activeNowTask = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);


### PR DESCRIPTION
## Closes

- Closes #103

## Problem

`HomeFeedConcurrencyTests` proves the fire-then-await pattern achieves concurrent execution in `HomeController.BuildFullResponseAsync`. Its fake `IHomeFeedQueryService` implementation used `Task.Delay(10)` to simulate DB latency and an `Interlocked` `PeakConcurrency` counter that the test asserted `>= 2`.

Copilot flagged this on PR #99 as flakiness-prone under slow CI runners: if scheduling slips past 10 ms before all tasks enter the fake service, the counter never reaches 2 and the test fails even though the production code is correct. Deferred on #99 as \"reliable here\" with a note to revisit if CI flakes. This PR revisits without waiting for the flake.

## Change

Replaced the delay-based proof with a `TaskCompletionSource` release gate:

- Every in-flight caller increments an arrival counter and `await`s the gate.
- When the arrival counter reaches `expectedConcurrency`, the gate's `TrySetResult` fires and every waiter unblocks.
- A linked 5 s `CancellationTokenSource` guarantees the test fails fast (not hangs) if concurrency was never achieved.
- Sequential-case tests pre-release the gate so single callers don't block.

`Task.WhenAll` returning is now itself proof that `expectedConcurrency` callers were simultaneously in-flight — no timing dependency, no CPU-runner sensitivity. The concurrent assertion also tightened from `PeakConcurrency >= 2` to `PeakConcurrency == expectedConcurrency` because the gate guarantees the exact number of arrivals.

Scope: test file only. Zero production code changes.

## Files changed

- `tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs` — `+52 / −14`

## Verification

Determinism proof — `dotnet test --filter HomeFeedConcurrencyTests` repeated 5× consecutively:

| Run | Passed | Failed | Duration |
|---|---|---|---|
| 1 | 5 / 5 | 0 | 79 ms |
| 2 | 5 / 5 | 0 | 47 ms |
| 3 | 5 / 5 | 0 | 28 ms |
| 4 | 5 / 5 | 0 | 25 ms |
| 5 | 5 / 5 | 0 | 24 ms |

Other gates:

- `dotnet format --verify-no-changes` (scoped to the touched file): clean. Pre-existing whitespace issues in `Signals/NlpExtractionServiceTests.cs` and an `xUnit1026` warning in `Clusters/CivisCalculatorTests.cs` are present on base and explicitly out of #103 scope.
- `dotnet build`: 0 errors, 132 pre-existing warnings (unchanged).
- Full `dotnet test` (unit suite): 348 / 348 pass, 363 ms total.

## Quality gates

- [x] G1 — build clean, tests green, format clean within scope.
- [x] G3 — test substance preserved (fire-then-await concurrency still validated), assertion tightened, no tests removed.
- [x] G6 — PR body matches diff scope exactly.

## Rebase status

Branch based on `origin/develop@d8d2fa5`, no rebase required; branch is one fast-forward commit ahead of develop.