### PR TITLE
fix(participation): restoration write-path mapping + atomic count snapshot (#142, #143)

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -1246,11 +1246,7 @@ components:
             Total count of restoration responses on this cluster (participation
             types restoration_yes + restoration_no + restoration_unsure).
             Populated only when state == possible_restoration. Aggregate count
-            only. Note: the current HTTP write path records `still_affected`
-            responses as `affected` rather than `restoration_no`, so those
-            responses do not presently contribute to this count. Tracked in
-            issue #142 — resolving it does not change the wire shape here,
-            only the data that populates it.
+            only.
     MyParticipation:
       type: object
       description: |

--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -80,29 +80,21 @@ public class ClustersController : ControllerBase
         }
 
         // Restoration progress snapshot — aggregate counts only, populated
-        // exclusively when the cluster is in possible_restoration. This is a
-        // pure read: we derive the ratio from two repo counts directly rather
-        // than invoking EvaluateRestorationAsync (which mutates state and
-        // emits outbox events — unsafe on a GET path).
+        // exclusively when the cluster is in possible_restoration. Pure read:
+        // we derive the ratio from a single atomic snapshot rather than
+        // invoking EvaluateRestorationAsync (which mutates state and emits
+        // outbox events — unsafe on a GET path). The snapshot guarantees
+        // yesVotes <= totalResponses by construction (#143).
         int? restorationYesVotes = null;
         int? restorationTotalVotes = null;
         double? restorationRatio = null;
         if (cluster.State == SignalState.PossibleRestoration)
         {
-            int yesVotes = await _participationRepo.CountByTypeAsync(id, ParticipationType.RestorationYes, ct);
-            int totalResponses = await _participationRepo.CountRestorationResponsesAsync(id, ct);
-            // Defensive clamp. Participations are not strictly append-only —
-            // RecordParticipationAsync deletes a device's prior row before
-            // inserting a new one. If a RestorationYes row is deleted between
-            // these two sequential reads, yesVotes (read first) can exceed
-            // totalResponses (read second), and the ratio can exceed 1. Clamp
-            // so the wire contract (yes <= total, ratio in [0, 1]) always
-            // holds. The proper atomic-read fix is tracked in issue #143.
-            if (yesVotes > totalResponses) yesVotes = totalResponses;
-            restorationYesVotes = yesVotes;
-            restorationTotalVotes = totalResponses;
-            restorationRatio = totalResponses > 0
-                ? (double)yesVotes / totalResponses
+            RestorationCountSnapshot snapshot = await _participationRepo.GetRestorationCountSnapshotAsync(id, ct);
+            restorationYesVotes = snapshot.YesVotes;
+            restorationTotalVotes = snapshot.TotalResponses;
+            restorationRatio = snapshot.TotalResponses > 0
+                ? (double)snapshot.YesVotes / snapshot.TotalResponses
                 : (double?)null;
         }
 

--- a/src/Hali.Application/Participation/IParticipationRepository.cs
+++ b/src/Hali.Application/Participation/IParticipationRepository.cs
@@ -7,6 +7,16 @@ using Hali.Domain.Enums;
 
 namespace Hali.Application.Participation;
 
+/// <summary>
+/// Atomic point-in-time snapshot of restoration vote counts for a cluster.
+/// Computed in a single database read so callers can rely on the invariants
+/// <c>YesVotes + NoVotes &lt;= TotalResponses</c> and (when <c>TotalResponses &gt; 0</c>)
+/// <c>YesVotes / TotalResponses ∈ [0, 1]</c>. <c>TotalResponses</c> is the sum
+/// of all rows whose <see cref="ParticipationType"/> is one of
+/// <c>RestorationYes</c>, <c>RestorationNo</c>, or <c>RestorationUnsure</c>.
+/// </summary>
+public sealed record RestorationCountSnapshot(int YesVotes, int NoVotes, int TotalResponses);
+
 public interface IParticipationRepository
 {
 	Task<Hali.Domain.Entities.Participation.Participation?> GetByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct);
@@ -26,7 +36,14 @@ public interface IParticipationRepository
 
 	Task<int> CountByTypeAsync(Guid clusterId, ParticipationType type, CancellationToken ct);
 
