### PR TITLE
perf(home): batch official-posts query across followed localities (#102)

### DIFF
--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -251,12 +251,8 @@ public class HomeController : ControllerBase
         if (localityIds.Count == 0)
             return EmptyPostSection();
 
-        var allPosts = new List<OfficialPostResponseDto>();
-        foreach (var lid in localityIds)
-        {
-            var posts = await _feedQuery.GetOfficialPostsByLocalityAsync(lid, ct);
-            allPosts.AddRange(posts);
-        }
+        IReadOnlyList<OfficialPostResponseDto> allPosts =
+            await _feedQuery.GetOfficialPostsByLocalitiesAsync(localityIds, ct);
 
         // Sort by CreatedAt descending, apply cursor
         var sorted = allPosts

--- a/src/Hali.Application/Home/IHomeFeedQueryService.cs
+++ b/src/Hali.Application/Home/IHomeFeedQueryService.cs
@@ -33,8 +33,11 @@ public interface IHomeFeedQueryService
         DateTime? cursorBefore, CancellationToken ct);
 
     /// <summary>
-    /// Returns published official posts scoped to a locality, mapped to response DTOs.
+    /// Returns published official posts scoped to any of the specified localities,
+    /// mapped to response DTOs. Results are de-duplicated by post id (a post
+    /// scoped to multiple localities returns once) and ordered by CreatedAt
+    /// descending. Single DB scope — replaces the previous per-locality loop.
     /// </summary>
-    Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
-        Guid localityId, CancellationToken ct);
+    Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
+        IEnumerable<Guid> localityIds, CancellationToken ct);
 }

--- a/src/Hali.Application/Home/IHomeFeedQueryService.cs
+++ b/src/Hali.Application/Home/IHomeFeedQueryService.cs
@@ -36,7 +36,8 @@ public interface IHomeFeedQueryService
     /// Returns published official posts scoped to any of the specified localities,
     /// mapped to response DTOs. Results are de-duplicated by post id (a post
     /// scoped to multiple localities returns once) and ordered by CreatedAt
-    /// descending. Single DB scope — replaces the previous per-locality loop.
+    /// descending. Single DI scope / DbContext — replaces the previous
+    /// per-locality loop.
     /// </summary>
     Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
         IEnumerable<Guid> localityIds, CancellationToken ct);

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -71,15 +71,18 @@ public class HomeFeedQueryService : IHomeFeedQueryService
         return await q.OrderByDescending(c => c.ActivatedAt).Take(limit).ToListAsync(ct);
     }
 
