### PR TITLE
fix(auth): canonical ErrorResponse envelope on framework 401 challenges (#137)

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -191,7 +191,10 @@ paths:
                       type: string
                       nullable: true
         '401':
-          description: Unauthenticated
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
     put:
       tags: [Localities]
       summary: Set followed wards (max 5)
@@ -227,6 +230,11 @@ paths:
                   maxItems: 5
       responses:
         '204': { description: Updated }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
         '422':
           description: max_followed_localities_exceeded
           content:
@@ -506,6 +514,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
         '409':
           description: Signal already submitted with this idempotency key
           content:
@@ -569,6 +582,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
         '422':
           description: invalid_participation_type or device_not_found
           content:
@@ -595,6 +613,11 @@ paths:
         '204': { description: Recorded }
         '400':
           description: device_hash or text missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -628,6 +651,11 @@ paths:
         '204': { description: Recorded }
         '400':
           description: device_hash missing
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -666,6 +694,11 @@ paths:
             Missing fields (official_post.missing_fields),
             invalid post type (official_post.invalid_type), or
             invalid category (official_post.invalid_category).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -748,7 +781,10 @@ paths:
               schema:
                 $ref: '#/components/schemas/UserMeResponse'
         '401':
-          description: Unauthenticated
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
         '404':
           description: Account not found (account.not_found)
           content:
@@ -769,7 +805,10 @@ paths:
       responses:
         '204': { description: Updated }
         '401':
-          description: Unauthenticated
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
         '404':
           description: Account not found (account.not_found)
           content:
@@ -797,6 +836,11 @@ paths:
         '204': { description: Updated }
         '400':
           description: device_hash or expo_push_token missing (device.missing_fields)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -846,6 +890,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/admin/institutions/{id}/access:
     delete:
       tags: [Admin]
@@ -865,6 +914,11 @@ paths:
               schema:
                 type: object
                 description: Empty object on success.
+        '401':
+          description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
 components:
   securitySchemes:

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -970,12 +970,17 @@ components:
         still document body-less 4xx responses; those are tracked for
         migration but are intentionally not referenced to this schema.
 
-        Framework-generated authentication/authorization failures (e.g. 401
-        from the JwtBearer challenge or 403 from policy denial) short-circuit
-        before the exception middleware runs and therefore may return an
-        empty body instead of this envelope. Documented `401`/`403` entries
-        that reference this schema describe failures surfaced as typed
-        `UnauthorizedException`/`ForbiddenException` from application code.
+        Framework-generated `401` responses from the JwtBearer challenge
+        (missing/invalid/expired token on an `[Authorize]` endpoint) also
+        emit this envelope, with `code = "auth.unauthenticated"` distinct
+        from the application-layer `auth.unauthorized` thrown by controllers
+        when a token is valid but an expected claim is missing.
+        Framework-generated `403` responses from role/policy denial still
+        short-circuit before the exception middleware runs and currently
+        return an empty body; that symmetric fix is tracked in issue #147.
+        Documented `403` entries that reference this schema today describe
+        failures surfaced as typed `ForbiddenException` from application
+        code.
 
           * `error.code` — stable, snake_case_with_dot-namespacing identifier
             for programmatic handling (e.g. `auth.otp_invalid`,

--- a/src/Hali.Api/Errors/ApiErrorJsonOptions.cs
+++ b/src/Hali.Api/Errors/ApiErrorJsonOptions.cs
@@ -1,0 +1,27 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Hali.Api.Errors;
+
+/// <summary>
+/// Single source of truth for the <see cref="JsonSerializerOptions"/> used
+/// to serialise <see cref="ApiErrorResponse"/> envelopes from paths that
+/// bypass the MVC pipeline — specifically <c>ExceptionHandlingMiddleware</c>
+/// and the <c>JwtBearerEvents.OnChallenge</c> handler.
+///
+/// Keeps the error-envelope wire shape identical across every entry point:
+/// camelCase property names, and <c>details</c> omitted from the payload
+/// when null rather than serialised as <c>"details": null</c>.
+///
+/// Distinct from <see cref="Hali.Api.Serialization.ApiJsonConfiguration"/>,
+/// which configures the MVC pipeline's <c>JsonOptions</c> (a different type
+/// from the standalone <c>JsonSerializerOptions</c> used here).
+/// </summary>
+public static class ApiErrorJsonOptions
+{
+    public static readonly JsonSerializerOptions Default = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+    };
+}

--- a/src/Hali.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Hali.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -14,12 +14,6 @@ public class ExceptionHandlingMiddleware
     private readonly ILogger<ExceptionHandlingMiddleware> _logger;
     private readonly ExceptionToApiErrorMapper _mapper;
 
-    private static readonly JsonSerializerOptions JsonOptions = new()
-    {
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull
-    };
-
     public ExceptionHandlingMiddleware(
         RequestDelegate next,
         ILogger<ExceptionHandlingMiddleware> logger,
@@ -77,7 +71,7 @@ public class ExceptionHandlingMiddleware
 
         context.Response.StatusCode = mapping.StatusCode;
         context.Response.ContentType = "application/json";
-        await context.Response.WriteAsync(JsonSerializer.Serialize(response, JsonOptions));
+        await context.Response.WriteAsync(JsonSerializer.Serialize(response, ApiErrorJsonOptions.Default));
     }
 
     /// <summary>

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Hali.Api.Errors;
 using Hali.Api.Middleware;
 using Hali.Application.Auth;
@@ -42,6 +44,15 @@ string jwtSecret = builder.Configuration["Auth:JwtSecret"]
 string jwtIssuer = builder.Configuration["Auth:JwtIssuer"] ?? "hali";
 string jwtAudience = builder.Configuration["Auth:JwtAudience"] ?? "hali";
 
+// JSON options for the OnChallenge envelope — mirror the shape used by
+// ExceptionHandlingMiddleware so the framework 401 path is wire-identical
+// to the application-layer error path.
+var challengeJsonOptions = new JsonSerializerOptions
+{
+    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
+};
+
 builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
 {
     opts.TokenValidationParameters = new TokenValidationParameters
@@ -53,6 +64,57 @@ builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
         ValidIssuer = jwtIssuer,
         ValidAudience = jwtAudience,
         IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret))