-	Task<int> CountRestorationResponsesAsync(Guid clusterId, CancellationToken ct);
+	/// <summary>
+	/// Returns an atomic snapshot of restoration vote counts for the given
+	/// cluster: <c>YesVotes</c>, <c>NoVotes</c>, and <c>TotalResponses</c>
+	/// (yes + no + unsure). Computed as a single database read so that
+	/// concurrent participation-type flips cannot produce
+	/// <c>YesVotes &gt; TotalResponses</c> or a ratio outside <c>[0, 1]</c>.
+	/// </summary>
+	Task<RestorationCountSnapshot> GetRestorationCountSnapshotAsync(Guid clusterId, CancellationToken ct);
 
 	/// <summary>Returns account IDs of all users with an active affected participation on this cluster.</summary>
 	Task<IReadOnlyList<Guid>> GetAffectedAccountIdsAsync(Guid clusterId, CancellationToken ct);

--- a/src/Hali.Application/Participation/ParticipationService.cs
+++ b/src/Hali.Application/Participation/ParticipationService.cs
@@ -81,7 +81,7 @@ public class ParticipationService : IParticipationService
         ParticipationType participationType = response switch
         {
             "restored" => ParticipationType.RestorationYes,
-            "still_affected" => ParticipationType.Affected,
+            "still_affected" => ParticipationType.RestorationNo,
             "not_sure" => ParticipationType.RestorationUnsure,
             _ => throw new ValidationException("Invalid restoration response value.", code: "validation.invalid_restoration_response"),
         };
@@ -96,8 +96,12 @@ public class ParticipationService : IParticipationService
         {
             return;
         }
-        int restorationYes = await _participationRepo.CountByTypeAsync(clusterId, ParticipationType.RestorationYes, ct);
-        int totalResponses = await _participationRepo.CountRestorationResponsesAsync(clusterId, ct);
+        // Atomic single-query snapshot — see issue #143. Two-query pattern
+        // (CountByType(RestorationYes) + CountRestorationResponses) could see
+        // an inconsistent yes/total under concurrent participation-type flips.
+        RestorationCountSnapshot snapshot = await _participationRepo.GetRestorationCountSnapshotAsync(clusterId, ct);
+        int restorationYes = snapshot.YesVotes;
+        int totalResponses = snapshot.TotalResponses;
         if (totalResponses >= _options.MinRestorationAffectedVotes)
         {
             double ratio = (double)restorationYes / (double)totalResponses;

--- a/src/Hali.Contracts/Clusters/ClusterResponseDto.cs
+++ b/src/Hali.Contracts/Clusters/ClusterResponseDto.cs
@@ -59,14 +59,6 @@ public record ClusterResponseDto(
     /// <c>restoration_unsure</c>). Populated only when <see cref="State"/> is
     /// <c>possible_restoration</c>. Aggregate count only.
     /// </summary>
-    /// <remarks>
-    /// Observable today: the HTTP write path records <c>still_affected</c>
-    /// restoration responses as <c>ParticipationType.Affected</c> rather
-    /// than <c>RestorationNo</c>, so those responses do not currently
-    /// contribute to this count. Tracked in issue #142; when that write-path
-    /// mapping is fixed, `RestorationNo` rows will start appearing and this
-    /// count will include them automatically with no wire-shape change.
-    /// </remarks>
     public int? RestorationTotalVotes { get; init; }
 }
 

--- a/src/Hali.Infrastructure/Participation/ParticipationRepository.cs
+++ b/src/Hali.Infrastructure/Participation/ParticipationRepository.cs
@@ -67,9 +67,24 @@ public class ParticipationRepository : IParticipationRepository
 		return _db.Participations.CountAsync((Hali.Domain.Entities.Participation.Participation p) => p.ClusterId == clusterId && (int)p.ParticipationType == (int)type, ct);
 	}
 