-    public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
-        Guid localityId, CancellationToken ct)
+    public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
+        IEnumerable<Guid> localityIds, CancellationToken ct)
     {
+        var ids = localityIds?.ToList() ?? new List<Guid>();
+        if (ids.Count == 0) return Array.Empty<OfficialPostResponseDto>();
+
         await using var scope = _scopeFactory.CreateAsyncScope();
         var db = scope.ServiceProvider.GetRequiredService<AdvisoriesDbContext>();
 
         var postIds = await db.OfficialPostScopes
             .AsNoTracking()
-            .Where(s => s.LocalityId == localityId)
+            .Where(s => s.LocalityId != null && ids.Contains(s.LocalityId.Value))
             .Select(s => s.OfficialPostId)
             .Distinct()
             .ToListAsync(ct);

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -87,6 +87,11 @@ public class HomeFeedQueryService : IHomeFeedQueryService
             .Distinct()
             .ToListAsync(ct);
 
+        // Short-circuit: no scoped posts means no results. Avoids a second
+        // round-trip with an empty IN() set in the common case where a
+        // followed locality set has no published official posts.
+        if (postIds.Count == 0) return Array.Empty<OfficialPostResponseDto>();
+
         var posts = await db.OfficialPosts
             .AsNoTracking()
             .Where(p => postIds.Contains(p.Id) && p.Status == "published")

--- a/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
+++ b/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
@@ -301,8 +301,8 @@ public class ContractDriftTests
                 Arg.Any<IEnumerable<Guid>>(), Arg.Any<int>(),
                 Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
-        feedQuery.GetOfficialPostsByLocalityAsync(
-                Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+        feedQuery.GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
             .Returns((IReadOnlyList<OfficialPostResponseDto>)Array.Empty<OfficialPostResponseDto>());
 
         // Cache miss on read, capture the JSON on write. The controller's

--- a/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
@@ -77,8 +77,8 @@ public class HomeAnonymousBrowseTests
             .Returns(new List<SignalCluster>().AsReadOnly());
 
         _feedQuery
-            .GetOfficialPostsByLocalityAsync(
-                Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
     }
 
@@ -126,8 +126,8 @@ public class HomeAnonymousBrowseTests
             .Returns(new List<SignalCluster>().AsReadOnly());
 
         _feedQuery
-            .GetOfficialPostsByLocalityAsync(
-                Arg.Any<Guid>(),
+            .GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(),
                 Arg.Any<CancellationToken>())
             .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
 
@@ -233,8 +233,8 @@ public class HomeAnonymousBrowseTests
             .Returns(new List<SignalCluster>().AsReadOnly());
 
         _feedQuery
-            .GetOfficialPostsByLocalityAsync(
-                Arg.Any<Guid>(),
+            .GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(),
                 Arg.Any<CancellationToken>())
             .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
 
@@ -282,8 +282,8 @@ public class HomeAnonymousBrowseTests
             .Returns(new List<SignalCluster>().AsReadOnly());
 
         _feedQuery
-            .GetOfficialPostsByLocalityAsync(
-                Arg.Any<Guid>(),
+            .GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(),
                 Arg.Any<CancellationToken>())
             .Returns(new List<Hali.Contracts.Advisories.OfficialPostResponseDto>());
 

--- a/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeFeedConcurrencyTests.cs
@@ -113,8 +113,8 @@ public class HomeFeedConcurrencyTests
             finally { Exit(); }
         }
 
-        public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalityAsync(
-            Guid localityId, CancellationToken ct)
+        public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
+            IEnumerable<Guid> localityIds, CancellationToken ct)
         {
             await EnterAsync(ct);
             try
@@ -152,7 +152,7 @@ public class HomeFeedConcurrencyTests
 
         // Mirror BuildFullResponseAsync pattern
         var t1 = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);
-        var t2 = svc.GetOfficialPostsByLocalityAsync(localityIds[0], CancellationToken.None);
+        var t2 = svc.GetOfficialPostsByLocalitiesAsync(localityIds, CancellationToken.None);
         var t3 = svc.GetActiveByLocalitiesPagedAsync(localityIds, true, 11, null, CancellationToken.None);
         var t4 = svc.GetAllActivePagedAsync(localityIds, 11, null, CancellationToken.None);
 
@@ -172,7 +172,7 @@ public class HomeFeedConcurrencyTests
         var localityIds = new List<Guid> { Guid.NewGuid() };
 
         var t1 = svc.GetActiveByLocalitiesPagedAsync(localityIds, false, 21, null, CancellationToken.None);
-        var t2 = svc.GetOfficialPostsByLocalityAsync(localityIds[0], CancellationToken.None);
+        var t2 = svc.GetOfficialPostsByLocalitiesAsync(localityIds, CancellationToken.None);
         var t3 = svc.GetActiveByLocalitiesPagedAsync(localityIds, true, 11, null, CancellationToken.None);
         var t4 = svc.GetAllActivePagedAsync(localityIds, 11, null, CancellationToken.None);
 

--- a/tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs
@@ -72,8 +72,8 @@ public class HomeObservabilityTests
                 Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
             .Returns(new List<SignalCluster>());
 
