### PR TITLE
refactor(home): delegate HomeFeedQueryService to canonical repos + consolidate mapper (#101, #100)

### DIFF
--- a/src/Hali.Application/Advisories/IOfficialPostRepository.cs
+++ b/src/Hali.Application/Advisories/IOfficialPostRepository.cs
@@ -17,5 +17,14 @@ public interface IOfficialPostRepository
     Task<bool> JurisdictionIntersectsScopeAsync(Guid institutionId, Guid postId, CancellationToken ct);
     Task<List<OfficialPost>> GetByClusterIdAsync(Guid clusterId, CancellationToken ct);
     Task<List<OfficialPost>> GetActiveByLocalityAsync(Guid localityId, CancellationToken ct);
+
+    /// <summary>
+    /// Returns published OfficialPost entities scoped to any of the given
+    /// localities, de-duplicated by post id (a post scoped to multiple
+    /// localities returns once) and ordered by CreatedAt descending.
+    /// Uses AsNoTracking — intended for read paths like the home feed.
+    /// </summary>
+    Task<List<OfficialPost>> GetActiveByLocalitiesAsync(IEnumerable<Guid> localityIds, CancellationToken ct);
+
     Task<int> ExpirePostsAsync(CancellationToken ct);
 }

--- a/src/Hali.Application/Advisories/IOfficialPostsService.cs
+++ b/src/Hali.Application/Advisories/IOfficialPostsService.cs
@@ -11,4 +11,5 @@ public interface IOfficialPostsService
     Task<OfficialPostResponseDto> CreatePostAsync(Guid institutionId, Guid? authorAccountId, CreateOfficialPostRequestDto dto, CancellationToken ct);
     Task<List<OfficialPostResponseDto>> GetByClusterIdAsync(Guid clusterId, CancellationToken ct);
     Task<List<OfficialPostResponseDto>> GetActiveByLocalityAsync(Guid localityId, CancellationToken ct);
+    Task<List<OfficialPostResponseDto>> GetActiveByLocalitiesAsync(IEnumerable<Guid> localityIds, CancellationToken ct);
 }

--- a/src/Hali.Application/Advisories/OfficialPostsService.cs
+++ b/src/Hali.Application/Advisories/OfficialPostsService.cs
@@ -116,6 +116,13 @@ public class OfficialPostsService : IOfficialPostsService
         return posts.Select(MapToDto).ToList();
     }
 
+    public async Task<List<OfficialPostResponseDto>> GetActiveByLocalitiesAsync(
+        IEnumerable<Guid> localityIds, CancellationToken ct)
+    {
+        var posts = await _repo.GetActiveByLocalitiesAsync(localityIds, ct);
+        return posts.Select(MapToDto).ToList();
+    }
+
     private static string EnumToSnakeCase(string name) =>
         System.Text.RegularExpressions.Regex.Replace(name, "(?<=[a-z])([A-Z])", "_$1").ToLowerInvariant();
 

--- a/src/Hali.Infrastructure/Advisories/OfficialPostRepository.cs
+++ b/src/Hali.Infrastructure/Advisories/OfficialPostRepository.cs
@@ -100,6 +100,30 @@ public class OfficialPostRepository : IOfficialPostRepository
             .ToListAsync(ct);
     }
 