-	public Task<int> CountRestorationResponsesAsync(Guid clusterId, CancellationToken ct)
+	public async Task<RestorationCountSnapshot> GetRestorationCountSnapshotAsync(Guid clusterId, CancellationToken ct)
 	{
-		return _db.Participations.CountAsync((Hali.Domain.Entities.Participation.Participation p) => p.ClusterId == clusterId && ((int)p.ParticipationType == 3 || (int)p.ParticipationType == 4 || (int)p.ParticipationType == 5), ct);
+		// Single EF query: GroupBy + conditional Count over the cluster's
+		// participation rows. Replaces the prior two-query pattern
+		// (CountByType(RestorationYes) followed by CountRestorationResponses)
+		// which exposed a race where a concurrent participation-type flip
+		// could produce yesVotes > totalResponses or a ratio > 1. See #143.
+		RestorationCountSnapshot? snapshot = await _db.Participations
+			.Where(p => p.ClusterId == clusterId)
+			.GroupBy(_ => 1)
+			.Select(g => new RestorationCountSnapshot(
+				g.Count(p => p.ParticipationType == ParticipationType.RestorationYes),
+				g.Count(p => p.ParticipationType == ParticipationType.RestorationNo),
+				g.Count(p => p.ParticipationType == ParticipationType.RestorationYes
+					|| p.ParticipationType == ParticipationType.RestorationNo
+					|| p.ParticipationType == ParticipationType.RestorationUnsure)))
+			.FirstOrDefaultAsync(ct);
+		return snapshot ?? new RestorationCountSnapshot(0, 0, 0);
 	}
 
 	public async Task<IReadOnlyList<Guid>> GetAffectedAccountIdsAsync(Guid clusterId, CancellationToken ct)

