### PR TITLE
[Issue #152] Fix mobile canonical error-envelope parsing

### DIFF
--- a/apps/citizen-mobile/__tests__/api/buildApiError.test.ts
+++ b/apps/citizen-mobile/__tests__/api/buildApiError.test.ts
@@ -1,0 +1,293 @@
+// apps/citizen-mobile/__tests__/api/buildApiError.test.ts
+//
+// Unit tests for the canonical-envelope error parser used by every
+// request path in `src/api/client.ts`. The parser must:
+//
+//   1. Read `error.code`, `error.message`, `error.details`, `error.traceId`
+//      from the canonical `{ error: { ... } }` envelope emitted by the
+//      Hali backend after H1 + H2.
+//   2. Fall back to the three pre-H1 shapes when a legacy or drifted
+//      endpoint does not emit the canonical envelope.
+//   3. Never throw; degrade malformed / missing / non-JSON bodies to
+//      `code: 'unknown_error'` with a generic message.
+
+import { buildApiError } from '../../src/api/client';
+
+describe('buildApiError — canonical envelope', () => {
+  it('extracts code and message from a canonical envelope', () => {
+    const body = {
+      error: {
+        code: 'validation.invalid_category',
+        message: 'Category is not a known taxonomy slug.',
+        traceId: '00-abc-123-00',
+      },
+    };
+
+    const result = buildApiError(400, body);
+
+    expect(result).toEqual({
+      status: 400,
+      code: 'validation.invalid_category',
+      message: 'Category is not a known taxonomy slug.',
+      traceId: '00-abc-123-00',
+    });
+  });
+
+  it('preserves `details` when present (object payload)', () => {
+    const body = {
+      error: {
+        code: 'validation.failed',
+        message: 'Request is invalid.',
+        details: {
+          fields: {
+            freeText: ['Required.'],
+            latitude: ['Out of range.'],
+          },
+        },
+        traceId: 'trace-xyz',
+      },
+    };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('validation.failed');
+    expect(result.traceId).toBe('trace-xyz');
+    expect(result.details).toEqual({
+      fields: {
+        freeText: ['Required.'],
+        latitude: ['Out of range.'],
+      },
+    });
+  });
+
+  it('preserves `details` when the backend sends an array', () => {
+    const body = {
+      error: {
+        code: 'validation.failed',
+        message: 'Multiple issues.',
+        details: ['issue-a', 'issue-b'],
+        traceId: 't',
+      },
+    };
+
+    const result = buildApiError(400, body);
+
+    expect(result.details).toEqual(['issue-a', 'issue-b']);
+  });
+
+  it('preserves `traceId` end-to-end', () => {
+    const body = {
+      error: {
+        code: 'auth.unauthenticated',
+        message: 'Authentication required.',
+        traceId: '00-f00d-b47e-01',
+      },
+    };
+
+    const result = buildApiError(401, body);
+
+    expect(result.traceId).toBe('00-f00d-b47e-01');
+  });
+
+  it('omits `traceId` when the field is missing', () => {
+    const body = {
+      error: {
+        code: 'signal.duplicate',
+        message: 'Signal already submitted.',
+      },
+    };
+
+    const result = buildApiError(409, body);
+
+    expect(result.code).toBe('signal.duplicate');
+    expect(result.message).toBe('Signal already submitted.');
+    expect('traceId' in result).toBe(false);
+    expect('details' in result).toBe(false);
+  });
+
+  it('omits `details` when the backend sends null', () => {
+    const body = {
+      error: {
+        code: 'cluster.not_found',
+        message: 'Cluster not found.',
+        details: null,
+        traceId: 'abc',
+      },
+    };
+
+    const result = buildApiError(404, body);
+
+    expect('details' in result).toBe(false);
+    expect(result.traceId).toBe('abc');
+  });
+
+  it('omits `traceId` when the backend sends an empty string', () => {
+    const body = {
+      error: {
+        code: 'auth.forbidden',
+        message: 'Access denied.',
+        traceId: '',
+      },
+    };
+
+    const result = buildApiError(403, body);
+
+    expect('traceId' in result).toBe(false);
+  });
+
+  it('degrades to unknown_error when canonical envelope is missing code', () => {
+    const body = {
+      error: {
+        message: 'Something went wrong.',
+        traceId: 't',
+      },
+    };
+
+    const result = buildApiError(500, body);
+
+    expect(result.code).toBe('unknown_error');
+    expect(result.message).toBe('Something went wrong.');
+    expect(result.traceId).toBe('t');
+  });
+
+  it('degrades message when canonical envelope is missing message', () => {
+    const body = {
+      error: {
+        code: 'dependency.nlp_unavailable',
+      },
+    };
+
+    const result = buildApiError(503, body);
+
+    expect(result.code).toBe('dependency.nlp_unavailable');
+    expect(result.message).toBe('An unexpected error occurred.');
+  });
+
+  it('ignores non-string code/message/traceId values', () => {
+    const body = {
+      error: {
+        code: 42,
+        message: { nested: 'not a string' },
+        traceId: 99,
+        details: { fields: { a: ['b'] } },
+      },
+    };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('unknown_error');
+    expect(result.message).toBe('An unexpected error occurred.');
+    expect('traceId' in result).toBe(false);
+    // details is passed through untyped
+    expect(result.details).toEqual({ fields: { a: ['b'] } });
+  });
+});
+
+describe('buildApiError — legacy fallbacks', () => {
+  it('parses legacy { error: "..." } string-only shape', () => {
+    const body = { error: 'OTP code has expired.' };
+
+    const result = buildApiError(400, body);
+
+    expect(result).toEqual({
+      status: 400,
+      code: 'unknown_error',
+      message: 'OTP code has expired.',
+    });
+  });
+
+  it('parses legacy { error, code } shape', () => {
+    const body = { error: 'Invalid taxonomy slug.', code: 'validation.failed' };
+
+    const result = buildApiError(422, body);
+
+    expect(result).toEqual({
+      status: 422,
+      code: 'validation.failed',
+      message: 'Invalid taxonomy slug.',
+    });
+  });
+
+  it('parses legacy { code, message } shape', () => {
+    const body = {
+      code: 'integrity.rate_limited',
+      message: 'Too many requests.',
+    };
+
+    const result = buildApiError(429, body);
+
+    expect(result).toEqual({
+      status: 429,
+      code: 'integrity.rate_limited',
+      message: 'Too many requests.',
+    });
+  });
+
+  it('treats an array-valued `error` as non-canonical and falls back', () => {
+    // `typeof [] === 'object'`; guard against arrays masquerading as the
+    // canonical envelope.
+    const body = { error: ['a', 'b'], code: 'legacy.code', message: 'm' };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('legacy.code');
+    expect(result.message).toBe('m');
+  });
+
+  it('treats null `error` as non-canonical and falls back', () => {
+    const body = { error: null, code: 'legacy.only_code' };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('legacy.only_code');
+  });
+});
+
+describe('buildApiError — resilience / malformed bodies', () => {
+  it('returns unknown_error for a null body (non-JSON or empty response)', () => {
+    const result = buildApiError(500, null);
+
+    expect(result).toEqual({
+      status: 500,
+      code: 'unknown_error',
+      message: 'An unexpected error occurred.',
+    });
+  });
+
+  it('returns unknown_error for an undefined body', () => {
+    const result = buildApiError(500, undefined);
+
+    expect(result.code).toBe('unknown_error');
+    expect(result.message).toBe('An unexpected error occurred.');
+    expect(result.status).toBe(500);
+  });
+
+  it('returns unknown_error for a string body', () => {
+    const result = buildApiError(502, 'Bad Gateway');
+
+    expect(result.code).toBe('unknown_error');
+  });
+
+  it('returns unknown_error for an empty object body', () => {
+    const result = buildApiError(400, {});
+
+    expect(result).toEqual({
+      status: 400,
+      code: 'unknown_error',
+      message: 'An unexpected error occurred.',
+    });
+  });
+
+  it('returns unknown_error for a body whose `error` is a boolean', () => {
+    const result = buildApiError(400, { error: true });
+
+    expect(result.code).toBe('unknown_error');
+  });
+
+  it('always preserves the HTTP status verbatim', () => {
+    const statuses = [0, 400, 401, 403, 404, 409, 422, 429, 500, 502, 503];
+    for (const status of statuses) {
+      expect(buildApiError(status, null).status).toBe(status);
+    }
+  });
+});

--- a/apps/citizen-mobile/__tests__/api/buildApiError.test.ts
+++ b/apps/citizen-mobile/__tests__/api/buildApiError.test.ts
@@ -163,6 +163,36 @@ describe('buildApiError — canonical envelope', () => {
     expect(result.message).toBe('An unexpected error occurred.');
   });
 
+  it('treats empty-string `code` as absent and degrades to unknown_error', () => {
+    const body = {
+      error: {
+        code: '',
+        message: 'Something went wrong.',
+        traceId: 'abc',
+      },
+    };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('unknown_error');
+    expect(result.message).toBe('Something went wrong.');
+    expect(result.traceId).toBe('abc');
+  });
+
+  it('treats empty-string `message` as absent and degrades to generic message', () => {
+    const body = {
+      error: {
+        code: 'auth.otp_invalid',
+        message: '',
+      },
+    };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('auth.otp_invalid');
+    expect(result.message).toBe('An unexpected error occurred.');
+  });
+
   it('ignores non-string code/message/traceId values', () => {
     const body = {
       error: {
@@ -232,6 +262,26 @@ describe('buildApiError — legacy fallbacks', () => {
 
     expect(result.code).toBe('legacy.code');
     expect(result.message).toBe('m');
+  });
+
+  it('applies the empty-string invariant on the legacy path (empty top-level code)', () => {
+    // A drifted endpoint sending `{ code: "", message: "Bad." }` must still
+    // degrade `code` to `unknown_error` rather than surface `""`.
+    const body = { code: '', message: 'Bad.' };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('unknown_error');
+    expect(result.message).toBe('Bad.');
+  });
+
+  it('applies the empty-string invariant on the legacy path (empty error string)', () => {
+    const body = { error: '' };
+
+    const result = buildApiError(400, body);
+
+    expect(result.code).toBe('unknown_error');
+    expect(result.message).toBe('An unexpected error occurred.');
   });
 
   it('treats null `error` as non-canonical and falls back', () => {

--- a/apps/citizen-mobile/src/api/client.ts
+++ b/apps/citizen-mobile/src/api/client.ts
@@ -92,6 +92,12 @@ export async function clearTokens(): Promise<void> {
  * Exported for targeted unit coverage; no runtime caller outside this module.
  */
 export function buildApiError(status: number, body: unknown): ApiError {
+  // A field counts as "present" only when it is a non-empty string. An empty
+  // string is treated as absent so `ApiError.code` / `.message` always carry
+  // a meaningful value — same contract `traceId` uses below.
+  const nonEmptyString = (v: unknown): string | undefined =>
+    typeof v === 'string' && v.length > 0 ? v : undefined;
+
   if (body !== null && typeof body === 'object') {
     const b = body as Record<string, unknown>;
 
@@ -103,15 +109,10 @@ export function buildApiError(status: number, body: unknown): ApiError {
       !Array.isArray(b.error)
     ) {
       const e = b.error as Record<string, unknown>;
-      const code = typeof e.code === 'string' ? e.code : 'unknown_error';
+      const code = nonEmptyString(e.code) ?? 'unknown_error';
       const message =
-        typeof e.message === 'string'
-          ? e.message
-          : 'An unexpected error occurred.';
-      const traceId =
-        typeof e.traceId === 'string' && e.traceId.length > 0
-          ? e.traceId
-          : undefined;
+        nonEmptyString(e.message) ?? 'An unexpected error occurred.';
+      const traceId = nonEmptyString(e.traceId);
       // Preserve any non-null details value (object, array, or string).
       // Null is treated as absent to avoid leaking a "present but empty"
       // signal into consumers.
@@ -125,13 +126,12 @@ export function buildApiError(status: number, body: unknown): ApiError {
     }
 
     // Legacy fallbacks — pre-H1 shapes still accepted defensively.
-    const code = typeof b.code === 'string' ? b.code : 'unknown_error';
+    // Same non-empty-string invariant applied here.
+    const code = nonEmptyString(b.code) ?? 'unknown_error';
     const message =
-      typeof b.message === 'string'
-        ? b.message
-        : typeof b.error === 'string'
-          ? b.error
-          : 'An unexpected error occurred.';
+      nonEmptyString(b.message) ??
+      nonEmptyString(b.error) ??
+      'An unexpected error occurred.';
     return { status, code, message };
   }
   return {

--- a/apps/citizen-mobile/src/api/client.ts
+++ b/apps/citizen-mobile/src/api/client.ts
@@ -68,18 +68,63 @@ export async function clearTokens(): Promise<void> {
 // ─── Error construction ──────────────────────────────────────────────────────
 
 /**
- * Normalise the three error body shapes used across the Hali backend:
- *   1. { error: "..." }                        — most endpoints
- *   2. { error: "...", code: "..." }           — clusters / official posts 422s
- *   3. { code: "...", message: "..." }         — signals rate limiter
+ * Normalise an HTTP error body into the mobile `ApiError` shape.
  *
- * Returns a unified ApiError with both `code` and `message` populated.
- * Prefers `message` over `error` when both are present; prefers `code` over
- * a default when provided.
+ * Primary shape — the canonical backend envelope (H1 + H2):
+ *
+ *   { "error": { "code": "...", "message": "...", "details"?: ..., "traceId": "..." } }
+ *
+ * The entire documented 4xx/5xx surface of the API — including framework
+ * 401/403 — emits this envelope. When it is present, `code`, `message`,
+ * `traceId`, and `details` are extracted verbatim (`details` is passed
+ * through as `unknown`; narrowing is the consumer's responsibility).
+ *
+ * Legacy fallbacks — retained so any still-drifted or third-party endpoint
+ * does not regress to a generic error:
+ *
+ *   1. { "error": "..." }                   — string-only body
+ *   2. { "error": "...", "code": "..." }    — string body + top-level code
+ *   3. { "code": "...", "message": "..." }  — top-level code + message
+ *
+ * Non-object bodies (null — set by `response.json().catch(() => null)` on
+ * malformed / non-JSON / empty bodies) always degrade to `unknown_error`.
+ *
+ * Exported for targeted unit coverage; no runtime caller outside this module.
  */
-function buildApiError(status: number, body: unknown): ApiError {
+export function buildApiError(status: number, body: unknown): ApiError {
   if (body !== null && typeof body === 'object') {
     const b = body as Record<string, unknown>;
+
+    // Canonical envelope: nested `error` object.
+    // (arrays also have typeof === 'object', so guard explicitly)
+    if (
+      b.error !== null &&
+      typeof b.error === 'object' &&
+      !Array.isArray(b.error)
+    ) {
+      const e = b.error as Record<string, unknown>;
+      const code = typeof e.code === 'string' ? e.code : 'unknown_error';
+      const message =
+        typeof e.message === 'string'
+          ? e.message
+          : 'An unexpected error occurred.';
+      const traceId =
+        typeof e.traceId === 'string' && e.traceId.length > 0
+          ? e.traceId
+          : undefined;
+      // Preserve any non-null details value (object, array, or string).
+      // Null is treated as absent to avoid leaking a "present but empty"
+      // signal into consumers.
+      const details =
+        e.details !== undefined && e.details !== null ? e.details : undefined;
+
+      const error: ApiError = { status, code, message };
+      if (traceId !== undefined) error.traceId = traceId;
+      if (details !== undefined) error.details = details;
+      return error;
+    }
+
+    // Legacy fallbacks — pre-H1 shapes still accepted defensively.
     const code = typeof b.code === 'string' ? b.code : 'unknown_error';
     const message =
       typeof b.message === 'string'

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -1,9 +1,28 @@
 // ─── Result + Error (canonical location — do not redeclare elsewhere) ───────
 
+/**
+ * Normalised error shape surfaced by the mobile API client.
+ *
+ * The wire contract is the canonical backend envelope:
+ *   { error: { code, message, details?, traceId } }
+ *
+ * `status` is the HTTP response status (0 for network errors). `code` and
+ * `message` are always populated — malformed/legacy bodies degrade to
+ * `code: 'unknown_error'` and a generic message. `traceId` and `details`
+ * are only set when the canonical envelope provides them.
+ *
+ * `details` is `unknown` on purpose: today it can be a keyed field-errors
+ * object (`{ fields: { fieldName: [...] } }` from `ValidationException`),
+ * a string, an array, or absent. Consumers that need to read it should
+ * narrow it at the use site — do not widen this type into a union here
+ * (that is tracked separately; see the mobile `ErrorCode` follow-up).
+ */
 export interface ApiError {
   status: number;
   code: string;
   message: string;
+  traceId?: string;
+  details?: unknown;
 }
 
 export type Result<T, E = ApiError> =


### PR DESCRIPTION
Closes #152.

## Problem

After PRs #106 (H1) and #134/#135/#140/#147/#148/#151 (H2 + framework-envelope parity), every documented 4xx/5xx on the backend emits a single canonical envelope:

```
{ "error": { "code": "...", "message": "...", "details"?: ..., "traceId": "..." } }
```

`apps/citizen-mobile/src/api/client.ts::buildApiError` had not been migrated. It still inspected top-level `body.code`, top-level `body.message`, and `typeof body.error === 'string'` — none of which match the canonical envelope (`body.error` is now an object). Every canonical 4xx therefore collapsed to:

```
code:    'unknown_error'
message: 'An unexpected error occurred.'
```

`error.code`, `error.message`, `error.details` (including validation `fieldErrors`), and `error.traceId` were all discarded before reaching any screen.

## Root cause

Parser drift. `buildApiError`'s docblock and body describe three pre-H1 shapes that predate the canonical envelope. The function never inspected `body.error.code` / `body.error.message`, so once the backend unified on the nested envelope, the parser's fast paths no longer matched any documented backend response.

Evidence (pre-fix):
- `grep -rn traceId apps/citizen-mobile/src` → 0 matches.
- `grep -rn 'fieldErrors\|details\.fields' apps/citizen-mobile/src` → 0 matches.
- `buildApiError` had no test file.

## What changed

**`apps/citizen-mobile/src/api/client.ts`** — rewrote `buildApiError` to:
- Detect the canonical `{ error: { … } }` envelope first; extract `code`, `message`, `traceId`, and `details` verbatim.
- Pass `details` through as `unknown` so consumers can narrow at the use site (today this is the `{ fields: { fieldName: [...] } }` payload from `ValidationException`; it may also be an array or string).
- Guard the canonical branch against arrays and `null` (both have `typeof === 'object'`), so only a real nested object triggers it.
- Preserve the three pre-H1 shapes as fallbacks so any still-drifted or third-party endpoint does not regress:
  1. `{ error: "..." }`
  2. `{ error: "...", code: "..." }`
  3. `{ code: "...", message: "..." }`
- Degrade null / undefined / non-object bodies to `unknown_error` with a generic message.
- Exported `buildApiError` for targeted unit coverage (previously internal).

**`apps/citizen-mobile/src/types/api.ts`** — extended `ApiError` with optional `traceId?: string` and `details?: unknown`. Non-breaking: every existing consumer reads `status`, `code`, and `message` only.

## Test coverage

New file: `apps/citizen-mobile/__tests__/api/buildApiError.test.ts` — 25 assertions across three groups.

**Canonical envelope (10):**
- extracts `code` and `message`
- preserves `details` (object with `fields`)
- preserves `details` (array payload)
- preserves `traceId`
- omits `traceId` when absent
- omits `details` when backend sends `null`
- omits `traceId` when backend sends `""`
- degrades missing `code` → `unknown_error`
- degrades missing `message` → generic message
- ignores non-string `code` / `message` / `traceId` values

**Legacy fallbacks (5):**
- string-only `{ error: "..." }` shape
- `{ error, code }` shape
- `{ code, message }` shape
- array-valued `error` falls through to legacy path
- `null` `error` falls through to legacy path

**Resilience (6):**
- `null` body (non-JSON / empty response)
- `undefined` body
- string body
- empty object body
- boolean-valued `error`
- HTTP status is preserved verbatim across `[0, 400, 401, 403, 404, 409, 422, 429, 500, 502, 503]`

Full mobile suite: **277/277 tests passing**. `npx tsc --noEmit`: **clean**.

## Out of scope

- Screen-level UX changes that consume the newly-surfaced `error.code` / `error.details` (intentional — keep scope tight).
- Typed / discriminated-union for `ApiError.code` (tracked separately — #154).
- Backend reason-code rename / central catalog (tracked separately — #153).
- Backend changes of any kind.
- Generic API-client refactor or unrelated error-handling cleanup.

## Risk

**Low.** The change is additive on the type side (`traceId`, `details` are optional) and strictly more permissive on the parser side (canonical envelope now recognised, legacy shapes still accepted). Downstream audit:

- `classifyFlushResult` (`src/utils/offlineQueueLogic.ts`) reads only `result.error.status` — unaffected.
- `LocationFallbackPicker` reads `reverse.error.status === 404` — unaffected.
- `client.ts` internal retry reads `firstAttempt.error.status !== 401` — unaffected.

No call site today reads `error.code` conditionally, so surfacing the correct code cannot regress an existing branch. Any consumer that was hard-coded to `error.message === 'An unexpected error occurred.'` (none found in-repo) would need manual regression, but that is the documented goal of this fix.

## Follow-up dependency note

This lands before #153 (H3 — central reason-code catalog + consistency pass, which will rename `integrity.rate_limited → rate_limit.exceeded`, collapse the three `*.invalid_coordinates` variants, and replace generic `validation.failed` buckets). Without this PR, those renames would ship invisibly on mobile because every code degraded to `unknown_error`. After this PR, mobile discriminates correctly on `error.code`, so #153's renames will be observable end-to-end. #154 will later formalise `ApiError.code` as a discriminated union against the OpenAPI-published `ErrorCode` enum.

## Test plan

- [x] `npx jest __tests__/api/buildApiError.test.ts` — 25/25 pass
- [x] `npx jest` (full mobile suite) — 277/277 pass
- [x] `npx tsc --noEmit` — zero errors
- [x] Pre-commit grep checks (hex colours / icons / Animated / `any`) — zero matches
- [ ] CI green
🤖 Generated with [Claude Code](https://claude.com/claude-code)