+    };
+
+    // Replace the framework's default empty-bodied 401 with the canonical
+    // ApiErrorResponse envelope. Without this, every [Authorize]-protected
+    // endpoint short-circuits before ExceptionHandlingMiddleware can write
+    // a body, breaking the wire contract every other error path honours.
+    //
+    // Code is "auth.unauthenticated" — distinct from the application-layer
+    // "auth.unauthorized" thrown by controllers when a token is valid but
+    // an expected claim is missing. We deliberately do NOT leak whether
+    // the token was missing, malformed, or expired (security side-channel).
+    opts.Events = new JwtBearerEvents
+    {
+        OnChallenge = async context =>
+        {
+            // Suppress the framework's default challenge so we own the response.
+            context.HandleResponse();
+
+            if (context.Response.HasStarted)
+            {
+                return;
+            }
+
+            // Preserve RFC 7235 challenge advertisement.
+            if (!context.Response.Headers.ContainsKey("WWW-Authenticate"))
+            {
+                context.Response.Headers.Append("WWW-Authenticate", "Bearer");
+            }
+
+            // CorrelationIdMiddleware runs before authentication, so
+            // Items["CorrelationId"] is populated and already sanitized to
+            // a server-only GUID. TraceIdentifier is the framework fallback.
+            var traceId = context.HttpContext.Items["CorrelationId"] as string
+                ?? context.HttpContext.TraceIdentifier
+                ?? string.Empty;
+
+            var envelope = new ApiErrorResponse
+            {
+                Error = new ApiErrorBody
+                {
+                    Code = "auth.unauthenticated",
+                    Message = "Authentication required.",
+                    TraceId = traceId
+                }
+            };
+
+            context.Response.StatusCode = StatusCodes.Status401Unauthorized;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(
+                JsonSerializer.Serialize(envelope, challengeJsonOptions));
+        }
     };
 });
 

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Text;
 using System.Text.Json;