--- a/src/Hali.Workers/EvaluatePossibleRestorationJob.cs
+++ b/src/Hali.Workers/EvaluatePossibleRestorationJob.cs
@@ -72,9 +72,17 @@ public sealed class EvaluatePossibleRestorationJob(
         CivisOptions options,
         CancellationToken ct)
     {
-        int restorationYes = await participationRepo.CountByTypeAsync(cluster.Id, ParticipationType.RestorationYes, ct);
-        int stillAffected = await participationRepo.CountByTypeAsync(cluster.Id, ParticipationType.Affected, ct);
-        int totalRestorationResponses = await participationRepo.CountRestorationResponsesAsync(cluster.Id, ct);
+        // Atomic snapshot of restoration vote counts (#143). "Still affected"
+        // votes are restoration_no rows: the HTTP write path maps the
+        // "still_affected" response value to ParticipationType.RestorationNo
+        // (see ParticipationService.RecordRestorationResponseAsync, fixed in
+        // #142). The previous Affected-row count conflated initial "I'm
+        // affected" reports with restoration-time dissents and is no longer
+        // the correct signal for revert-to-active.
+        RestorationCountSnapshot snapshot = await participationRepo.GetRestorationCountSnapshotAsync(cluster.Id, ct);
+        int restorationYes = snapshot.YesVotes;
+        int stillAffected = snapshot.NoVotes;
+        int totalRestorationResponses = snapshot.TotalResponses;
 
         // Revert to active if still-affected votes overwhelm restoration votes
         if (stillAffected > restorationYes && stillAffected >= options.MinRestorationAffectedVotes)

--- a/tests/Hali.Tests.Integration/Clusters/ClusterIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Clusters/ClusterIntegrationTests.cs
@@ -111,26 +111,20 @@ public sealed class ClusterIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task GetCluster_PossibleRestoration_ExposesRestorationProgressFields()
     {
-        // Seed a cluster in possible_restoration with a participation mix
-        // that mirrors what the HTTP write path actually produces today:
+        // Seed a cluster in possible_restoration with the participation mix
+        // the HTTP write path produces post-#142:
         //   "restored"       -> ParticipationType.RestorationYes
-        //   "still_affected" -> ParticipationType.Affected  (NOT counted in
-        //                       restoration totals — see issue #142)
+        //   "still_affected" -> ParticipationType.RestorationNo
         //   "not_sure"       -> ParticipationType.RestorationUnsure
         //
-        // Expected counts:
-        //   yesVotes   = 2 (two RestorationYes rows)
-        //   totalVotes = 3 (two yes + one unsure; the Affected row is excluded
-        //                   by CountRestorationResponsesAsync, which only
-        //                   counts types restoration_yes/no/unsure)
-        //   ratio      = 2 / 3
-        //
-        // This simultaneously verifies the happy path and the "still_affected
-        // is not counted" contract documented on RestorationTotalVotes.
+        // Expected counts (atomic snapshot, #143):
+        //   yesVotes   = 2
+        //   totalVotes = 4 (yes + no + unsure)
+        //   ratio      = 2 / 4 = 0.5
         var clusterId = await SeedClusterInStateAsync("possible_restoration");
         await SeedParticipationAsync(clusterId, "restoration_yes");
         await SeedParticipationAsync(clusterId, "restoration_yes");
-        await SeedParticipationAsync(clusterId, "affected");        // still_affected
+        await SeedParticipationAsync(clusterId, "restoration_no");
         await SeedParticipationAsync(clusterId, "restoration_unsure");
 
         var resp = await Client.GetAsync($"/v1/clusters/{clusterId}");
@@ -139,8 +133,8 @@ public sealed class ClusterIntegrationTests : IntegrationTestBase
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal("possible_restoration", body.GetProperty("state").GetString());
         Assert.Equal(2, body.GetProperty("restorationYesVotes").GetInt32());
-        Assert.Equal(3, body.GetProperty("restorationTotalVotes").GetInt32());
-        Assert.Equal(2.0 / 3.0, body.GetProperty("restorationRatio").GetDouble(), 6);
+        Assert.Equal(4, body.GetProperty("restorationTotalVotes").GetInt32());
+        Assert.Equal(0.5, body.GetProperty("restorationRatio").GetDouble(), 6);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Advisories/EvaluatePossibleRestorationJobTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/EvaluatePossibleRestorationJobTests.cs
@@ -80,15 +80,12 @@ public class EvaluatePossibleRestorationJobTests
             return Task.FromResult(count);
         }
 
-        public Task<int> CountRestorationResponsesAsync(Guid clusterId, CancellationToken ct)
+        public Task<RestorationCountSnapshot> GetRestorationCountSnapshotAsync(Guid clusterId, CancellationToken ct)
         {
-            int total = 0;
-            foreach (var type in new[] { ParticipationType.RestorationYes, ParticipationType.RestorationNo, ParticipationType.RestorationUnsure })
-            {
-                _counts.TryGetValue((clusterId, type), out var c);
-                total += c;
-            }
-            return Task.FromResult(total);
+            _counts.TryGetValue((clusterId, ParticipationType.RestorationYes), out var yes);
+            _counts.TryGetValue((clusterId, ParticipationType.RestorationNo), out var no);
+            _counts.TryGetValue((clusterId, ParticipationType.RestorationUnsure), out var unsure);
+            return Task.FromResult(new RestorationCountSnapshot(yes, no, yes + no + unsure));
         }
 
         public Task<ParticipationEntity?> GetByDeviceAsync(Guid c, Guid d, CancellationToken ct) => Task.FromResult<ParticipationEntity?>(null);
@@ -115,9 +112,12 @@ public class EvaluatePossibleRestorationJobTests
         CivisOptions options)
     {
         var ct = CancellationToken.None;
-        int restorationYes = await participRepo.CountByTypeAsync(cluster.Id, ParticipationType.RestorationYes, ct);
-        int stillAffected = await participRepo.CountByTypeAsync(cluster.Id, ParticipationType.Affected, ct);
-        int totalRestorationResponses = await participRepo.CountRestorationResponsesAsync(cluster.Id, ct);
+        // Mirror the production path: single atomic snapshot, "still affected"
+        // votes are RestorationNo rows (#142 + #143).
+        RestorationCountSnapshot snapshot = await participRepo.GetRestorationCountSnapshotAsync(cluster.Id, ct);
+        int restorationYes = snapshot.YesVotes;
+        int stillAffected = snapshot.NoVotes;
+        int totalRestorationResponses = snapshot.TotalResponses;
 
         if (stillAffected > restorationYes && stillAffected >= options.MinRestorationAffectedVotes)
         {
@@ -180,7 +180,10 @@ public class EvaluatePossibleRestorationJobTests
         var counts = new Dictionary<(Guid, ParticipationType), int>
         {
             { (clusterId, ParticipationType.RestorationYes), 1 },
-            { (clusterId, ParticipationType.Affected), 3 }  // 3 still-affected > 1 yes
+            // 3 still-affected restoration votes — recorded as RestorationNo
+            // by the write path post-#142, counted as snapshot.NoVotes by
+            // the worker post-#143.
+            { (clusterId, ParticipationType.RestorationNo), 3 }
         };
 
         var clusterRepo = new FakeClusterRepo(new[] { cluster });
@@ -245,12 +248,13 @@ public class EvaluatePossibleRestorationJobTests
             LastSeenAt = DateTime.UtcNow
         };
 
-        // 2 yes out of 5 total = 0.40 < 0.60
+        // 2 yes out of 5 total = 0.40 < 0.60. Dissent is RestorationUnsure
+        // so the revert-to-active path (which now keys off RestorationNo
+        // post-#142/#143) is not exercised by this ratio-only test.
         var counts = new Dictionary<(Guid, ParticipationType), int>
         {
             { (clusterId, ParticipationType.RestorationYes), 2 },
-            { (clusterId, ParticipationType.RestorationNo), 3 },
-            { (clusterId, ParticipationType.Affected), 0 }
+            { (clusterId, ParticipationType.RestorationUnsure), 3 }
         };
 
         var clusterRepo = new FakeClusterRepo(new[] { cluster });
@@ -278,11 +282,12 @@ public class EvaluatePossibleRestorationJobTests
             LastSeenAt = DateTime.UtcNow
         };
 