+    public async Task<List<OfficialPost>> GetActiveByLocalitiesAsync(IEnumerable<Guid> localityIds, CancellationToken ct)
+    {
+        var ids = localityIds?.ToList() ?? new List<Guid>();
+        if (ids.Count == 0) return new List<OfficialPost>();
+
+        var postIds = await _db.OfficialPostScopes
+            .AsNoTracking()
+            .Where(s => s.LocalityId != null && ids.Contains(s.LocalityId.Value))
+            .Select(s => s.OfficialPostId)
+            .Distinct()
+            .ToListAsync(ct);
+
+        // Short-circuit: no scoped posts means no results. Avoids a second
+        // round-trip with an empty IN() set in the common case where a
+        // followed locality set has no published official posts.
+        if (postIds.Count == 0) return new List<OfficialPost>();
+
+        return await _db.OfficialPosts
+            .AsNoTracking()
+            .Where(p => postIds.Contains(p.Id) && p.Status == "published")
+            .OrderByDescending(p => p.CreatedAt)
+            .ToListAsync(ct);
+    }
+
     public async Task<int> ExpirePostsAsync(CancellationToken ct)
     {
         return await _db.OfficialPosts

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -1,24 +1,22 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Advisories;
+using Hali.Application.Clusters;
 using Hali.Application.Home;
 using Hali.Contracts.Advisories;
-using Hali.Domain.Entities.Advisories;
 using Hali.Domain.Entities.Clusters;
-using Hali.Infrastructure.Data.Advisories;
-using Hali.Infrastructure.Data.Clusters;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Hali.Infrastructure.Home;
 
 /// <summary>
-/// Read-only home feed query service. Each method creates a new DI scope
-/// and resolves a fresh DbContext, making concurrent calls safe — no two
-/// tasks share a DbContext instance. All queries use AsNoTracking.
+/// Read-only home feed query service. Each method creates a new DI scope and
+/// resolves the scoped canonical repository/service implementations from that
+/// scope, then delegates. Per-call scope isolation keeps concurrent section
+/// reads safe — no two tasks share a DbContext instance. Canonical paths
+/// already use AsNoTracking, so this façade inherits that posture.
 /// </summary>
 public class HomeFeedQueryService : IHomeFeedQueryService
 {
@@ -34,22 +32,8 @@ public class HomeFeedQueryService : IHomeFeedQueryService
         DateTime? cursorBefore, CancellationToken ct)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<ClustersDbContext>();
-
-        var ids = localityIds.ToList();
-        var q = db.SignalClusters
-            .AsNoTracking()
-            .Where(c => c.LocalityId != null && ids.Contains(c.LocalityId.Value) && (int)c.State == 1);
-
-        if (recurringOnly == true)
-            q = q.Where(c => c.TemporalType == "recurring");
-        else if (recurringOnly == false)
-            q = q.Where(c => c.TemporalType != "recurring");
-
-        if (cursorBefore.HasValue)
-            q = q.Where(c => c.ActivatedAt < cursorBefore.Value);
-
-        return await q.OrderByDescending(c => c.ActivatedAt).Take(limit).ToListAsync(ct);
+        var clusters = scope.ServiceProvider.GetRequiredService<IClusterRepository>();
+        return await clusters.GetActiveByLocalitiesPagedAsync(localityIds, recurringOnly, limit, cursorBefore, ct);
     }
 
     public async Task<IReadOnlyList<SignalCluster>> GetAllActivePagedAsync(
@@ -57,66 +41,15 @@ public class HomeFeedQueryService : IHomeFeedQueryService
         DateTime? cursorBefore, CancellationToken ct)
     {
         await using var scope = _scopeFactory.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<ClustersDbContext>();
-
-        var excludeIds = excludeLocalityIds.ToList();
-        var q = db.SignalClusters
-            .AsNoTracking()
-            .Where(c => (int)c.State == 1 &&
-                        (c.LocalityId == null || !excludeIds.Contains(c.LocalityId.Value)));
-
-        if (cursorBefore.HasValue)
-            q = q.Where(c => c.ActivatedAt < cursorBefore.Value);
-
-        return await q.OrderByDescending(c => c.ActivatedAt).Take(limit).ToListAsync(ct);
+        var clusters = scope.ServiceProvider.GetRequiredService<IClusterRepository>();
+        return await clusters.GetAllActivePagedAsync(excludeLocalityIds, limit, cursorBefore, ct);
     }
 
     public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
         IEnumerable<Guid> localityIds, CancellationToken ct)
     {
-        var ids = localityIds?.ToList() ?? new List<Guid>();
-        if (ids.Count == 0) return Array.Empty<OfficialPostResponseDto>();
-
         await using var scope = _scopeFactory.CreateAsyncScope();
-        var db = scope.ServiceProvider.GetRequiredService<AdvisoriesDbContext>();
-
-        var postIds = await db.OfficialPostScopes
-            .AsNoTracking()
-            .Where(s => s.LocalityId != null && ids.Contains(s.LocalityId.Value))
-            .Select(s => s.OfficialPostId)
-            .Distinct()
-            .ToListAsync(ct);
-
-        // Short-circuit: no scoped posts means no results. Avoids a second
-        // round-trip with an empty IN() set in the common case where a
-        // followed locality set has no published official posts.
-        if (postIds.Count == 0) return Array.Empty<OfficialPostResponseDto>();
-
-        var posts = await db.OfficialPosts
-            .AsNoTracking()
-            .Where(p => postIds.Contains(p.Id) && p.Status == "published")
-            .OrderByDescending(p => p.CreatedAt)
-            .ToListAsync(ct);
-
-        return posts.Select(MapToDto).ToList();
+        var officialPosts = scope.ServiceProvider.GetRequiredService<IOfficialPostsService>();
+        return await officialPosts.GetActiveByLocalitiesAsync(localityIds, ct);
     }
