### PR TITLE
fix(auth): canonical ErrorResponse envelope on framework 403 forbidden (#147)

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -704,9 +704,11 @@ paths:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
         '403':
           description: |
-            Outside institution jurisdiction
-            (official_post.outside_jurisdiction) or missing/malformed
-            institution_id claim on the JWT (auth.institution_id_missing).
+            Authenticated caller does not hold the institution role
+            (auth.role_insufficient), is outside the institution's
+            jurisdiction (official_post.outside_jurisdiction), or is
+            missing/has a malformed institution_id claim on the JWT
+            (auth.institution_id_missing).
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
@@ -895,6 +897,13 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '403':
+          description: |
+            Authenticated caller does not hold the admin role
+            (auth.role_insufficient).
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
   /v1/admin/institutions/{id}/access:
     delete:
       tags: [Admin]
@@ -916,6 +925,13 @@ paths:
                 description: Empty object on success.
         '401':
           description: Unauthenticated (auth.unauthenticated)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '403':
+          description: |
+            Authenticated caller does not hold the admin role
+            (auth.role_insufficient).
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -104,6 +104,47 @@ builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
             context.Response.ContentType = "application/json";
             await context.Response.WriteAsync(
                 JsonSerializer.Serialize(envelope, ApiErrorJsonOptions.Default));
+        },
+
+        // Mirror of OnChallenge for the 403 path: when an authenticated caller
+        // fails a role-gated [Authorize(Roles = ...)] check, the authorization
+        // stage short-circuits with a 403 that bypasses
+        // ExceptionHandlingMiddleware, producing a bare empty body. This hook
+        // emits the canonical ApiErrorResponse envelope instead so role-gated
+        // endpoints match the wire contract used everywhere else.
+        //
+        // Code is "auth.role_insufficient" — distinct from:
+        //   - "auth.unauthenticated" (OnChallenge above — no/invalid token)
+        //   - "auth.unauthorized" (application-layer, claim missing in logic)
+        //   - "auth.refresh_token_invalid" (refresh-endpoint-specific)
+        // Message is deliberately opaque: we do NOT leak the required role,
+        // policy, or claim name, because that information exposes the shape
+        // of the authorization graph to unauthorized callers.
+        OnForbidden = async context =>
+        {
+            if (context.Response.HasStarted)
+            {
+                return;
+            }
+
+            var traceId = context.HttpContext.Items["CorrelationId"] as string
+                ?? context.HttpContext.TraceIdentifier
+                ?? string.Empty;
+
+            var envelope = new ApiErrorResponse
+            {
+                Error = new ApiErrorBody
+                {
+                    Code = "auth.role_insufficient",
+                    Message = "Access to this resource is not permitted.",
+                    TraceId = traceId
+                }
+            };
+
+            context.Response.StatusCode = StatusCodes.Status403Forbidden;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(
+                JsonSerializer.Serialize(envelope, ApiErrorJsonOptions.Default));
         }
     };
 });