-        // 1 still-affected, but min is 2 — should not revert
+        // 1 still-affected (RestorationNo) restoration vote, but min is 2
+        // — should not revert.
         var counts = new Dictionary<(Guid, ParticipationType), int>
         {
             { (clusterId, ParticipationType.RestorationYes), 0 },
-            { (clusterId, ParticipationType.Affected), 1 }  // < MinRestorationAffectedVotes
+            { (clusterId, ParticipationType.RestorationNo), 1 }  // < MinRestorationAffectedVotes
         };
 
         var clusterRepo = new FakeClusterRepo(new[] { cluster });

--- a/tests/Hali.Tests.Unit/Advisories/RestorationEvaluationTests.cs
+++ b/tests/Hali.Tests.Unit/Advisories/RestorationEvaluationTests.cs
@@ -77,11 +77,13 @@ public class RestorationEvaluationTests
         public Task<int> CountByTypeAsync(Guid clusterId, ParticipationType type, CancellationToken ct)
             => Task.FromResult(_store.FindAll(x => x.ClusterId == clusterId && x.ParticipationType == type).Count);
 
-        public Task<int> CountRestorationResponsesAsync(Guid clusterId, CancellationToken ct)
-            => Task.FromResult(_store.FindAll(x => x.ClusterId == clusterId &&
-                (x.ParticipationType == ParticipationType.RestorationYes ||
-                 x.ParticipationType == ParticipationType.RestorationNo ||
-                 x.ParticipationType == ParticipationType.RestorationUnsure)).Count);
+        public Task<RestorationCountSnapshot> GetRestorationCountSnapshotAsync(Guid clusterId, CancellationToken ct)
+        {
+            int yes = _store.Count(x => x.ClusterId == clusterId && x.ParticipationType == ParticipationType.RestorationYes);
+            int no = _store.Count(x => x.ClusterId == clusterId && x.ParticipationType == ParticipationType.RestorationNo);
+            int unsure = _store.Count(x => x.ClusterId == clusterId && x.ParticipationType == ParticipationType.RestorationUnsure);
+            return Task.FromResult(new RestorationCountSnapshot(yes, no, yes + no + unsure));
+        }
 
         public Task<IReadOnlyList<Guid>> GetAffectedAccountIdsAsync(Guid clusterId, CancellationToken ct)
             => Task.FromResult((IReadOnlyList<Guid>)Array.Empty<Guid>());
@@ -100,8 +102,10 @@ public class RestorationEvaluationTests
         Id = id ?? Guid.NewGuid(),
         State = SignalState.Active,
         Category = CivicCategory.Roads,
-        CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow,
-        FirstSeenAt = DateTime.UtcNow, LastSeenAt = DateTime.UtcNow
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+        FirstSeenAt = DateTime.UtcNow,
+        LastSeenAt = DateTime.UtcNow
     };
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs
+++ b/tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs
@@ -60,9 +60,12 @@ internal sealed class FakeParticipationRepo : IParticipationRepository
 		return Task.FromResult(_store.Count((Hali.Domain.Entities.Participation.Participation x) => x.ClusterId == clusterId && x.ParticipationType == type));
 	}
 
-	public Task<int> CountRestorationResponsesAsync(Guid clusterId, CancellationToken ct)
+	public Task<RestorationCountSnapshot> GetRestorationCountSnapshotAsync(Guid clusterId, CancellationToken ct)
 	{
-		return Task.FromResult(_store.Count((Hali.Domain.Entities.Participation.Participation x) => x.ClusterId == clusterId && (x.ParticipationType == ParticipationType.RestorationYes || x.ParticipationType == ParticipationType.RestorationNo || x.ParticipationType == ParticipationType.RestorationUnsure)));
+		int yes = _store.Count((Hali.Domain.Entities.Participation.Participation x) => x.ClusterId == clusterId && x.ParticipationType == ParticipationType.RestorationYes);
+		int no = _store.Count((Hali.Domain.Entities.Participation.Participation x) => x.ClusterId == clusterId && x.ParticipationType == ParticipationType.RestorationNo);
+		int unsure = _store.Count((Hali.Domain.Entities.Participation.Participation x) => x.ClusterId == clusterId && x.ParticipationType == ParticipationType.RestorationUnsure);
+		return Task.FromResult(new RestorationCountSnapshot(yes, no, yes + no + unsure));
 	}
 
 	public Task<IReadOnlyList<Guid>> GetAffectedAccountIdsAsync(Guid clusterId, CancellationToken ct)