-
-    // ── DTO mapping (mirrors OfficialPostsService.MapToDto exactly) ─────────
-
-    private static string EnumToSnakeCase(string name) =>
-        Regex.Replace(name, "(?<=[a-z])([A-Z])", "_$1").ToLowerInvariant();
-
-    private static OfficialPostResponseDto MapToDto(OfficialPost p) => new(
-        p.Id,
-        p.InstitutionId,
-        EnumToSnakeCase(p.Type.ToString()),
-        EnumToSnakeCase(p.Category.ToString()),
-        p.Title,
-        p.Body,
-        p.StartsAt,
-        p.EndsAt,
-        p.Status,
-        p.RelatedClusterId,
-        p.IsRestorationClaim,
-        p.CreatedAt);
 }

--- a/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
+++ b/src/Hali.Infrastructure/Home/HomeFeedQueryService.cs
@@ -48,6 +48,14 @@ public class HomeFeedQueryService : IHomeFeedQueryService
     public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
         IEnumerable<Guid> localityIds, CancellationToken ct)
     {
+        // Pre-scope short-circuit: preserves the #102 optimisation that avoids
+        // creating an AsyncServiceScope and resolving a scoped service for the
+        // common empty-follows case. Covers the materialised inputs HomeController
+        // passes (always a List<Guid>); non-materialised enumerables fall through
+        // to the scope path, where the downstream repo short-circuits again.
+        if (localityIds is ICollection<Guid> c && c.Count == 0)
+            return Array.Empty<OfficialPostResponseDto>();
+
         await using var scope = _scopeFactory.CreateAsyncScope();
         var officialPosts = scope.ServiceProvider.GetRequiredService<IOfficialPostsService>();
         return await officialPosts.GetActiveByLocalitiesAsync(localityIds, ct);

--- a/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
@@ -40,8 +40,10 @@ public class OfficialPostsServiceTests
         public Task<List<OfficialPost>> GetActiveByLocalityAsync(Guid localityId, CancellationToken ct)
             => Task.FromResult(new List<OfficialPost>());
 
+        public List<OfficialPost> ActiveByLocalitiesResult { get; set; } = new();
+
         public Task<List<OfficialPost>> GetActiveByLocalitiesAsync(IEnumerable<Guid> localityIds, CancellationToken ct)
-            => Task.FromResult(new List<OfficialPost>());
+            => Task.FromResult(ActiveByLocalitiesResult);
 
         public Task<int> ExpirePostsAsync(CancellationToken ct) => Task.FromResult(0);
     }