--- a/tests/Hali.Tests.Integration/Auth/ForbiddenRoleEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Auth/ForbiddenRoleEnvelopeTests.cs
@@ -1,0 +1,117 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Hali.Tests.Integration.Infrastructure;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Hali.Tests.Integration.Auth;
+
+/// <summary>
+/// Issue #147: mirror of <see cref="UnauthenticatedChallengeEnvelopeTests"/>
+/// for the 403 path. When an authenticated caller holds a valid JWT but the
+/// caller's role claim does not match a <c>[Authorize(Roles = "...")]</c>
+/// requirement, the authorization stage short-circuits with a 403 that
+/// bypasses ExceptionHandlingMiddleware. Without <c>JwtBearerEvents.OnForbidden</c>
+/// this produced a bare empty-body 403, breaking the canonical H2 envelope.
+///
+/// One representative endpoint per role-gated controller is exercised here —
+/// adding all of them would be redundant because every role-gated endpoint
+/// hits the same OnForbidden hook.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class ForbiddenRoleEnvelopeTests : IntegrationTestBase
+{
+    public ForbiddenRoleEnvelopeTests(HaliWebApplicationFactory factory)
+        : base(factory) { }
+
+    [Theory]
+    // OfficialPostsController: [Authorize(Roles = "institution")] — exercised
+    // with a citizen-role JWT (the common wrong-role case for this endpoint).
+    [InlineData("POST", "/v1/official-posts", "citizen", "{}")]
+    // AdminController: class-level [Authorize(Roles = "admin")] — exercised
+    // with both a citizen-role and institution-role JWT to cover the two
+    // realistic wrong-role shapes a caller can present on admin routes.
+    [InlineData("POST", "/v1/admin/institutions", "citizen", "{}")]
+    [InlineData("POST", "/v1/admin/institutions", "institution", "{}")]
+    [InlineData("DELETE", "/v1/admin/institutions/00000000-0000-0000-0000-000000000000/access", "citizen", null)]
+    public async Task RoleGatedEndpoint_AuthenticatedWithWrongRole_EmitsCanonicalForbiddenEnvelope(
+        string method,
+        string path,
+        string wrongRole,
+        string? jsonBody)
+    {
+        // Mint a structurally valid JWT that the framework will accept, but
+        // whose role claim does not satisfy the endpoint's [Authorize(Roles = ...)]
+        // requirement. The request therefore reaches the authorization stage
+        // and is short-circuited with a 403 — exactly the framework seam this
+        // test is exercising.
+        var jwt = MintJwt(Guid.NewGuid(), wrongRole);
+
+        using var request = new HttpRequestMessage(new HttpMethod(method), path);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
+        if (jsonBody is not null)
+        {
+            request.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+        }
+
+        using var response = await Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
+
+        var body = await response.Content.ReadAsStringAsync();
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+
+        Assert.Equal(JsonValueKind.Object, root.ValueKind);
+        Assert.True(root.TryGetProperty("error", out var error),
+            "envelope must have a top-level `error` property");
+        Assert.Equal(JsonValueKind.Object, error.ValueKind);
+
+        Assert.True(error.TryGetProperty("code", out var code));
+        Assert.Equal("auth.role_insufficient", code.GetString());
+
+        Assert.True(error.TryGetProperty("message", out var message));
+        var messageText = message.GetString();
+        Assert.False(string.IsNullOrWhiteSpace(messageText),
+            "envelope must include a non-empty message");
+
+        // Security: the message must be opaque — it must not leak the
+        // specific role, policy, or claim name required by the endpoint,
+        // because that exposes the shape of the authorization graph.
+        Assert.DoesNotContain("admin", messageText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("institution", messageText, StringComparison.OrdinalIgnoreCase);
+        Assert.DoesNotContain("role", messageText, StringComparison.OrdinalIgnoreCase);
+
+        Assert.True(error.TryGetProperty("traceId", out var traceId),
+            "envelope must include a traceId for support/log correlation");
+        Assert.False(string.IsNullOrWhiteSpace(traceId.GetString()),
+            "traceId must be non-empty");
+    }
+
+    private static string MintJwt(Guid accountId, string role)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestConstants.JwtSecret));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: TestConstants.JwtIssuer,
+            audience: TestConstants.JwtAudience,
+            claims: new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, accountId.ToString()),
+                new Claim(ClaimTypes.Role, role),
+            },
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
Closes #147.

## What the old behavior was

When an authenticated caller hit a role-gated `[Authorize(Roles = "...")]` endpoint with a valid JWT but the wrong role claim, ASP.NET Core's authorization stage short-circuited with a **bare 403 — no body at all**. This bypasses `ExceptionHandlingMiddleware`, so the canonical `ApiErrorResponse` envelope everyone else emits was absent on this path.

Affected endpoints today:
- `POST /v1/official-posts` (`[Authorize(Roles = "institution")]`)
- `POST /v1/admin/institutions`, `DELETE /v1/admin/institutions/{id}/access`, and the rest of `/v1/admin/*` (class-level `[Authorize(Roles = "admin")]`)

Symptom: wire-contract consumers (SDKs, Dredd, mobile) had to special-case "sometimes envelope, sometimes empty body" on the one code path H2 otherwise retired.

## What is fixed now

Hooked `JwtBearerEvents.OnForbidden` in `src/Hali.Api/Program.cs` to emit the canonical envelope:

```json
{ "error": { "code": "auth.role_insufficient", "message": "Access to this resource is not permitted.", "traceId": "…" } }
```

- HTTP 403 preserved.
- `Content-Type: application/json` set on the response.
- `traceId` pulled from the `CorrelationId` item populated by `CorrelationIdMiddleware` (same source OnChallenge uses), falling back to `HttpContext.TraceIdentifier`.
- Response short-circuits cleanly if `Response.HasStarted` (defensive — same guard as OnChallenge).

## Why this is intentionally symmetric with #137 but distinct in semantics

#137 fixed the **401 framework short-circuit** by wiring `OnChallenge`. The 403 path is structurally identical — authorization middleware bypasses the exception handler — but semantically distinct. Four distinct failure modes, four distinct codes:

| Code | Where | When |
|---|---|---|
| `auth.unauthenticated` | `OnChallenge` (#137) | no token / invalid / expired |
| `auth.role_insufficient` | `OnForbidden` (this PR) | valid token, wrong role for `[Authorize(Roles = …)]` |
| `auth.unauthorized` | app-layer `UnauthorizedException` | valid token, controller logic found a missing claim |
| `auth.refresh_token_invalid` | refresh endpoint | bad/expired/revoked refresh token |

Keeping the four codes distinct preserves the "genuine failure mode → distinct code" partition that #137 established.

## Why `auth.role_insufficient` is the chosen code

Alternatives considered:
- `auth.forbidden` — too broad; already implicitly covered by app-layer `ForbiddenException` codes such as `auth.institution_id_missing` and `official_post.outside_jurisdiction`.
- `auth.role_missing` — leaks "the issue is your role", inviting attackers to enumerate.
- `auth.insufficient_permissions` — same leakage framing, slightly less precise.

`auth.role_insufficient` is the minimum-information handle a client needs to recognise the failure class (it's an authorization, not authentication, failure) without hinting at which role, policy, or claim was checked. The human-facing message is even more opaque ("Access to this resource is not permitted.") — no mention of "role", "admin", or "institution" in body or headers.

## OpenAPI paths updated

`02_openapi.yaml`:

- `POST /v1/official-posts` — the existing `403` entry was broadened to include `auth.role_insufficient` alongside the existing app-layer codes (`official_post.outside_jurisdiction`, `auth.institution_id_missing`). Same schema ref (`ErrorResponse`); only the description changed.
- `POST /v1/admin/institutions` — new `403` entry pointing at `ErrorResponse` with `auth.role_insufficient`.
- `DELETE /v1/admin/institutions/{id}/access` — new `403` entry pointing at `ErrorResponse` with `auth.role_insufficient`.

Deliberately **not** widened: non-role-gated endpoints kept their existing response sets. This PR is scoped to the framework role-gate seam, not a global 403 audit.

## Integration coverage added

`tests/Hali.Tests.Integration/Auth/ForbiddenRoleEnvelopeTests.cs` — parameterised `[Theory]` mirroring `UnauthenticatedChallengeEnvelopeTests`:

- Mints a valid JWT with a role claim that does not satisfy the endpoint's `[Authorize(Roles = …)]`.
- Covers both role-gated controller classes:
  - `OfficialPostsController`: `POST /v1/official-posts` with `role=citizen`
  - `AdminController`: `POST /v1/admin/institutions` with `role=citizen` and `role=institution`; `DELETE /v1/admin/institutions/{id}/access` with `role=citizen`
- Asserts:
  - HTTP 403
  - `Content-Type: application/json`
  - canonical envelope shape (`error.code`, `error.message`, `error.traceId`)
  - `code == "auth.role_insufficient"`
  - non-empty `message` and `traceId`
  - **security assertion**: `message` does not contain `"admin"`, `"institution"`, or `"role"` (opacity check)

## Why the message stays opaque

Revealing the required role or claim on a 403 is an authorization side-channel: it tells an unauthenticated or misauthenticated caller the shape of the authorization graph (which endpoints require which roles), making targeted credential-stuffing and privilege-escalation reconnaissance easier. The message is therefore fixed, short, and information-free. Callers that need to reason about the failure class inspect `error.code`; that code is already a generic class marker, not a leak.

## Scope guardrails

Deliberately **not** touched:
- 401 behaviour from #137.
- Application-layer error paths (`auth.unauthorized`, `auth.refresh_token_invalid`, `auth.institution_id_missing`, `official_post.outside_jurisdiction` — all already envelope-correct).
- Controller `[Authorize]` attributes.
- Role/claim model.
- Authorization logic.
- Mobile/UI.

## Validation

| Check | Result |
|---|---|
| `dotnet format --verify-no-changes` (Program.cs + new test file) | ✅ clean |
| `dotnet build Hali.sln` | ✅ 0 errors (warning count unchanged vs baseline) |
| `dotnet test tests/Hali.Tests.Unit` | ✅ 353 / 353 passed |
| `dotnet test tests/Hali.Tests.Integration` | ✅ 51 / 51 passed (incl. 4 new forbidden cases) |
| `npx swagger-cli validate 02_openapi.yaml` | ✅ valid |

## Test plan

- [x] Unit tests green
- [x] Integration tests green (both pre-existing `UnauthenticatedChallengeEnvelopeTests` still pass, plus the new `ForbiddenRoleEnvelopeTests` cases)
- [x] OpenAPI spec validates
- [x] Self-validation: PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)