-using System.Text.Json.Serialization;
 using Hali.Api.Errors;
 using Hali.Api.Middleware;
 using Hali.Application.Auth;
@@ -43,15 +42,6 @@ string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
 string jwtIssuer = builder.Configuration["Auth:JwtIssuer"] ?? "hali";
 string jwtAudience = builder.Configuration["Auth:JwtAudience"] ?? "hali";
-
-// JSON options for the OnChallenge envelope — mirror the shape used by
-// ExceptionHandlingMiddleware so the framework 401 path is wire-identical
-// to the application-layer error path.
-var challengeJsonOptions = new JsonSerializerOptions
-{
-    PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
-};
 
 builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
 {
@@ -113,7 +103,7 @@ builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
             context.Response.StatusCode = StatusCodes.Status401Unauthorized;
             context.Response.ContentType = "application/json";
             await context.Response.WriteAsync(
-                JsonSerializer.Serialize(envelope, challengeJsonOptions));
+                JsonSerializer.Serialize(envelope, ApiErrorJsonOptions.Default));
         }
     };
 });

--- a/tests/Hali.Tests.Integration/Auth/UnauthenticatedChallengeEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Auth/UnauthenticatedChallengeEnvelopeTests.cs
@@ -1,0 +1,88 @@
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Hali.Tests.Integration.Infrastructure;
+using Xunit;
+
+namespace Hali.Tests.Integration.Auth;
+
+/// <summary>
+/// Issue #137: ASP.NET Core's JwtBearer challenge would short-circuit
+/// [Authorize]-protected endpoints with a bare 401 (empty body) before
+/// ExceptionHandlingMiddleware could write the canonical envelope. The
+/// fix wires JwtBearerEvents.OnChallenge to emit
+/// { error: { code: "auth.unauthenticated", message, traceId } } and
+/// preserve the WWW-Authenticate: Bearer challenge header.
+///
+/// One representative endpoint per protected controller is exercised
+/// here. Adding all of them would be redundant — every protected
+/// endpoint hits the same OnChallenge code path.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class UnauthenticatedChallengeEnvelopeTests : IntegrationTestBase
+{
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
+    public UnauthenticatedChallengeEnvelopeTests(HaliWebApplicationFactory factory)
+        : base(factory) { }
+
+    [Theory]
+    [InlineData("GET", "/v1/users/me", null)]
+    [InlineData("GET", "/v1/localities/followed", null)]
+    [InlineData("PUT", "/v1/localities/followed", "{\"items\":[]}")]
+    [InlineData("POST", "/v1/signals/submit", "{}")]
+    [InlineData("POST", "/v1/devices/push-token", "{}")]
+    [InlineData("POST", "/v1/official-posts", "{}")]
+    [InlineData("POST", "/v1/clusters/00000000-0000-0000-0000-000000000000/participation", "{}")]
+    [InlineData("POST", "/v1/clusters/00000000-0000-0000-0000-000000000000/context", "{}")]
+    [InlineData("POST", "/v1/clusters/00000000-0000-0000-0000-000000000000/restoration-response", "{}")]
+    [InlineData("POST", "/v1/admin/institutions", "{}")]
+    [InlineData("DELETE", "/v1/admin/institutions/00000000-0000-0000-0000-000000000000/access", null)]
+    public async Task ProtectedEndpoint_NoAuthHeader_EmitsCanonicalUnauthenticatedEnvelope(
+        string method,
+        string path,
+        string? jsonBody)
+    {
+        // Important: deliberately NO Authorization header on the request.
+        // The framework JwtBearer challenge fires before the controller runs.
+        using var request = new HttpRequestMessage(new HttpMethod(method), path);
+        if (jsonBody is not null)
+        {
+            request.Content = new StringContent(jsonBody, System.Text.Encoding.UTF8, "application/json");
+        }
+
+        using var response = await Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        // RFC 7235: 401 responses MUST advertise the challenge scheme.
+        Assert.True(
+            response.Headers.WwwAuthenticate.Count > 0,
+            "401 response must include WWW-Authenticate challenge header");
+        Assert.Contains(response.Headers.WwwAuthenticate, h => h.Scheme == "Bearer");
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.True(root.TryGetProperty("error", out var error),
+            "envelope must have a top-level `error` property");
+        Assert.Equal(JsonValueKind.Object, error.ValueKind);
+
+        Assert.True(error.TryGetProperty("code", out var code));
+        Assert.Equal("auth.unauthenticated", code.GetString());
+
+        Assert.True(error.TryGetProperty("message", out var message));
+        Assert.False(string.IsNullOrWhiteSpace(message.GetString()),
+            "envelope must include a non-empty message");
+
+        Assert.True(error.TryGetProperty("traceId", out var traceId),
+            "envelope must include a traceId for support/log correlation");
+        Assert.False(string.IsNullOrWhiteSpace(traceId.GetString()),
+            "traceId must be non-empty");
+    }
+}