@@ -205,5 +207,82 @@ public class OfficialPostsServiceTests
 
         Assert.Equal(SignalState.Active, cluster.State);
         Assert.Empty(clusterRepo.Decisions);
+    }
+
+    // ── GetActiveByLocalitiesAsync — batched read path (#101/#100) ─────────
+
+    [Fact]
+    public async Task GetActiveByLocalitiesAsync_MapsEntitiesToDtosAndPreservesOrder()
+    {
+        // Seed two entities with deliberately distinct Type and Category values
+        // so we can verify both snake_case enum conversions land in the DTO,
+        // and keep them in a specific input order so we can assert the service
+        // preserves ordering from the repo (it does not re-sort).
+        var firstId = Guid.NewGuid();
+        var secondId = Guid.NewGuid();
+        var inst = Guid.NewGuid();
+        var cluster = Guid.NewGuid();
+        var firstAt = new DateTime(2026, 04, 14, 10, 00, 00, DateTimeKind.Utc);
+        var secondAt = new DateTime(2026, 04, 14, 09, 00, 00, DateTimeKind.Utc);
+
+        var repo = new FakeOfficialPostRepo
+        {
+            ActiveByLocalitiesResult = new List<OfficialPost>
+            {
+                new OfficialPost
+                {
+                    Id                 = firstId,
+                    InstitutionId      = inst,
+                    Type               = OfficialPostType.ScheduledDisruption,
+                    Category           = CivicCategory.Water,
+                    Title              = "First",
+                    Body               = "First body",
+                    StartsAt           = firstAt,
+                    EndsAt             = null,
+                    Status             = "published",
+                    RelatedClusterId   = cluster,
+                    IsRestorationClaim = false,
+                    CreatedAt          = firstAt,
+                },
+                new OfficialPost
+                {
+                    Id                 = secondId,
+                    InstitutionId      = inst,
+                    Type               = OfficialPostType.AdvisoryPublicNotice,
+                    Category           = CivicCategory.Electricity,
+                    Title              = "Second",
+                    Body               = "Second body",
+                    StartsAt           = secondAt,
+                    EndsAt             = null,
+                    Status             = "published",
+                    RelatedClusterId   = null,
+                    IsRestorationClaim = true,
+                    CreatedAt          = secondAt,
+                },
+            },
+        };
+        var svc = new OfficialPostsService(repo, new FakeClusterRepo());
+
+        var dtos = await svc.GetActiveByLocalitiesAsync(
+            new List<Guid> { Guid.NewGuid(), Guid.NewGuid() },
+            CancellationToken.None);
+
+        // Count + order preserved from the repo (service does not re-sort).
+        Assert.Equal(2, dtos.Count);
+        Assert.Equal(firstId, dtos[0].Id);
+        Assert.Equal(secondId, dtos[1].Id);
+
+        // Snake_case Type + Category conversion.
+        Assert.Equal("scheduled_disruption", dtos[0].Type);
+        Assert.Equal("water", dtos[0].Category);
+        Assert.Equal("advisory_public_notice", dtos[1].Type);
+        Assert.Equal("electricity", dtos[1].Category);
+
+        // Straight-through fields.
+        Assert.Equal("First", dtos[0].Title);
+        Assert.Equal(cluster, dtos[0].RelatedClusterId);
+        Assert.False(dtos[0].IsRestorationClaim);
+        Assert.True(dtos[1].IsRestorationClaim);
+        Assert.Null(dtos[1].RelatedClusterId);
     }
 }

--- a/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs
@@ -40,6 +40,9 @@ public class OfficialPostsServiceTests
         public Task<List<OfficialPost>> GetActiveByLocalityAsync(Guid localityId, CancellationToken ct)
             => Task.FromResult(new List<OfficialPost>());
 
+        public Task<List<OfficialPost>> GetActiveByLocalitiesAsync(IEnumerable<Guid> localityIds, CancellationToken ct)
+            => Task.FromResult(new List<OfficialPost>());
+
         public Task<int> ExpirePostsAsync(CancellationToken ct) => Task.FromResult(0);
     }
 