-        _feedQuery.GetOfficialPostsByLocalityAsync(
-                Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+        _feedQuery.GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
             .Returns(new List<OfficialPostResponseDto>());
 
         _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())


### PR DESCRIPTION
## Closes

- Closes #102

## Problem

\`HomeController.BuildOfficialUpdatesSectionAsync\` loops over every followed locality and issues one \`GetOfficialPostsByLocalityAsync\` call per locality before sorting the concatenated result. Followed-wards is capped at 5, so per-request blast radius is bounded — but it is 5 DI scopes, 5 \`DbContext\` instances, 5 round-trips, on a home-feed hot path, for work that a single query can do.

Flagged on PR #99 and deferred as pre-existing behaviour carried forward from the original controller. This PR closes that deferral.

## Change

A focused hot-path fix — no surrounding refactor.

### `IHomeFeedQueryService` / `HomeFeedQueryService`

Renamed `GetOfficialPostsByLocalityAsync(Guid, ...)` to `GetOfficialPostsByLocalitiesAsync(IEnumerable<Guid>, ...)` and reshaped the implementation to use a single DI scope and two queries regardless of the number of followed localities:

\`\`\`csharp
public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
    IEnumerable<Guid> localityIds, CancellationToken ct)
{
    var ids = localityIds?.ToList() ?? new List<Guid>();
    if (ids.Count == 0) return Array.Empty<OfficialPostResponseDto>();

    await using var scope = _scopeFactory.CreateAsyncScope();
    var db = scope.ServiceProvider.GetRequiredService<AdvisoriesDbContext>();

    var postIds = await db.OfficialPostScopes
        .AsNoTracking()
        .Where(s => s.LocalityId != null && ids.Contains(s.LocalityId.Value))
        .Select(s => s.OfficialPostId)
        .Distinct()
        .ToListAsync(ct);

    var posts = await db.OfficialPosts
        .AsNoTracking()
        .Where(p => postIds.Contains(p.Id) && p.Status == "published")
        .OrderByDescending(p => p.CreatedAt)
        .ToListAsync(ct);

    return posts.Select(MapToDto).ToList();
}
\`\`\`

The nullable-predicate shape (\`s.LocalityId != null && ids.Contains(s.LocalityId.Value)\`) matches the existing idiom on \`GetActiveByLocalitiesPagedAsync\` in the same file; EF silently filtered nulls before as well, so null-scoped rows continue not to match.

### `HomeController.BuildOfficialUpdatesSectionAsync`

The loop collapses to one line:

\`\`\`diff
-var allPosts = new List<OfficialPostResponseDto>();
-foreach (var lid in localityIds)
-{
-    var posts = await _feedQuery.GetOfficialPostsByLocalityAsync(lid, ct);
-    allPosts.AddRange(posts);
-}
+IReadOnlyList<OfficialPostResponseDto> allPosts =
+    await _feedQuery.GetOfficialPostsByLocalitiesAsync(localityIds, ct);
\`\`\`

**Sort / cursor / \`TotalCount\` logic below this block is strictly untouched.** \`PagedSection<OfficialPostResponseDto>\` shape, pagination, `nextCursor` encoding, and the `LimitOfficialUpdates + 1` hasMore trick are all preserved verbatim. The local variable type changed from `List<T>` to `IReadOnlyList<T>`; every downstream LINQ call works unchanged.

### `BuildFullResponseAsync` concurrency pattern — preserved

The four concurrent `Task.WhenAll` sections that `HomeController.BuildFullResponseAsync` fires remain intact. The batched method still allocates its own DI scope per call, so the fire-then-await pattern continues to be safe — same isolation properties as the singular method it replaces.

### Test migration

Six test call sites migrated to the new signature — pure NSubstitute-setup or fake-implementation signature swaps, no assertion behaviour changes:

- `HomeAnonymousBrowseTests.cs` — 4 setups.
- `HomeFeedConcurrencyTests.cs` — 1 fake implementation + 2 call sites.
- `ContractDriftTests.cs` — 1 setup.
- `HomeObservabilityTests.cs` — 1 setup.

`TrackingFeedQueryService`'s release-gate logic is unchanged — the 4-section concurrency proof still holds because \`BuildFullResponseAsync\` still fires four IO calls in parallel, one of which now takes an \`IEnumerable<Guid>\` instead of a \`Guid\`.

## Intentional behaviour improvement — multi-scoped post deduplication

**Important reviewer note.** This is a visible semantic change and worth calling out explicitly.

- **Before:** the looped implementation called `GetOfficialPostsByLocalityAsync(lid)` once per followed locality. An \`official_post\` scoped to two followed localities via two \`official_post_scopes\` rows was returned **twice** in \`allPosts\` — once per locality pass — and counted twice in \`OfficialUpdates.TotalCount\`.
- **After:** the batched query uses a single DB-level `Distinct()` on `OfficialPostId` across all followed localities, so each multi-scoped post is returned **once**.

**Wire shape is unchanged** — `OfficialPostResponseDto`, `PagedSection<OfficialPostResponseDto>`, \`items\`, \`nextCursor\` are all identical. **`OfficialUpdates.TotalCount` may be lower in duplicate cases** than it was under the looped implementation.

This is an **intentional correctness/UX improvement, not an accidental regression**. Duplicate entries for the same civic post in a home feed are a UX bug, and paginating a duplicate-inflated \`TotalCount\` is misleading. The natural shape of a batched query produces the correct behaviour without extra code; preserving the double-count would require artificial list expansion, which is perverse.

No existing unit or integration test seeded multi-scoped posts or asserted on \`TotalCount\` against the duplication, so no assertions needed updating — the improvement is invisible in today's test fixtures but will manifest correctly the moment a multi-scoped post exists in production data.

## Explicitly NOT in this PR

This PR is scoped to the N+1 → batched-query fix on one hot path. Related home-feed work that was deliberately left alone:

- **#100 — shared \`OfficialPost\` DTO mapper extraction.** The \`MapToDto\` / \`EnumToSnakeCase\` helpers in `HomeFeedQueryService` remain duplicated with `OfficialPostsService`. Extracting the mapper is the #100 lane in the sequencing plan and will be picked up in the #101-absorbing-#100 PR.
- **#101 — `HomeFeedQueryService` delegation to canonical repositories.** This service still owns its own LINQ implementations rather than delegating to `IClusterRepository` / `IOfficialPostsService`. Moving to delegation is the #101 lane and will be done in the same follow-up PR as #100.

Keeping this PR to the batched-query surface keeps the review surface small and preserves the sequencing's stated "home-feed serialised" discipline: land #102 first, then the deeper refactor in #101/#100, without conflating two architectural changes.

## Validation

| Gate | Result |
|---|---|
| `dotnet format --verify-no-changes` (touched files) | clean |
| `dotnet build` | 0 errors, 122 pre-existing warnings, zero new warnings in touched files |
| `dotnet test` Unit | **348 / 348 pass** |
| `dotnet test` Integration | **29 / 29 pass** |

## Quality gates

- [x] G1 — build clean, tests green, format clean within scope.
- [x] G2 — no `[ProducesResponseType]` drift; wire contract unchanged; no OpenAPI change (semantic dedup improvement does not alter the spec shape).
- [x] G3 — no test methods removed; 6 test call sites migrated to the new signature with no assertion-behaviour changes.
- [x] G4 — no log surface change; `[AllowAnonymous]` / auth posture unchanged.
- [x] G6 — PR description scopes the diff precisely, explicitly flags the dedup behaviour improvement, and explicitly states that #100 / #101 work is NOT in this PR.

## Rebase status

Branch based on `origin/develop@a39ffc1` (Group 2 merged). Single commit `3d1623c` ahead of develop. No rebase needed.