--- a/tests/Hali.Tests.Unit/Participation/ParticipationServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Participation/ParticipationServiceTests.cs
@@ -171,14 +171,57 @@ public class ParticipationServiceTests
 	}
 
 	[Fact]
-	public async Task RecordRestorationResponse_StillAffected_MapsToAffected()
+	public async Task RecordRestorationResponse_StillAffected_MapsToRestorationNo()
 	{
+		// Issue #142: the write path used to record "still_affected" as
+		// ParticipationType.Affected, which excluded it from restoration
+		// totals (CountRestorationResponses only counted types 3/4/5).
+		// Post-fix it must be persisted as RestorationNo so dissenting
+		// votes are visible to the restoration ratio gate.
 		SignalCluster cluster = ActiveCluster();
 		var (svc, pRepo, _) = Build(cluster);
 		await SeedAffectedAsync(svc, DeviceA);
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "still_affected", default(CancellationToken));
 		Hali.Domain.Entities.Participation.Participation p = pRepo.All.Single((Hali.Domain.Entities.Participation.Participation x) => x.DeviceId == DeviceA);
-		Assert.Equal(ParticipationType.Affected, p.ParticipationType);
+		Assert.Equal(ParticipationType.RestorationNo, p.ParticipationType);
+	}
+
+	[Fact]
+	public async Task RecordRestorationResponse_StillAffected_DropsAffectedRowAndDecrementsAffectedCount()
+	{
+		// Confirms the corrected mapping flows through RefreshCountsAsync:
+		// the seeded Affected row is replaced by a RestorationNo row, so
+		// the cluster's AffectedCount falls back to 0. This documents the
+		// AffectedCount semantic shift called out in #142's acceptance
+		// criteria — Affected counts no longer include silent
+		// "still_affected" restoration dissents.
+		SignalCluster cluster = ActiveCluster();
+		var (svc, pRepo, _) = Build(cluster);
+		await SeedAffectedAsync(svc, DeviceA);
+		Assert.Equal(1, cluster.AffectedCount);
+		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "still_affected", default(CancellationToken));
+		Assert.Equal(0, cluster.AffectedCount);
+		Assert.DoesNotContain(pRepo.All, x => x.DeviceId == DeviceA && x.ParticipationType == ParticipationType.Affected);
+	}
+
+	[Fact]
+	public async Task EvaluateRestoration_IncludesStillAffectedDissentInTotal()
+	{
+		// Regression for #142: when one device votes "restored" and another
+		// votes "still_affected", the ratio must be 1/2 (not 1/1). Pre-fix
+		// the still_affected row was Affected and excluded from the total,
+		// flipping the cluster to possible_restoration on a fully dissented
+		// vote.
+		SignalCluster cluster = ActiveCluster();
+		var (svc, _, cRepo) = Build(cluster);
+		await SeedAffectedAsync(svc, DeviceA);
+		await SeedAffectedAsync(svc, DeviceB);
+		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default);
+		await svc.RecordRestorationResponseAsync(ClusterId, DeviceB, null, "still_affected", default);
+		// 1 yes / 2 total = 0.5 < RestorationRatio (0.6) → cluster must
+		// remain Active and no possible_restoration decision must be written.
+		Assert.Equal(SignalState.Active, cluster.State);
+		Assert.Empty(cRepo.Decisions);
 	}
 
 	[Fact]
@@ -238,5 +281,53 @@ public class ParticipationServiceTests
 		await svc.RecordRestorationResponseAsync(ClusterId, DeviceA, null, "restored", default(CancellationToken));
 		Assert.Equal(SignalState.Active, cluster.State);
 		Assert.Empty(cRepo.Decisions);