### PR DESCRIPTION
## Closes

- Closes #101 — Refactor `HomeFeedQueryService` to delegate to scoped repository instances.
- Closes #100 — Extract shared `OfficialPost` DTO mapper (see **Reviewer note on #100** below for how this is resolved).

## Follow-up surfaced during review

- #146 — Add integration test coverage for `/v1/home` home-feed controller. Pre-existing coverage gap, not introduced by this PR. See **Test coverage — honesty note** below.

## Problem

`HomeFeedQueryService` has carried two drift risks since PR #99 (Phase A7):

1. **Query duplication.** All three methods (`GetActiveByLocalitiesPagedAsync`, `GetAllActivePagedAsync`, `GetOfficialPostsByLocalitiesAsync`) reimplemented EF LINQ that the canonical repositories already own. Any change to filtering, ordering, or pagination in the canonical paths had to be manually mirrored here — enforced only by convention. Copilot flagged this on #99 three times and each was rejected as out-of-scope for that PR.

2. **Mapper duplication.** `OfficialPostResponseDto` mapping logic (`MapToDto` + `EnumToSnakeCase`) was an exact copy of the private version in `OfficialPostsService`. Any new DTO field, renamed enum, or serialisation change had to be applied in two places — same silent-drift risk, different layer.

Both concerns have been waiting for the home-feed lane to stabilise. After #102 landed (PR #144), the data shapes converged and this refactor became a clean move.

## Change

A disciplined delegation refactor — net **−23 lines** across six files in the primary commit, plus an additional **+88 / −1** follow-up commit addressing Copilot review. The home-feed layer shrinks into pure plumbing; the batched official-posts logic introduced in #102 moves down one layer to its canonical home.

### Add batched methods on the canonical surfaces

**`IOfficialPostRepository.GetActiveByLocalitiesAsync(IEnumerable<Guid>, CancellationToken)`** — new batched entity-list method. Implementation lifts #102's batched LINQ **verbatim** from `HomeFeedQueryService`:

```csharp
OfficialPostScopes
    .AsNoTracking()
    .Where(s => s.LocalityId != null && ids.Contains(s.LocalityId.Value))
    .Select(s => s.OfficialPostId)
    .Distinct()
    .ToListAsync(ct);
// empty-input short-circuit + empty-postIds short-circuit preserved
OfficialPosts
    .AsNoTracking()
    .Where(p => postIds.Contains(p.Id) && p.Status == "published")
    .OrderByDescending(p => p.CreatedAt)
    .ToListAsync(ct);
```

**`IOfficialPostsService.GetActiveByLocalitiesAsync(IEnumerable<Guid>, CancellationToken)`** — thin batched DTO-list method mirroring the existing singular pattern: `_repo.GetActiveByLocalitiesAsync(...)` then `.Select(MapToDto).ToList()`.

### Refactor `HomeFeedQueryService` to pure delegation

The class shrinks from ~114 lines to 55. Each of the three methods now does `CreateAsyncScope` → `GetRequiredService` → delegate. For the official-posts method, a pre-scope empty-input short-circuit is preserved from #102 so the common empty-follows case skips scope creation entirely:

```csharp
public async Task<IReadOnlyList<OfficialPostResponseDto>> GetOfficialPostsByLocalitiesAsync(
    IEnumerable<Guid> localityIds, CancellationToken ct)
{
    if (localityIds is ICollection<Guid> c && c.Count == 0)
        return Array.Empty<OfficialPostResponseDto>();

    await using var scope = _scopeFactory.CreateAsyncScope();
    var officialPosts = scope.ServiceProvider.GetRequiredService<IOfficialPostsService>();
    return await officialPosts.GetActiveByLocalitiesAsync(localityIds, ct);
}
```