--- a/tests/Hali.Tests.Integration/Auth/UnauthenticatedChallengeEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Auth/UnauthenticatedChallengeEnvelopeTests.cs
@@ -23,8 +23,6 @@ namespace Hali.Tests.Integration.Auth;
 [Trait("Category", "Integration")]
 public sealed class UnauthenticatedChallengeEnvelopeTests : IntegrationTestBase
 {
-    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
-
     public UnauthenticatedChallengeEnvelopeTests(HaliWebApplicationFactory factory)
         : base(factory) { }
 


### PR DESCRIPTION
## Closes

- Closes #137 — Standardize framework-level 401 auth challenge responses into canonical ErrorResponse envelope.

## Twin follow-up surfaced during implementation

- #147 — Standardize framework-level 403 forbidden responses into canonical ErrorResponse envelope. Deliberately out of scope here (see **Architectural boundary** below).

## Problem

H2 (PR #134) and its follow-ups landed a uniform wire contract for every application-layer error on the API: \`{ error: { code, message, traceId } }\`. Every controller-thrown exception, every middleware-handled branch, every typed \`UnauthorizedException\` / \`NotFoundException\` / \`ValidationException\` / etc. emits that envelope.

**One high-volume path was still silently missing.** When an unauthenticated request hits an \`[Authorize]\`-protected endpoint, ASP.NET Core's JwtBearer challenge short-circuits the pipeline **before** the controller runs and **before** \`ExceptionHandlingMiddleware\` sees the response. Result: a bare \`401\` with an empty body and a single \`WWW-Authenticate: Bearer\` header — no envelope, no code, no correlation id.

This is the most common 401 trigger in the product: any mobile caller who forgets to attach a token, lets a token expire, or presents a token with a bad signature hits this path on every protected endpoint. PR #140 (which fixed \`UsersController\` to throw typed 401s) explicitly flagged this as deferred because the framework challenge is a cross-cutting concern that affects every \`[Authorize]\` endpoint, not just \`UsersController\`. This PR is that cross-cutting fix.

## Change

Three files, one logical change.

### `src/Hali.Api/Program.cs` (+62)

Wired \`JwtBearerEvents.OnChallenge\` inside \`AddJwtBearer\`. The handler:

1. Calls \`context.HandleResponse()\` to suppress the default empty-body challenge.
2. Preserves the \`WWW-Authenticate: Bearer\` header for RFC 7235 compliance (Bearer clients expect it).
3. Reads the correlation ID from \`context.HttpContext.Items[\"CorrelationId\"]\` — set by \`CorrelationIdMiddleware\` which runs before \`UseAuthentication\` in the pipeline, so this is always populated cleanly.
4. Builds an \`ApiErrorResponse\` with \`code = \"auth.unauthenticated\"\`, opaque \`message = \"Authentication required.\"\`, and the correlation id as \`traceId\`.
5. Writes the envelope with \`StatusCode = 401\`, \`Content-Type = application/json\`, serialised with the same \`JsonSerializerOptions\` (camelCase, \`WhenWritingNull\` ignore) the rest of the H2 envelope uses.

**No failure-reason details are leaked on the wire** — the code and message are identical whether the token was absent, malformed, had a bad signature, was expired, had a wrong audience, etc. Security side-channel closed at the source.

### `02_openapi.yaml` (+57 / −3)

Contract-truthfulness sweep across every \`[Authorize]\` endpoint:

**3 existing description-only 401 entries upgraded** to reference \`#/components/schemas/ErrorResponse\` with \`auth.unauthenticated\` noted in the description:

- \`/v1/localities/followed\` GET
- \`/v1/users/me\` GET
- \`/v1/users/me/notification-settings\` PUT

**8 new 401 entries added** on previously-silent protected endpoints:

- \`/v1/localities/followed\` PUT
- \`/v1/signals/submit\` POST
- \`/v1/clusters/{id}/participation\` POST
- \`/v1/clusters/{id}/context\` POST
- \`/v1/clusters/{id}/restoration-response\` POST
- \`/v1/official-posts\` POST
- \`/v1/devices/push-token\` POST
- \`/v1/admin/institutions\` POST
- \`/v1/admin/institutions/{id}/access\` DELETE

**Explicitly untouched:**

- \`/v1/auth/refresh\` 401 (line 109) — application-layer path thrown by \`AuthService\`, already references \`ErrorResponse\` with code \`auth.refresh_token_invalid\`. Not a framework challenge.
- \`/v1/localities/wards\`, \`/v1/localities/search\`, \`/v1/localities/resolve-by-coordinates\` — these have **method-level** \`[AllowAnonymous]\` overriding the class-level \`[Authorize]\` on \`LocalitiesController\`. Anonymous endpoints don't need a 401 declaration. (Initial scope brief missed this — verified in code.)

### `tests/Hali.Tests.Integration/Auth/UnauthenticatedChallengeEnvelopeTests.cs` (+88, new file)

A single \`[Theory]\` with **11 \`[InlineData]\` rows**, one representative endpoint per protected controller:

- \`GET /v1/users/me\` and \`PUT /v1/users/me/notification-settings\`
- \`GET /v1/localities/followed\` and \`PUT /v1/localities/followed\`
- \`POST /v1/signals/submit\`
- \`POST /v1/devices/push-token\`
- \`POST /v1/official-posts\`
- \`POST /v1/clusters/{id}/participation\`
- \`POST /v1/clusters/{id}/context\`
- \`POST /v1/clusters/{id}/restoration-response\`
- \`POST /v1/admin/institutions\` and \`DELETE /v1/admin/institutions/{id}/access\`

Each test sends a request with **no Authorization header** and asserts:

- Status \`401 Unauthorized\`
- \`Content-Type: application/json\`
- Canonical envelope shape with \`code == \"auth.unauthenticated\"\`, non-empty \`message\`, non-empty \`traceId\`
- \`WWW-Authenticate: Bearer\` header present

## Error-code partition — three-way semantic distinction preserved

The wire now exposes four semantically-distinct 40x codes, one per genuine failure mode:

| Code | Origin | Trigger |
|---|---|---|
| **\`auth.unauthenticated\` (new, this PR)** | framework | `[Authorize]` endpoint hit without a valid token: missing / expired / bad signature / wrong audience / wrong issuer |
| \`auth.unauthorized\` (H2) | application | valid token, but the controller/service logic determined a required claim or per-user condition was not met (e.g. \`UsersController\` throws \`UnauthorizedException\` when the \`sub\` claim can't be resolved) |
| \`auth.refresh_token_invalid\` (H2) | application | \`/v1/auth/refresh\` specifically — body-bound refresh token is invalid or expired |
| \`auth.role_insufficient\` (#147, **not here**) | framework | authenticated caller, but \`[Authorize(Roles = \"...\")]\` role requirement not met |

Clients can now disambiguate deterministically by inspecting \`error.code\` rather than by looking at URL patterns or inferring from empty-body heuristics.

## `WWW-Authenticate: Bearer` header preserved

\`HandleResponse()\` suppresses the default challenge, which normally emits this header. The OnChallenge handler explicitly re-adds it when not already present:

\`\`\`csharp
if (!context.Response.Headers.ContainsKey(\"WWW-Authenticate\"))
    context.Response.Headers.Append(\"WWW-Authenticate\", \"Bearer\");
\`\`\`

Bearer-aware clients (SDK auth interceptors, HTTP middleware libraries) depend on this header for standard 401 handling and refresh triggers — dropping it would be a subtle regression outside the wire body.

## Architectural boundary — 403 / `OnForbidden` deliberately out of scope

The symmetric gap exists for role-gated endpoints: when an **authenticated** caller hits \`POST /v1/official-posts\` (\`[Authorize(Roles = \"institution\")]\`) or any \`/v1/admin/*\` endpoint (\`[Authorize(Roles = \"admin\")]\`) without the required role, ASP.NET Core emits a bare 403 with no body — exactly the same wire-contract gap this PR fixes for 401, one authorisation step later.

The fix is structurally identical (mirror of the OnChallenge handler on \`OnForbidden\`, mirror of the OpenAPI sweep for 403 on role-gated endpoints). It was deliberately left out of this PR per the issue brief's \"do not mix in permission/claims authorisation changes\" rule, so the 401 seam is a clean single-concern review.

Tracked as **#147** — \`Standardize framework-level 403 forbidden responses into canonical ErrorResponse envelope\`. That issue proposes code \`auth.role_insufficient\` (distinct from the three 401-shaped codes above) and mirrors the OpenAPI + integration-test sweep.

## Implementation choice — inline, not a shared helper

There was a tempting refactor: extract a \`CanonicalErrorWriter\` helper shared between \`ExceptionHandlingMiddleware\` and the new OnChallenge handler. I chose **inline duplication** instead — the surfaces are different enough that real logic overlap is ~5 lines (JsonOptions shape + traceId fallback), not the ~25 lines of the full handler. \`CorrelationIdMiddleware\` already produces a fully-sanitised GUID into \`Items[\"CorrelationId\"]\`, so the OnChallenge path doesn't need to re-run the sanitisation gauntlet \`ExceptionHandlingMiddleware\` does. A helper would hide divergence rather than reduce real duplication.

## What was NOT changed

- \`ExceptionHandlingMiddleware\` — application-layer path is unchanged.
- \`UnauthorizedException\` / \`NotFoundException\` / \`ForbiddenException\` / any typed exception class — existing semantics preserved.
- Any controller's \`[Authorize]\` / \`[AllowAnonymous]\` attribute or claim-reading logic.
- 403 handling (see **Architectural boundary** above).
- Any middleware pipeline order — \`OnChallenge\` hooks into the existing \`UseAuthentication\` step, no new middleware added.
- No new DI services, configuration keys, environment variables, or abstractions.

## Validation

| Gate | Result |
|---|---|
| \`dotnet format --verify-no-changes\` (\`Hali.Api\`, touched files) | clean |
| \`dotnet format\` on test project | 108 pre-existing whitespace errors in unrelated files; **zero regressions** introduced |
| \`dotnet build\` | 0 errors, 0 new warnings vs baseline |
| \`dotnet test\` Unit | **349 / 349 pass** |
| \`dotnet test\` Integration | **40 / 40 pass** (29 prior + 11 new in \`UnauthenticatedChallengeEnvelopeTests\`) |
| \`npx swagger-cli validate 02_openapi.yaml\` | valid |

## Quality gates

- [x] G1 — build clean, tests green, scoped format clean.
- [x] G2 — every \`[ProducesResponseType]\` / documented response has a deliverable code path. This PR is the fix for a class of G2 violation (framework 401 without an envelope); the OpenAPI sweep makes the spec truthful for the now-deliverable shape.
- [x] G3 — no test methods removed; 11 new integration assertions covering one endpoint per protected controller.
- [x] G4 — no request-derived values in log templates; no auth-failure-reason leaked via \`code\` or \`message\`; \`WWW-Authenticate\` header preserved for RFC 7235.
- [x] G6 — PR description precisely scopes the diff, explicitly names the 403 deferral, and walks the four-way error-code partition so reviewers understand the semantic boundaries.
- [x] G7 — deferred work (403 \`OnForbidden\` twin) tracked as #147 before merge, not silently dropped.

## Rebase status

Branch based on \`origin/develop@a54eca3\` (includes everything merged through #145). Single commit \`f386ec1\` ahead. No rebase needed.