+	}
+
+	[Fact]
+	public async Task GetRestorationCountSnapshot_ReturnsYesNoTotalConsistently()
+	{
+		// Direct contract test for the new repository surface: yes + no +
+		// unsure must equal total, and yes must never exceed total. This
+		// covers #143's atomic-snapshot invariant at the repo boundary so
+		// any future implementation (real EF or fake) can be checked
+		// against the same shape.
+		var pRepo = new FakeParticipationRepo();
+		var clusterId = ClusterId;
+
+		Hali.Domain.Entities.Participation.Participation Make(ParticipationType t, Guid device) => new()
+		{
+			Id = Guid.NewGuid(),
+			ClusterId = clusterId,
+			DeviceId = device,
+			ParticipationType = t,
+			CreatedAt = DateTime.UtcNow
+		};
+
+		// 3 yes, 2 no, 1 unsure, plus 1 unrelated Affected row that must not
+		// be included in the totals.
+		await pRepo.AddAsync(Make(ParticipationType.RestorationYes, Guid.NewGuid()), default);
+		await pRepo.AddAsync(Make(ParticipationType.RestorationYes, Guid.NewGuid()), default);
+		await pRepo.AddAsync(Make(ParticipationType.RestorationYes, Guid.NewGuid()), default);
+		await pRepo.AddAsync(Make(ParticipationType.RestorationNo, Guid.NewGuid()), default);
+		await pRepo.AddAsync(Make(ParticipationType.RestorationNo, Guid.NewGuid()), default);
+		await pRepo.AddAsync(Make(ParticipationType.RestorationUnsure, Guid.NewGuid()), default);
+		await pRepo.AddAsync(Make(ParticipationType.Affected, Guid.NewGuid()), default);
+
+		RestorationCountSnapshot snapshot = await pRepo.GetRestorationCountSnapshotAsync(clusterId, default);
+
+		Assert.Equal(3, snapshot.YesVotes);
+		Assert.Equal(2, snapshot.NoVotes);
+		Assert.Equal(6, snapshot.TotalResponses);
+		Assert.True(snapshot.YesVotes <= snapshot.TotalResponses);
+	}
+
+	[Fact]
+	public async Task GetRestorationCountSnapshot_NoRestorationVotes_ReturnsZeros()
+	{
+		var pRepo = new FakeParticipationRepo();
+		RestorationCountSnapshot snapshot = await pRepo.GetRestorationCountSnapshotAsync(ClusterId, default);
+		Assert.Equal(0, snapshot.YesVotes);
+		Assert.Equal(0, snapshot.NoVotes);
+		Assert.Equal(0, snapshot.TotalResponses);
 	}
 }


### PR DESCRIPTION
## Summary

Bundled fix for two restoration-correctness issues that share a hot
code path. Splitting them would have required the worker-semantics
shift in #142 to live in one PR and the snapshot it relies on in
another — net more churn for less clarity.

| Issue | Was | Is |
|---|---|---|
| #142 | `still_affected` recorded as `ParticipationType.Affected` and silently excluded from `restorationTotalVotes`/`restorationRatio` — a fully-dissented vote could flip the cluster to `possible_restoration` | `still_affected` → `RestorationNo`; dissent counted in totals; ratio reflects reality |
| #143 | Two-query pattern (`CountByType(RestorationYes)` + `CountRestorationResponses`) could observe a participation-type flip mid-read and surface `yes > total` / `ratio > 1` | Single atomic snapshot (`GetRestorationCountSnapshotAsync` → `RestorationCountSnapshot(YesVotes, NoVotes, TotalResponses)`) used at all three call sites |

### Why bundled

The worker's revert-to-active path currently keys off
`CountByType(Affected)` to mean "still-affected restoration dissents".
Once #142 lands in isolation, that count drops to zero (because
"still affected" no longer writes `Affected` rows) — so the worker
needs to read `RestorationNo` instead. The cleanest place to source
that count is the new snapshot from #143. Doing them together avoids
shipping a half-broken worker between PRs.

## Behavior changes

**Write path** (`ParticipationService.RecordRestorationResponseAsync`):
- `restored` → `RestorationYes`  *(unchanged)*
- `still_affected` → **`RestorationNo`** *(was `Affected`)*
- `not_sure` → `RestorationUnsure`  *(unchanged)*

A device responding `still_affected` now has its prior `Affected` row
replaced by a `RestorationNo` row, so `AffectedCount` drops by one.
That drop is the corrected semantics — the user's restoration vote
is in the restoration bucket, not the active-affected bucket — not a
regression. New unit test
`RecordRestorationResponse_StillAffected_DropsAffectedRowAndDecrementsAffectedCount`
documents the shift.

