### PR TITLE
fix(h2): UsersController typed errors + OpenAPI envelope refs (#135)

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -749,10 +749,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserMeResponse'
         '401':
-          description: Unauthenticated (auth.unauthorized)
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ErrorResponse' }
+          description: Unauthenticated
         '404':
           description: Account not found (account.not_found)
           content:
@@ -773,10 +770,7 @@ paths:
       responses:
         '204': { description: Updated }
         '401':
-          description: Unauthenticated (auth.unauthorized)
-          content:
-            application/json:
-              schema: { $ref: '#/components/schemas/ErrorResponse' }
+          description: Unauthenticated
         '404':
           description: Account not found (account.not_found)
           content:

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -748,8 +748,16 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/UserMeResponse'
-        '401': { description: Unauthenticated }
-        '404': { description: Account not found }
+        '401':
+          description: Unauthenticated (auth.unauthorized)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '404':
+          description: Account not found (account.not_found)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/users/me/notification-settings:
     put:
       tags: [Users]
@@ -764,7 +772,16 @@ paths:
               $ref: '#/components/schemas/NotificationSettings'
       responses:
         '204': { description: Updated }
-        '401': { description: Unauthenticated }
+        '401':
+          description: Unauthenticated (auth.unauthorized)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '404':
+          description: Account not found (account.not_found)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Devices ─────────────────────────────────────────────────────────
   /v1/devices/push-token:

--- a/src/Hali.Api/Controllers/UsersController.cs
+++ b/src/Hali.Api/Controllers/UsersController.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hali.Api.Logging;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Contracts.Auth;
 using Hali.Contracts.Notifications;
 using Microsoft.AspNetCore.Authorization;
@@ -29,13 +30,14 @@ public class UsersController : ControllerBase
     [HttpGet("me")]
     public async Task<IActionResult> GetMe(CancellationToken ct)
     {
-        var accountId = GetAccountId();
-        if (accountId == null)
-            return Unauthorized();
+        var accountId = GetAccountId()
+            ?? throw new UnauthorizedException();
 
-        var account = await _auth.FindAccountByIdAsync(accountId.Value, ct);
+        var account = await _auth.FindAccountByIdAsync(accountId, ct);
         if (account == null)
-            return NotFound();
+            throw new NotFoundException(
+                code: "account.not_found",
+                message: "Account not found.");
 
         var settings = ParseNotificationSettings(account.NotificationSettings);
 
@@ -56,13 +58,14 @@ public class UsersController : ControllerBase
         [FromBody] NotificationSettingsDto dto,
         CancellationToken ct)
     {
-        var accountId = GetAccountId();
-        if (accountId == null)
-            return Unauthorized();
+        var accountId = GetAccountId()
+            ?? throw new UnauthorizedException();
 
-        var account = await _auth.FindAccountByIdAsync(accountId.Value, ct);
+        var account = await _auth.FindAccountByIdAsync(accountId, ct);
         if (account == null)
-            return NotFound();
+            throw new NotFoundException(
+                code: "account.not_found",
+                message: "Account not found.");
 
         account.NotificationSettings = JsonSerializer.Serialize(dto);
         account.UpdatedAt = DateTime.UtcNow;

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -114,7 +114,7 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
             audience: TestConstants.JwtAudience,
             claims: new[]
             {
-                new Claim(ClaimTypes.NameIdentifier, accountId.ToString()),
+                new Claim(JwtRegisteredClaimNames.Sub, accountId.ToString()),
             },
             notBefore: DateTime.UtcNow,
             expires: DateTime.UtcNow.AddMinutes(10),

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -1,8 +1,13 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Hali.Tests.Integration.Infrastructure;
+using Microsoft.IdentityModel.Tokens;
 using Xunit;
 
 namespace Hali.Tests.Integration.Errors;
@@ -79,6 +84,42 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "places.query_too_short");
+    }
+
+    [Fact]
+    public async Task UsersMe_AccountMissing_EmitsStandardErrorEnvelope()
+    {
+        // Exercises the H2 retype of UsersController's bare NotFound() -> typed
+        // NotFoundException("account.not_found"). A framework JWT challenge on
+        // a missing Authorization header returns 401 before the controller
+        // runs, so we cannot exercise the application-layer envelope path by
+        // omitting the header; instead we mint a valid JWT bound to a random
+        // account ID that has never been persisted, which routes the request
+        // through the controller and into its typed-exception branch.
+        var jwt = MintJwt(Guid.NewGuid());
+
+        var authedClient = CreateAuthenticatedClient(jwt);
+        var response = await authedClient.GetAsync("/v1/users/me");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "account.not_found");
+    }
+
+    private static string MintJwt(Guid accountId)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestConstants.JwtSecret));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: TestConstants.JwtIssuer,
+            audience: TestConstants.JwtAudience,
+            claims: new[]
+            {
+                new Claim(ClaimTypes.NameIdentifier, accountId.ToString()),
+            },
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -98,7 +98,7 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
         // through the controller and into its typed-exception branch.
         var jwt = MintJwt(Guid.NewGuid());
 
-        var authedClient = CreateAuthenticatedClient(jwt);
+        using var authedClient = CreateAuthenticatedClient(jwt);
         var response = await authedClient.GetAsync("/v1/users/me");
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);


### PR DESCRIPTION
## Closes

- Closes #135

## Follow-up surfaced and tracked

- #137 — Standardize framework-level 401 auth challenge responses into canonical ErrorResponse envelope

See **Architectural boundary** section below.

## Problem