Same shape for `GetActiveByLocalitiesPagedAsync` (delegates to `IClusterRepository`) and `GetAllActivePagedAsync`, minus the short-circuit (those paths' canonical methods don't carry the same pre-scope optimisation and the common home-feed input always has ≥1 locality by the time it reaches those sections).

### Removed from `HomeFeedQueryService`

- Direct EF Core usage (both `ClustersDbContext` and `AdvisoriesDbContext` references, `AsNoTracking` calls, `ToListAsync` calls, all LINQ predicates).
- Private `MapToDto` method.
- Private `EnumToSnakeCase` helper.
- `System.Linq`, `System.Text.RegularExpressions`, `Microsoft.EntityFrameworkCore` imports.
- `Hali.Domain.Entities.Advisories`, `Hali.Infrastructure.Data.Advisories`, `Hali.Infrastructure.Data.Clusters` imports.

The file is now verifiably pure plumbing — ctor, three delegation methods, nothing else.

## Preserved behaviour from #102 — dedup and all

The batched official-posts move is **verbatim** — every invariant #102 established survives:

- **Dedup of multi-scoped posts** — DB-level `.Distinct()` on `OfficialPostId` across followed localities; a post scoped to multiple followed wards returns exactly once. `OfficialUpdates.TotalCount` remains accurate on the new code path.
- **Nullable `LocalityId` guard** — `s.LocalityId != null && ids.Contains(s.LocalityId.Value)` prevents the compile error against a `List<Guid>.Contains(Guid?)` and matches the existing idiom on `GetActiveByLocalitiesPagedAsync`.
- **`AsNoTracking()`** — applied to both the `OfficialPostScopes` probe and the `OfficialPosts` fetch. Home-feed read-path performance posture preserved.
- **Empty-input short-circuit** — `ids.Count == 0` returns empty without hitting the DB. Now enforced **twice**: once at the home-feed service level before scope creation, once at the repo level.
- **Empty-postIds short-circuit** — `postIds.Count == 0` returns empty without issuing the second query with an empty `IN()` set (this was the Copilot-review fix from PR #144).
- **Descending `CreatedAt` ordering** — `OrderByDescending(p => p.CreatedAt)` on the second query.

## Reviewer note on #100 — resolved by deletion, not extraction

The original #100 framing suggested extracting a shared static mapper class so both services could call into it. This PR takes a stricter line: **#100 resolves by deletion, not by introducing a new abstraction.**

After delegation, `HomeFeedQueryService.GetOfficialPostsByLocalitiesAsync` calls into `IOfficialPostsService.GetActiveByLocalitiesAsync`, which returns pre-mapped DTOs. `HomeFeedQueryService` no longer maps anything. Its private `MapToDto` / `EnumToSnakeCase` copies just go away. Only one mapper remains — the original private `MapToDto` in `OfficialPostsService`, where it has always belonged.

No `OfficialPostMapper` shared class was created, because none is needed. Introducing one would add a cross-cutting abstraction for work that naturally consolidates through an existing service seam.

## Out of scope — deliberately not fixed

- **Pre-existing `AsNoTracking()` gap on singular `OfficialPostRepository.GetActiveByLocalityAsync`**. That method (separate from the new batched one) does not use `AsNoTracking()`. Adding it would ripple through every caller of `IOfficialPostsService.GetActiveByLocalityAsync` and their tests. Pre-existing inconsistency, explicitly out of this PR's scope. The NEW batched method has `AsNoTracking()` applied — matching #102's posture.

## What was NOT changed

This PR is internal refactor work — nothing user-visible changes:

- `IHomeFeedQueryService` interface shape is unchanged. No consumer, no mock, no fake needed updating at the interface level.
- Canonical `IClusterRepository` signatures and implementations untouched.
- Existing singular methods on repo and service untouched.
- `HomeController.BuildFullResponseAsync` `Task.WhenAll` pattern untouched.
- `PagedSection<T>` shape, cursor encoding, `TotalCount` semantics untouched.
- No OpenAPI change.
- No mobile consumer change.
- No DI registration change — `HomeFeedQueryService` stays singleton, `IClusterRepository` / `IOfficialPostsService` stay scoped, resolved via `IServiceScopeFactory.CreateAsyncScope()` as before.

## Test updates

Two test files touched:

- `tests/Hali.Tests.Unit/Advisories/OfficialPostsServiceTests.cs` — its `FakeOfficialPostRepo` implements `IOfficialPostRepository`, which gained the new batched member. Added a configurable `ActiveByLocalitiesResult` property + one new unit test `GetActiveByLocalitiesAsync_MapsEntitiesToDtosAndPreservesOrder` that seeds two entities with distinct Type/Category values and asserts DTO count, order preservation, snake_case enum conversion, and straight-through field mapping. Added in the Copilot-review follow-up commit.

`TrackingFeedQueryService` in `HomeFeedConcurrencyTests.cs` is a separate `IHomeFeedQueryService` impl that never depended on the concrete `HomeFeedQueryService` class — untouched. `HomeAnonymousBrowseTests`, `ContractDriftTests`, `HomeObservabilityTests` use `Substitute.For<IHomeFeedQueryService>()` at the interface level — untouched.

## Test coverage — honesty note

The **unit suite** (349/349 after the new test) covers the controller layer via `Substitute.For<IHomeFeedQueryService>()` and covers the delegation-via-fake pattern via `HomeFeedConcurrencyTests`. It does **not** exercise the concrete `HomeFeedQueryService` end-to-end.

The **integration suite** (29/29) covers Auth, Clusters, Errors, Health, Localities, Participation, and Signals — **not** the `/v1/home` controller. No `HomeController` integration test currently exists in `tests/Hali.Tests.Integration/`. This is a **pre-existing coverage gap**, not introduced by this refactor — the end-to-end path through this refactored delegation has not been integration-validated.

What this means for PR #145:

- The refactor is validated at unit-test level (interface mocks) and by `dotnet build` / `swagger-cli validate`.
- Behavioural equivalence with pre-#101 is preserved by construction — the LINQ and mapping code moved verbatim; #102's invariants walk through unchanged.
- The missing integration coverage is tracked as **#146** and is independent work.

Earlier drafts of this PR body overclaimed "integration tests pass end-to-end through the home-feed controller" — that was inaccurate and has been corrected here.

## Validation

| Gate | Result |
|---|---|
| `dotnet format --verify-no-changes` (touched files) | clean |
| `dotnet build` | 0 errors, 132 warnings (identical to baseline) |
| `dotnet test` Unit | **349 / 349 pass** (+1 new test on `OfficialPostsService.GetActiveByLocalitiesAsync`) |
| `dotnet test` Integration | **29 / 29 pass** — does **not** include `/v1/home` coverage; see follow-up #146 |
| `npx swagger-cli validate 02_openapi.yaml` | valid |

## Quality gates

- [x] G1 — build clean, tests green, format clean within scope.
- [x] G2 — no `[ProducesResponseType]` drift; no wire-contract change; no OpenAPI change.
- [x] G3 — no test methods removed; one targeted mapping-preservation test added.
- [x] G4 — no log surface change; no auth surface change; no new security surface.
- [x] G6 — PR description scopes the diff precisely, explicitly calls out the #100 "resolves by deletion" approach, the pre-existing `AsNoTracking` gap left out of scope, and the honest boundaries of integration-test coverage.
- [x] G7 — deferred finding (missing `/v1/home` integration coverage) logged as **#146** before merge.

## Rebase status

Branch based on `origin/develop@77779f7` (PR #144 / #102 merged). Two commits ahead:
- `624eff7` — primary refactor.
- `6a34e18` — Copilot review fixes (pre-scope short-circuit restoration + new unit test).

No rebase needed.