**Read path** (`ClustersController.GetCluster`):
- Switched to the atomic snapshot.
- The defensive clamp added in #141 (and its block comment referencing
  #143) is removed — atomic semantics make it unnecessary.
- Wire shape unchanged: `restorationYesVotes`, `restorationTotalVotes`,
  `restorationRatio` still populated only for `possible_restoration`.

**Decision paths** (`EvaluateRestorationAsync`,
`EvaluatePossibleRestorationJob.EvaluateClusterAsync`):
- Both switched to the atomic snapshot.
- Worker's `stillAffected` count now reads `snapshot.NoVotes` (the
  `RestorationNo` bucket post-#142) instead of
  `CountByType(Affected)`. The previous count conflated initial "I'm
  affected" reports with restoration-time dissents.

**Repository surface**:
- Added `RestorationCountSnapshot` record + `GetRestorationCountSnapshotAsync`.
- Removed `CountRestorationResponsesAsync` (no remaining callers).
- `CountByTypeAsync` retained — still used for `Affected`/`Observing`
  counts in `RefreshCountsAsync`.

## Docs / contract

- `ClusterResponseDto.RestorationTotalVotes` — removed the
  "Observable today: still_affected recorded as Affected" remarks
  block introduced in #141.
- `02_openapi.yaml` — removed the matching "Note: the current HTTP
  write path records `still_affected` as `affected`..." paragraph.
  Both intentionally documented the pre-fix bug and are no longer
  truthful.
- Wire shape of `ClusterResponseDto` unchanged.

## No schema change

`participation_type` Postgres enum already contains `restoration_no`
(verified in `HaliWebApplicationFactory.EnsureSchemaAsync`). EF model
already maps it. No migration needed.

## Tests

Added:
- `RecordRestorationResponse_StillAffected_MapsToRestorationNo`
  *(rename of the pre-fix `MapsToAffected` test)*
- `RecordRestorationResponse_StillAffected_DropsAffectedRowAndDecrementsAffectedCount`
- `EvaluateRestoration_IncludesStillAffectedDissentInTotal` — direct
  regression for the #142 ratio bug
- `GetRestorationCountSnapshot_ReturnsYesNoTotalConsistently`
- `GetRestorationCountSnapshot_NoRestorationVotes_ReturnsZeros`

Updated:
- `EvaluatePossibleRestorationJobTests`:
  `StillAffectedVotesExceedRestoration_RevertsToActive` seed switched
  from `Affected` to `RestorationNo`; `RatioBelow60Percent_DoesNotResolve`
  dissent switched to `RestorationUnsure` so it remains a ratio-only
  check (a `RestorationNo` dissent would now exercise the revert path).
- `ClusterIntegrationTests.GetCluster_PossibleRestoration_ExposesRestorationProgressFields`
  — seed `affected` → `restoration_no`; expected `yesVotes=2`,
  `totalVotes=4`, `ratio=0.5`.
- All in-test `IParticipationRepository` fakes updated to implement
  `GetRestorationCountSnapshotAsync` and drop
  `CountRestorationResponsesAsync`.

## Validation

- `dotnet build` — 0 errors, no new warnings vs. develop baseline.
- `dotnet format src/Hali.Api/Hali.Api.csproj --verify-no-changes` — exit 0 (the CI gate).
- `dotnet test tests/Hali.Tests.Unit` — **353/353 passed**, 0 failures.
- `npx swagger-cli validate 02_openapi.yaml` — valid.
- Integration tests will run on CI (require Testcontainers Postgres).

## Scope discipline

- 12 files changed, +205/-84.
- No unrelated refactors. No format-only churn (an early `dotnet format`
  pass was reverted because it overscoped to 49 files; only behaviorally
  needed edits remain).
- No documentation files modified beyond removing the now-untruthful
  notes from PR #141.
- `CountRestorationResponsesAsync` removed because it is dead-code-as-of-
  this-PR; not a broader repository redesign.

## Test plan

- [ ] CI: build, lint/format, unit, integration green
- [ ] Manual: confirm a `still_affected` vote produces a `restoration_no`
      row and contributes to `restorationTotalVotes`
- [ ] Manual: under load, confirm `restorationRatio` no longer exceeds 1
      under concurrent participation flips

Closes #142
Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)