`UsersController` was the last application-layer hold-out after PR #134 (H2). Two endpoints returned **body-less** MVC results that bypassed the H1 `ExceptionHandlingMiddleware` envelope:

- `GET /v1/users/me` — `return Unauthorized()` (line 34), `return NotFound()` (line 38)
- `PUT /v1/users/me/notification-settings` — `return Unauthorized()` (line 61), `return NotFound()` (line 65)

Every other application-level 404 in the API post-H2 emits the canonical `{ error: { code, message, traceId } }` envelope. These four returns were a live contradiction of that contract.

## Change

Three files, minimal and localized:

### `src/Hali.Api/Controllers/UsersController.cs`

All four body-less returns replaced with typed exception throws matching the convention established in `DevicesController` and `LocalitiesController` during H2:

- `return Unauthorized();` → `throw new UnauthorizedException();` (default code `auth.unauthorized`).
- `return NotFound();` → `throw new NotFoundException(code: "account.not_found", message: "Account not found.");`

`GetMe` and `UpdateNotificationSettings` also collapsed their `Guid? accountId` local to non-null `Guid` via `?? throw` after the unauthorized guard, so the subsequent `.Value` access disappears. Adds `using Hali.Application.Errors;`.

### `02_openapi.yaml`

On both `/v1/users/me` and `/v1/users/me/notification-settings`:

- **404 now references `#/components/schemas/ErrorResponse`** with code-tagged description (`account.not_found`). This path is reachable via the controller-thrown `NotFoundException` that this PR adds; the middleware emits the envelope verbatim.
- **401 is description-only with no response body schema.** `[Authorize]`-protected endpoints short-circuit through the JwtBearer challenge (see **Architectural boundary** below) before the controller runs, so advertising `ErrorResponse` on 401 would be spec dishonesty about what callers actually receive. Aligned with the existing pattern on other bearer-auth endpoints (e.g. `/v1/localities/followed` 401). 401 entries across all `[Authorize]` endpoints will be pointed at `ErrorResponse` in one pass when the framework-level envelope work lands via **#137**.

No other path touched. Does not overlap with the already-merged #138.

### `tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs`

Added `UsersMe_AccountMissing_EmitsStandardErrorEnvelope` plus a local `MintJwt` helper. The test mints a valid JWT bound to a random non-persisted account ID and asserts **404 + canonical envelope** on `GET /v1/users/me` — exercising the application-layer `account.not_found` branch (see **Architectural boundary** below for why the literal "no Authorization header → 401 envelope" test is not used).

`MintJwt` issues the token with `JwtRegisteredClaimNames.Sub` to mirror the production shape emitted by `AuthService.IssueAccessToken` (`src/Hali.Application/Auth/AuthService.cs:103`), so the integration test catches any future drift at the claim-name level rather than relying on inbound claim mapping.

## Architectural boundary — why the test asserts 404, not 401

The issue's suggested acceptance test was "`GET /v1/users/me` without an Authorization header → 401 envelope". This was implemented literally first and **failed** with an empty body.

Root cause: in ASP.NET Core with `[Authorize]` + JwtBearer, an unauthenticated request is short-circuited by the JwtBearer auth middleware's challenge mechanism **before** the controller executes and **before** `ExceptionHandlingMiddleware` sees the response. The bare 401 never reaches the `UnauthorizedException` throw this PR adds.

The reachable application-layer path is the `account.not_found` branch: a caller presents a valid JWT for an account ID that no longer exists in the database. `GetMe` hits `_auth.FindAccountByIdAsync(accountId) == null` and throws `NotFoundException`, which `ExceptionHandlingMiddleware` translates to the envelope.

**Framework-level 401 inconsistency remains.** It is a cross-cutting concern (`JwtBearerEvents.OnChallenge` or `UseStatusCodePages`) that affects every `[Authorize]` endpoint, not just `UsersController`. Keeping it inside #135 would have expanded scope from "one controller" to "app-wide auth challenge rewrite". Tracked as **#137** for a focused, cross-cutting PR. Once #137 lands, the 401 description-only entries on `/v1/users/me` and `/v1/users/me/notification-settings` — and every other `[Authorize]` 401 — will point at `ErrorResponse` in a single change set.

## Verification

- `dotnet format --verify-no-changes` (touched files): PASS. Repo-wide run flags pre-existing whitespace in `tests/Hali.Tests.Integration/Infrastructure/IntegrationTestBase.cs`, `TestConstants.cs`, and `ParticipationIntegrationTests.cs` — untouched by this PR and explicitly out of scope.
- `dotnet build`: 0 errors, 7 warnings (baseline).
- `dotnet test` (Unit): 348 / 348.
- `dotnet test` (Integration): 26 / 26 — includes the new envelope assertion on the `sub`-claim-minted path.

## Quality gates

- [x] G1 — build clean, tests green, scoped format clean.
- [x] G2 — OpenAPI now references the schema the code actually emits for the 404 path; the 401 path is description-only to stay truthful until #137 lands. Error codes follow `<category>.<reason>`. No `[ProducesResponseType]` drift introduced.
- [x] G3 — no test methods removed; new assertion added; assertion matches semantics (404 + canonical envelope); test JWT shape matches production (`sub` claim).
- [x] G4 — no new log-template surface; no auth surface expansion.
- [x] G6 — PR description accurately scopes the diff and explicitly flags the architectural boundary.
- [x] G7 — the real deferred work (framework-level 401) is logged as **#137** before merge, not quietly dropped.

## Rebase status

Branch rebased on latest `origin/develop` (includes merged PRs #138 and #139). Latest commit: `32f25ef` — `test(h2): mint test JWT with 'sub' claim matching production`.
