### PR TITLE
[Issue #153] Centralize and normalize backend error codes

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -977,6 +977,79 @@ components:
         platform: { type: string, enum: [ios, android], nullable: true }
         sessionId: { type: string, format: uuid, nullable: true }
 
+    ErrorCode:
+      type: string
+      description: |
+        Stable, programmatic identifier for an application-level error
+        condition emitted by the Hali API. Codes follow the
+        `namespace.reason` snake_case convention (e.g. `auth.otp_invalid`,
+        `validation.locality_unresolved`, `signal.duplicate`).
+
+        The canonical source of truth on the server is
+        `Hali.Application.Errors.ErrorCodes`; this enum is the wire-visible
+        subset. Internal-only codes used for log/trace correlation (e.g.
+        `clustering.no_spatial_cell`) are redacted to
+        `server.internal_error` by the exception mapper and are NOT listed
+        here.
+
+        Client applications should treat an unknown code as equivalent to
+        `server.internal_error` for UX fallback purposes, but log the
+        received code verbatim for forward-compatible debugging.
+
+        Drift between this enum and the server-side catalog is enforced by
+        a unit test (`ErrorCodeCatalogTests`).
+      enum:
+        - account.not_found
+        - auth.forbidden
+        - auth.institution_id_missing
+        - auth.otp_invalid
+        - auth.otp_rate_limited
+        - auth.refresh_token_invalid
+        - auth.role_insufficient
+        - auth.unauthenticated
+        - auth.unauthorized
+        - cluster.not_found
+        - dependency.nlp_unavailable
+        - dependency.spatial_derivation_failed
+        - device.missing_fields
+        - device.not_found
+        - institution.missing_fields
+        - invite.already_accepted
+        - invite.expired
+        - invite.invalid
+        - locality.not_found
+        - locality.query_too_long
+        - locality.query_too_short
+        - locality.search_rate_limited
+        - official_post.invalid_category
+        - official_post.invalid_type
+        - official_post.missing_fields
+        - official_post.outside_jurisdiction
+        - participation.context_requires_affected
+        - participation.context_window_expired
+        - participation.restoration_requires_affected
+        - places.query_too_long
+        - places.query_too_short
+        - places.reverse_rate_limited
+        - places.search_rate_limited
+        - rate_limit.exceeded
+        - server.internal_error
+        - signal.duplicate
+        - validation.device_not_found
+        - validation.failed
+        - validation.invalid_category
+        - validation.invalid_coordinates
+        - validation.invalid_location_source
+        - validation.invalid_participation_type
+        - validation.invalid_restoration_response
+        - validation.invalid_section
+        - validation.locality_unresolved
+        - validation.location_label_required
+        - validation.location_label_too_long
+        - validation.max_followed_localities_exceeded
+        - validation.missing_coordinates
+        - validation.missing_field
+
     ErrorResponse:
       type: object
       description: |
@@ -991,16 +1064,15 @@ components:
         emit this envelope, with `code = "auth.unauthenticated"` distinct
         from the application-layer `auth.unauthorized` thrown by controllers
         when a token is valid but an expected claim is missing.
-        Framework-generated `403` responses from role/policy denial still
-        short-circuit before the exception middleware runs and currently
-        return an empty body; that symmetric fix is tracked in issue #147.
-        Documented `403` entries that reference this schema today describe
-        failures surfaced as typed `ForbiddenException` from application
-        code.
+        Framework-generated `403` responses from role/policy denial emit
+        this envelope with `code = "auth.role_insufficient"` (see
+        `OnForbidden` handler in `Program.cs`). Documented `403` entries
+        that reference this schema from controller logic describe failures
+        surfaced as typed `ForbiddenException` (`auth.forbidden`).
 
-          * `error.code` — stable, snake_case_with_dot-namespacing identifier
-            for programmatic handling (e.g. `auth.otp_invalid`,
-            `validation.locality_unresolved`, `signal.duplicate`).
+          * `error.code` — stable `ErrorCode` identifier for programmatic
+            handling (see the named `ErrorCode` enum schema for the full
+            published set).
           * `error.message` — short human-readable summary safe to surface
             in UI. Not localized; treat wording as unstable between versions.
           * `error.details` — optional. When present on 400 responses it
@@ -1015,7 +1087,7 @@ components:
           type: object
           required: [code, message, traceId]
           properties:
-            code: { type: string }
+            code: { $ref: '#/components/schemas/ErrorCode' }
             message: { type: string }
             details: { type: object, nullable: true, additionalProperties: true }
             traceId: { type: string }

--- a/src/Hali.Api/Controllers/AdminController.cs
+++ b/src/Hali.Api/Controllers/AdminController.cs
@@ -32,7 +32,7 @@ public class AdminController : ControllerBase
         {
             throw new ValidationException(
                 "name is required.",
-                code: "institution.missing_fields",
+                code: ErrorCodes.InstitutionMissingFields,
                 fieldErrors: new Dictionary<string, string[]> { ["name"] = new[] { "name is required" } });
         }
 

--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -53,7 +53,7 @@ public class ClustersController : ControllerBase
         SignalCluster cluster = await _clusters.GetClusterByIdAsync(id, ct);
         if (cluster == null)
         {
-            throw new NotFoundException("cluster.not_found", "Cluster not found.");
+            throw new NotFoundException(ErrorCodes.ClusterNotFound, "Cluster not found.");
         }
         var officialPosts = await _officialPosts.GetByClusterIdAsync(id, ct);
 
@@ -130,7 +130,7 @@ public class ClustersController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.DeviceHash))
         {
             throw new ValidationException("device_hash is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["device_hash is required."]
@@ -139,7 +139,7 @@ public class ClustersController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.Type))
         {
             throw new ValidationException("type is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["type"] = ["type is required."]
@@ -155,7 +155,7 @@ public class ClustersController : ControllerBase
         if (flag2)
         {
             throw new ValidationException("Invalid participation type.",
-                code: "validation.invalid_participation_type",
+                code: ErrorCodes.ValidationInvalidParticipationType,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["type"] = ["Invalid participation type."]
@@ -165,7 +165,7 @@ public class ClustersController : ControllerBase
         if (device == null)
         {
             throw new ValidationException("Device not recognised.",
-                code: "validation.device_not_found",
+                code: ErrorCodes.ValidationDeviceNotFound,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["Device not recognised."]
@@ -187,7 +187,7 @@ public class ClustersController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.DeviceHash))
         {
             throw new ValidationException("device_hash is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["device_hash is required."]
@@ -196,7 +196,7 @@ public class ClustersController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.Text))
         {
             throw new ValidationException("text is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["text"] = ["text is required."]
@@ -206,7 +206,7 @@ public class ClustersController : ControllerBase
         if (device == null)
         {
             throw new ValidationException("Device not recognised.",
-                code: "validation.device_not_found",
+                code: ErrorCodes.ValidationDeviceNotFound,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["Device not recognised."]
@@ -224,7 +224,7 @@ public class ClustersController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.DeviceHash))
         {
             throw new ValidationException("device_hash is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["device_hash is required."]
@@ -234,7 +234,7 @@ public class ClustersController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.Response) || !validResponses.Contains(dto.Response))
         {
             throw new ValidationException("Invalid response value.",
-                code: "validation.invalid_restoration_response",
+                code: ErrorCodes.ValidationInvalidRestorationResponse,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["response"] = ["Invalid response value. Must be one of: still_affected, restored, not_sure."]
@@ -244,7 +244,7 @@ public class ClustersController : ControllerBase
         if (device == null)
         {
             throw new ValidationException("Device not recognised.",
-                code: "validation.device_not_found",
+                code: ErrorCodes.ValidationDeviceNotFound,
                 fieldErrors: new Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["Device not recognised."]

--- a/src/Hali.Api/Controllers/DevicesController.cs
+++ b/src/Hali.Api/Controllers/DevicesController.cs
@@ -38,7 +38,7 @@ public class DevicesController : ControllerBase
         {
             throw new ValidationException(
                 "expo_push_token and device_hash are required.",
-                code: "device.missing_fields",
+                code: ErrorCodes.DeviceMissingFields,
                 fieldErrors: missing);
         }
 
@@ -49,7 +49,7 @@ public class DevicesController : ControllerBase
             // "no matching device" is semantically a missing resource. The
             // client is expected to re-register the device before retrying.
             throw new NotFoundException(
-                code: "device.not_found",
+                code: ErrorCodes.DeviceNotFound,
                 message: "Device not recognised.");
         }
 

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -107,7 +107,7 @@ public class HomeController : ControllerBase
                     _logger?.LogInformation(
                         "{EventName} section={Section} statusCode={StatusCode} durationMs={DurationMs}",
                         ObservabilityEvents.HomeRequestCompleted, safeSection, 400, sw.ElapsedMilliseconds);
-                    throw new ValidationException("Unknown section name.", code: "validation.invalid_section");
+                    throw new ValidationException("Unknown section name.", code: ErrorCodes.ValidationInvalidSection);
                 }
 
                 sw.Stop();

--- a/src/Hali.Api/Controllers/LocalitiesController.cs
+++ b/src/Hali.Api/Controllers/LocalitiesController.cs
@@ -163,11 +163,11 @@ public class LocalitiesController : ControllerBase
     public async Task<IActionResult> Search([FromQuery] string q, CancellationToken ct)
     {
         if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
-            throw new ValidationException("Query must be at least 2 characters.", code: "locality.query_too_short");
+            throw new ValidationException("Query must be at least 2 characters.", code: ErrorCodes.LocalityQueryTooShort);
 
         var query = q.Trim();
         if (query.Length > MaxSearchQueryLength)
-            throw new ValidationException($"Query must be at most {MaxSearchQueryLength} characters.", code: "locality.query_too_long");
+            throw new ValidationException($"Query must be at most {MaxSearchQueryLength} characters.", code: ErrorCodes.LocalityQueryTooLong);
 
         // Anonymous endpoint — rate limit per client IP to bound DoS surface
         // (each call may trigger an upstream Nominatim request + PostGIS lookup).
@@ -177,7 +177,7 @@ public class LocalitiesController : ControllerBase
         if (!allowed)
         {
             throw new RateLimitException(
-                code: "locality.search_rate_limited",
+                code: ErrorCodes.LocalitySearchRateLimited,
                 message: "Too many requests.");
         }
 
@@ -257,11 +257,11 @@ public class LocalitiesController : ControllerBase
         CancellationToken ct)
     {
         if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)
-            throw new ValidationException("Invalid coordinates.", code: "locality.invalid_coordinates");
+            throw new ValidationException("Invalid coordinates.", code: ErrorCodes.ValidationInvalidCoordinates);
 
         var locality = await _localities.FindByPointAsync(latitude, longitude, ct);
         if (locality is null)
-            throw new NotFoundException(code: "locality.not_found", message: "No locality found for the given coordinates.");
+            throw new NotFoundException(code: ErrorCodes.LocalityNotFound, message: "No locality found for the given coordinates.");
 
         return Ok(new LocalitySummaryDto
         {

--- a/src/Hali.Api/Controllers/OfficialPostsController.cs
+++ b/src/Hali.Api/Controllers/OfficialPostsController.cs
@@ -35,7 +35,7 @@ public class OfficialPostsController : ControllerBase
         {
             throw new ValidationException(
                 "type, category, title, and body are required.",
-                code: "official_post.missing_fields",
+                code: ErrorCodes.OfficialPostMissingFields,
                 fieldErrors: missing);
         }
 
@@ -47,7 +47,7 @@ public class OfficialPostsController : ControllerBase
         if (string.IsNullOrEmpty(institutionClaim) || !Guid.TryParse(institutionClaim, out var institutionId))
         {
             throw new ForbiddenException(
-                code: "auth.institution_id_missing",
+                code: ErrorCodes.AuthInstitutionIdMissing,
                 message: "Institution identity required.");
         }
 

--- a/src/Hali.Api/Controllers/PlacesController.cs
+++ b/src/Hali.Api/Controllers/PlacesController.cs
@@ -82,13 +82,13 @@ public class PlacesController : ControllerBase
     {
         if (string.IsNullOrWhiteSpace(q) || q.Trim().Length < 2)
         {
-            throw new ValidationException("Query must be at least 2 characters.", code: "places.query_too_short");
+            throw new ValidationException("Query must be at least 2 characters.", code: ErrorCodes.PlacesQueryTooShort);
         }
 
         string query = q.Trim();
         if (query.Length > MaxSearchQueryLength)
         {
-            throw new ValidationException($"Query must be at most {MaxSearchQueryLength} characters.", code: "places.query_too_long");
+            throw new ValidationException($"Query must be at most {MaxSearchQueryLength} characters.", code: ErrorCodes.PlacesQueryTooLong);
         }
 
         string clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
@@ -97,7 +97,7 @@ public class PlacesController : ControllerBase
         if (!allowed)
         {
             throw new RateLimitException(
-                code: "places.search_rate_limited",
+                code: ErrorCodes.PlacesSearchRateLimited,
                 message: "Too many requests.");
         }
 
@@ -183,7 +183,7 @@ public class PlacesController : ControllerBase
     {
         if (latitude < -90 || latitude > 90 || longitude < -180 || longitude > 180)
         {
-            throw new ValidationException("Invalid coordinates.", code: "places.invalid_coordinates");
+            throw new ValidationException("Invalid coordinates.", code: ErrorCodes.ValidationInvalidCoordinates);
         }
 
         string clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
@@ -192,7 +192,7 @@ public class PlacesController : ControllerBase
         if (!allowed)
         {
             throw new RateLimitException(
-                code: "places.reverse_rate_limited",
+                code: ErrorCodes.PlacesReverseRateLimited,
                 message: "Too many requests.");
         }
 
@@ -215,7 +215,7 @@ public class PlacesController : ControllerBase
         LocalitySummary? locality = await _localities.FindByPointAsync(latitude, longitude, ct);
         if (locality is null)
         {
-            throw new NotFoundException(code: "places.locality_not_found", message: "No locality found for the given coordinates.");
+            throw new NotFoundException(code: ErrorCodes.LocalityNotFound, message: "No locality found for the given coordinates.");
         }
 
         // Label-only cache. Keyed by quantized coords AND the resolved

--- a/src/Hali.Api/Controllers/SignalsController.cs
+++ b/src/Hali.Api/Controllers/SignalsController.cs
@@ -39,12 +39,12 @@ public class SignalsController : ControllerBase
         var _previewCount = await _previewDb.StringIncrementAsync(_previewKey);
         if (_previewCount == 1) await _previewDb.KeyExpireAsync(_previewKey, TimeSpan.FromMinutes(10));
         if (_previewCount > 10)
-            throw new RateLimitException("integrity.rate_limited", "Too many preview requests.");
+            throw new RateLimitException(ErrorCodes.RateLimitExceeded, "Too many preview requests.");
 
         if (string.IsNullOrWhiteSpace(dto.FreeText))
         {
             throw new ValidationException("free_text is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
                 {
                     ["free_text"] = ["free_text is required."]
@@ -61,7 +61,7 @@ public class SignalsController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.IdempotencyKey))
         {
             throw new ValidationException("idempotency_key is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
                 {
                     ["idempotency_key"] = ["idempotency_key is required."]
@@ -70,7 +70,7 @@ public class SignalsController : ControllerBase
         if (string.IsNullOrWhiteSpace(dto.DeviceHash))
         {
             throw new ValidationException("device_hash is required.",
-                code: "validation.failed",
+                code: ErrorCodes.ValidationMissingField,
                 fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
                 {
                     ["device_hash"] = ["device_hash is required."]

--- a/src/Hali.Api/Controllers/UsersController.cs
+++ b/src/Hali.Api/Controllers/UsersController.cs
@@ -36,7 +36,7 @@ public class UsersController : ControllerBase
         var account = await _auth.FindAccountByIdAsync(accountId, ct);
         if (account == null)
             throw new NotFoundException(
-                code: "account.not_found",
+                code: ErrorCodes.AccountNotFound,
                 message: "Account not found.");
 
         var settings = ParseNotificationSettings(account.NotificationSettings);
@@ -64,7 +64,7 @@ public class UsersController : ControllerBase
         var account = await _auth.FindAccountByIdAsync(accountId, ct);
         if (account == null)
             throw new NotFoundException(
-                code: "account.not_found",
+                code: ErrorCodes.AccountNotFound,
                 message: "Account not found.");
 
         account.NotificationSettings = JsonSerializer.Serialize(dto);

--- a/src/Hali.Api/Errors/ExceptionToApiErrorMapper.cs
+++ b/src/Hali.Api/Errors/ExceptionToApiErrorMapper.cs
@@ -67,7 +67,7 @@ public sealed class ExceptionToApiErrorMapper
             _ => new ApiErrorMapping
             {
                 StatusCode = 500,
-                Code = "server.internal_error",
+                Code = ErrorCodes.ServerInternalError,
                 Message = "An unexpected error occurred.",
                 LogLevel = LogLevel.Error
             }
@@ -76,6 +76,22 @@ public sealed class ExceptionToApiErrorMapper
 
     private static ApiErrorMapping MapByCategory(AppException ae)
     {
+        // ErrorCategory.Unexpected represents an internal invariant violation
+        // carried by a typed AppException (e.g. InvariantViolationException).
+        // The typed form preserves ae.Code for logs/traces, but the wire MUST
+        // NOT leak the internal code — it is redacted to ServerInternalError,
+        // matching the behaviour of the unmapped-exception fallback above.
+        if (ae.Category == ErrorCategory.Unexpected)
+        {
+            return new ApiErrorMapping
+            {
+                StatusCode = 500,
+                Code = ErrorCodes.ServerInternalError,
+                Message = "An unexpected error occurred.",
+                LogLevel = LogLevel.Error
+            };
+        }
+
         var (statusCode, logLevel) = ae.Category switch
         {
             ErrorCategory.Validation => (400, LogLevel.Information),

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Hali.Api.Errors;
 using Hali.Api.Middleware;
 using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Application.Notifications;
 using Hali.Application.Participation;
 using Hali.Application.Signals;
@@ -94,7 +95,7 @@ builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
             {
                 Error = new ApiErrorBody
                 {
-                    Code = "auth.unauthenticated",
+                    Code = ErrorCodes.AuthUnauthenticated,
                     Message = "Authentication required.",
                     TraceId = traceId
                 }
@@ -135,7 +136,7 @@ builder.Services.AddAuthentication("Bearer").AddJwtBearer(opts =>
             {
                 Error = new ApiErrorBody
                 {
-                    Code = "auth.role_insufficient",
+                    Code = ErrorCodes.AuthRoleInsufficient,
                     Message = "Access to this resource is not permitted.",
                     TraceId = traceId
                 }

--- a/src/Hali.Application/Advisories/OfficialPostsService.cs
+++ b/src/Hali.Application/Advisories/OfficialPostsService.cs
@@ -30,16 +30,16 @@ public class OfficialPostsService : IOfficialPostsService
         CancellationToken ct)
     {
         if (!Enum.TryParse<OfficialPostType>(dto.Type.Replace("_", ""), ignoreCase: true, out var postType))
-            throw new ValidationException("Invalid post type.", code: "official_post.invalid_type");
+            throw new ValidationException("Invalid post type.", code: ErrorCodes.OfficialPostInvalidType);
 
         if (!Enum.TryParse<CivicCategory>(dto.Category.Replace("_", ""), ignoreCase: true, out var category))
-            throw new ValidationException("Invalid category.", code: "official_post.invalid_category");
+            throw new ValidationException("Invalid category.", code: ErrorCodes.OfficialPostInvalidCategory);
 
         // Geo-scope enforcement BEFORE insert — no out-of-jurisdiction row ever lands in the DB
         bool allowed = await _repo.CheckJurisdictionForLocalityAsync(institutionId, dto.LocalityId, ct);
         if (!allowed)
             throw new ForbiddenException(
-                code: "official_post.outside_jurisdiction",
+                code: ErrorCodes.OfficialPostOutsideJurisdiction,
                 message: "Post scope is outside institution jurisdiction.");
 
         var post = new OfficialPost

--- a/src/Hali.Application/Auth/AuthService.cs
+++ b/src/Hali.Application/Auth/AuthService.cs
@@ -34,7 +34,7 @@ public class AuthService : IAuthService
     {
         if (!(await _otpService.ConsumeOtpAsync(request.Destination, request.Otp, ct)))
         {
-            throw new ValidationException("Invalid or expired OTP.", code: "auth.otp_invalid");
+            throw new ValidationException("Invalid or expired OTP.", code: ErrorCodes.AuthOtpInvalid);
         }
         DateTime now = DateTime.UtcNow;
         Account account = await _repo.FindAccountByPhoneAsync(request.Destination, ct);
@@ -61,7 +61,7 @@ public class AuthService : IAuthService
         if (stored == null)
         {
             throw new UnauthorizedException(
-                code: "auth.refresh_token_invalid",
+                code: ErrorCodes.AuthRefreshTokenInvalid,
                 message: "Invalid or expired refresh token.");
         }
         await _repo.RevokeRefreshTokenAsync(stored, now, ct);

--- a/src/Hali.Application/Auth/InstitutionService.cs
+++ b/src/Hali.Application/Auth/InstitutionService.cs
@@ -76,13 +76,13 @@ public class InstitutionService : IInstitutionService
         DateTime now = DateTime.UtcNow;
 
         if (invite == null)
-            throw new ValidationException("Invalid invite token.", code: "invite.invalid");
+            throw new ValidationException("Invalid invite token.", code: ErrorCodes.InviteInvalid);
 
         if (invite.ExpiresAt <= now)
-            throw new ValidationException("Invite token has expired.", code: "invite.expired");
+            throw new ValidationException("Invite token has expired.", code: ErrorCodes.InviteExpired);
 
         if (invite.AcceptedAt != null)
-            throw new ConflictException("invite.already_accepted", "Invite has already been accepted.");
+            throw new ConflictException(ErrorCodes.InviteAlreadyAccepted, "Invite has already been accepted.");
 
         // Create account with institution role
         Account? existing = await _authRepo.FindAccountByPhoneAsync(request.PhoneNumber, ct);

--- a/src/Hali.Application/Auth/OtpService.cs
+++ b/src/Hali.Application/Auth/OtpService.cs
@@ -34,7 +34,7 @@ public class OtpService : IOtpService
         if (!(await _rateLimiter.IsAllowedAsync(key, _opts.MaxRequestsPerWindow, TimeSpan.FromMinutes(_opts.WindowMinutes), ct)))
         {
             throw new RateLimitException(
-                code: "auth.otp_rate_limited",
+                code: ErrorCodes.AuthOtpRateLimited,
                 message: "Too many OTP requests. Please try again later.");
         }
         string otp = GenerateOtp(_opts.Length);

--- a/src/Hali.Application/Clusters/ClusteringService.cs
+++ b/src/Hali.Application/Clusters/ClusteringService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Errors;
 using Hali.Application.Observability;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Signals;
@@ -37,7 +38,17 @@ public class ClusteringService : IClusteringService
     {
         if (signal.SpatialCellId is null)
         {
-            throw new InvalidOperationException("CLUSTERING_NO_SPATIAL_CELL");
+            // H3 retype (#153): was a bare InvalidOperationException deferred
+            // from PR #134. The typed InvariantViolationException preserves
+            // the structured `clustering.no_spatial_cell` code on logs/traces
+            // (see ErrorCodes.InternalOnlyCodes) while
+            // ExceptionToApiErrorMapper redacts ErrorCategory.Unexpected on
+            // the wire to ServerInternalError. No public-wire change: the
+            // response remains 500 with `server.internal_error`, identical
+            // to the pre-H3 mapper-fallback behaviour.
+            throw new InvariantViolationException(
+                ErrorCodes.ClusteringNoSpatialCell,
+                "Signal reached the clustering pipeline without a derived spatial cell.");
         }
         string[] searchCells = _h3.GetKRingCells(signal.SpatialCellId, 1);
         IReadOnlyList<SignalCluster> candidates = await _repo.FindCandidateClustersAsync(searchCells, signal.Category, ct);

--- a/src/Hali.Application/Errors/ErrorCodes.cs
+++ b/src/Hali.Application/Errors/ErrorCodes.cs
@@ -24,7 +24,9 @@ public static class ErrorCodes
     /// <summary>
     /// Emitted by the JwtBearer challenge handler for missing/invalid/expired
     /// tokens on <c>[Authorize]</c> endpoints. No controller throws this
-    /// directly — it is produced by <c>CustomJwtBearerEvents</c>.
+    /// directly — it is produced by the inline
+    /// <c>JwtBearerEvents.OnChallenge</c> handler configured in
+    /// <c>src/Hali.Api/Program.cs</c>.
     /// </summary>
     public const string AuthUnauthenticated = "auth.unauthenticated";
     public const string AuthUnauthorized = "auth.unauthorized";

--- a/src/Hali.Application/Errors/ErrorCodes.cs
+++ b/src/Hali.Application/Errors/ErrorCodes.cs
@@ -1,0 +1,152 @@
+using System.Collections.Generic;
+
+namespace Hali.Application.Errors;
+
+/// <summary>
+/// Canonical catalog of stable wire error codes used by the Hali API.
+///
+/// Every <see cref="AppException"/> subclass thrown from application/controller
+/// code MUST pass one of these constants as its <c>code</c> argument, never a
+/// bare string literal. This is enforced by
+/// <c>Hali.Tests.Unit.Errors.ErrorCodeCatalogTests</c>.
+///
+/// Codes follow the <c>namespace.reason</c> snake_case convention established
+/// by H1 (#106) and H2 (#134). The <see cref="InternalOnlyCodes"/> set lists
+/// codes that appear in logs/traces for debuggability but are redacted to
+/// <see cref="ServerInternalError"/> before reaching the wire.
+/// </summary>
+public static class ErrorCodes
+{
+    // --- account.* ---
+    public const string AccountNotFound = "account.not_found";
+
+    // --- auth.* ---
+    /// <summary>
+    /// Emitted by the JwtBearer challenge handler for missing/invalid/expired
+    /// tokens on <c>[Authorize]</c> endpoints. No controller throws this
+    /// directly — it is produced by <c>CustomJwtBearerEvents</c>.
+    /// </summary>
+    public const string AuthUnauthenticated = "auth.unauthenticated";
+    public const string AuthUnauthorized = "auth.unauthorized";
+    public const string AuthForbidden = "auth.forbidden";
+    /// <summary>
+    /// Emitted by the JwtBearer forbidden handler when an authenticated caller
+    /// fails a role-gated <c>[Authorize(Roles = ...)]</c> check. Distinct from
+    /// the application-layer <see cref="AuthForbidden"/> (thrown by controller
+    /// code when a permission is denied in the logic path).
+    /// </summary>
+    public const string AuthRoleInsufficient = "auth.role_insufficient";
+    public const string AuthInstitutionIdMissing = "auth.institution_id_missing";
+    public const string AuthOtpInvalid = "auth.otp_invalid";
+    public const string AuthOtpRateLimited = "auth.otp_rate_limited";
+    public const string AuthRefreshTokenInvalid = "auth.refresh_token_invalid";
+
+    // --- cluster.* ---
+    public const string ClusterNotFound = "cluster.not_found";
+
+    // --- dependency.* ---
+    public const string DependencyNlpUnavailable = "dependency.nlp_unavailable";
+    public const string DependencySpatialDerivationFailed = "dependency.spatial_derivation_failed";
+
+    // --- device.* ---
+    public const string DeviceMissingFields = "device.missing_fields";
+    public const string DeviceNotFound = "device.not_found";
+
+    // --- institution.* ---
+    public const string InstitutionMissingFields = "institution.missing_fields";
+
+    // --- invite.* ---
+    public const string InviteAlreadyAccepted = "invite.already_accepted";
+    public const string InviteExpired = "invite.expired";
+    public const string InviteInvalid = "invite.invalid";
+
+    // --- locality.* ---
+    public const string LocalityNotFound = "locality.not_found";
+    public const string LocalityQueryTooLong = "locality.query_too_long";
+    public const string LocalityQueryTooShort = "locality.query_too_short";
+    public const string LocalitySearchRateLimited = "locality.search_rate_limited";
+
+    // --- official_post.* ---
+    public const string OfficialPostInvalidCategory = "official_post.invalid_category";
+    public const string OfficialPostInvalidType = "official_post.invalid_type";
+    public const string OfficialPostMissingFields = "official_post.missing_fields";
+    public const string OfficialPostOutsideJurisdiction = "official_post.outside_jurisdiction";
+
+    // --- participation.* ---
+    public const string ParticipationContextRequiresAffected = "participation.context_requires_affected";
+    public const string ParticipationContextWindowExpired = "participation.context_window_expired";
+    public const string ParticipationRestorationRequiresAffected = "participation.restoration_requires_affected";
+
+    // --- places.* ---
+    public const string PlacesQueryTooLong = "places.query_too_long";
+    public const string PlacesQueryTooShort = "places.query_too_short";
+    public const string PlacesReverseRateLimited = "places.reverse_rate_limited";
+    public const string PlacesSearchRateLimited = "places.search_rate_limited";
+
+    // --- rate_limit.* ---
+    /// <summary>
+    /// Default code for <see cref="RateLimitException"/>. Replaces the pre-H3
+    /// <c>integrity.rate_limited</c> code; the rename is documented in the
+    /// PR for #153.
+    /// </summary>
+    public const string RateLimitExceeded = "rate_limit.exceeded";
+
+    // --- server.* ---
+    /// <summary>
+    /// Generic 500 emitted by <c>ExceptionToApiErrorMapper</c> for unmapped
+    /// exceptions and for typed <see cref="AppException"/>s carrying
+    /// <c>ErrorCategory.Unexpected</c> (internal-invariant violations).
+    /// </summary>
+    public const string ServerInternalError = "server.internal_error";
+
+    // --- signal.* ---
+    public const string SignalDuplicate = "signal.duplicate";
+
+    // --- validation.* ---
+    /// <summary>
+    /// Default code for <see cref="ValidationException"/>. Kept for
+    /// back-compat; call sites should prefer a more specific code
+    /// (e.g. <see cref="ValidationMissingField"/>) whenever the concept is
+    /// discriminable.
+    /// </summary>
+    public const string ValidationFailed = "validation.failed";
+    public const string ValidationDeviceNotFound = "validation.device_not_found";
+    public const string ValidationInvalidCategory = "validation.invalid_category";
+    public const string ValidationInvalidCoordinates = "validation.invalid_coordinates";
+    public const string ValidationInvalidLocationSource = "validation.invalid_location_source";
+    public const string ValidationInvalidParticipationType = "validation.invalid_participation_type";
+    public const string ValidationInvalidRestorationResponse = "validation.invalid_restoration_response";
+    public const string ValidationInvalidSection = "validation.invalid_section";
+    public const string ValidationLocalityUnresolved = "validation.locality_unresolved";
+    public const string ValidationLocationLabelRequired = "validation.location_label_required";
+    public const string ValidationLocationLabelTooLong = "validation.location_label_too_long";
+    public const string ValidationMaxFollowedLocalitiesExceeded = "validation.max_followed_localities_exceeded";
+    public const string ValidationMissingCoordinates = "validation.missing_coordinates";
+    /// <summary>
+    /// Discriminable code for "a required field was absent or blank". Replaces
+    /// generic <see cref="ValidationFailed"/> in missing-field sites so mobile
+    /// can branch on the code rather than parsing messages.
+    /// </summary>
+    public const string ValidationMissingField = "validation.missing_field";
+
+    // --- Internal-only (never on the wire) ---
+    /// <summary>
+    /// Signal reached the clustering pipeline without a derived spatial cell —
+    /// an internal invariant violation, not a client-visible error. Redacted
+    /// by <see cref="Hali.Api.Errors.ExceptionToApiErrorMapper"/> to
+    /// <see cref="ServerInternalError"/> before reaching the response body.
+    /// </summary>
+    public const string ClusteringNoSpatialCell = "clustering.no_spatial_cell";
+
+    /// <summary>
+    /// Codes that are thrown with typed exceptions for internal
+    /// log/trace correlation but must never be surfaced on the HTTP wire.
+    /// The exception mapper redacts these to <see cref="ServerInternalError"/>
+    /// via <see cref="Hali.Domain.Errors.ErrorCategory.Unexpected"/>; the
+    /// OpenAPI <c>ErrorCode</c> enum does not include them.
+    /// </summary>
+    public static readonly IReadOnlySet<string> InternalOnlyCodes = new HashSet<string>
+    {
+        ClusteringNoSpatialCell,
+    };
+}

--- a/src/Hali.Application/Errors/ForbiddenException.cs
+++ b/src/Hali.Application/Errors/ForbiddenException.cs
@@ -6,7 +6,7 @@ namespace Hali.Application.Errors;
 public class ForbiddenException : AppException
 {
     public ForbiddenException(
-        string code = "auth.forbidden",
+        string code = ErrorCodes.AuthForbidden,
         string message = "This action is not permitted.",
         IReadOnlyDictionary<string, object?>? metadata = null)
         : base(code, message, ErrorCategory.Forbidden, metadata: metadata)

--- a/src/Hali.Application/Errors/InvariantViolationException.cs
+++ b/src/Hali.Application/Errors/InvariantViolationException.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using Hali.Domain.Errors;
+
+namespace Hali.Application.Errors;
+
+/// <summary>
+/// Thrown when an internal invariant is broken — a state the code assumes
+/// cannot occur under correct use of the module (e.g. a signal reaching the
+/// clustering pipeline without a derived spatial cell).
+///
+/// Carries <see cref="ErrorCategory.Unexpected"/>. The exception mapper
+/// preserves the original <see cref="AppException.Code"/> in logs/traces for
+/// debuggability but redacts the wire response to
+/// <c>server.internal_error</c> so internal invariant names never reach
+/// clients.
+/// </summary>
+public sealed class InvariantViolationException : AppException
+{
+    public InvariantViolationException(
+        string code,
+        string message,
+        IReadOnlyDictionary<string, object?>? metadata = null,
+        Exception? innerException = null)
+        : base(code, message, ErrorCategory.Unexpected, isTransient: false, metadata: metadata, innerException: innerException)
+    {
+    }
+}

--- a/src/Hali.Application/Errors/RateLimitException.cs
+++ b/src/Hali.Application/Errors/RateLimitException.cs
@@ -6,7 +6,7 @@ namespace Hali.Application.Errors;
 public class RateLimitException : AppException
 {
     public RateLimitException(
-        string code = "integrity.rate_limited",
+        string code = ErrorCodes.RateLimitExceeded,
         string message = "Too many requests. Please try again later.",
         IReadOnlyDictionary<string, object?>? metadata = null)
         : base(code, message, ErrorCategory.RateLimit, isTransient: true, metadata: metadata)

--- a/src/Hali.Application/Errors/UnauthorizedException.cs
+++ b/src/Hali.Application/Errors/UnauthorizedException.cs
@@ -6,7 +6,7 @@ namespace Hali.Application.Errors;
 public class UnauthorizedException : AppException
 {
     public UnauthorizedException(
-        string code = "auth.unauthorized",
+        string code = ErrorCodes.AuthUnauthorized,
         string message = "Authentication is required.",
         IReadOnlyDictionary<string, object?>? metadata = null)
         : base(code, message, ErrorCategory.Unauthorized, metadata: metadata)

--- a/src/Hali.Application/Errors/ValidationException.cs
+++ b/src/Hali.Application/Errors/ValidationException.cs
@@ -10,7 +10,7 @@ public class ValidationException : AppException
 
     public ValidationException(
         string message,
-        string code = "validation.failed",
+        string code = ErrorCodes.ValidationFailed,
         IReadOnlyDictionary<string, string[]>? fieldErrors = null,
         IReadOnlyDictionary<string, object?>? metadata = null)
         : base(code, message, ErrorCategory.Validation, metadata: metadata)

--- a/src/Hali.Application/Notifications/FollowService.cs
+++ b/src/Hali.Application/Notifications/FollowService.cs
@@ -70,7 +70,7 @@ public class FollowService : IFollowService
         if (deduped.Count > MaxFollowedLocalities)
             throw new ValidationException(
                 "You may follow at most 5 localities.",
-                code: "validation.max_followed_localities_exceeded");
+                code: ErrorCodes.ValidationMaxFollowedLocalitiesExceeded);
 
         await _repo.ReplaceFollowsAsync(accountId, deduped, ct);
     }

--- a/src/Hali.Application/Participation/ParticipationService.cs
+++ b/src/Hali.Application/Participation/ParticipationService.cs
@@ -52,12 +52,12 @@ public class ParticipationService : IParticipationService
         Hali.Domain.Entities.Participation.Participation? participation = await _participationRepo.GetByDeviceAsync(clusterId, deviceId, ct);
         if (participation == null || participation.ParticipationType != ParticipationType.Affected)
         {
-            throw new ConflictException("participation.context_requires_affected", "Context requires an active affected participation.");
+            throw new ConflictException(ErrorCodes.ParticipationContextRequiresAffected, "Context requires an active affected participation.");
         }
         DateTime windowExpiry = participation.CreatedAt.AddMinutes(_options.ContextEditWindowMinutes);
         if (DateTime.UtcNow > windowExpiry)
         {
-            throw new ConflictException("participation.context_window_expired", "Context edit window has expired.");
+            throw new ConflictException(ErrorCodes.ParticipationContextWindowExpired, "Context edit window has expired.");
         }
         await _participationRepo.UpdateContextAsync(participation.Id, contextText, ct);
     }
@@ -75,7 +75,7 @@ public class ParticipationService : IParticipationService
         }
         if (current == null || current.ParticipationType != ParticipationType.Affected)
         {
-            throw new ConflictException("participation.restoration_requires_affected", "Restoration response requires an active affected participation.");
+            throw new ConflictException(ErrorCodes.ParticipationRestorationRequiresAffected, "Restoration response requires an active affected participation.");
         }
 
         ParticipationType participationType = response switch
@@ -83,7 +83,7 @@ public class ParticipationService : IParticipationService
             "restored" => ParticipationType.RestorationYes,
             "still_affected" => ParticipationType.RestorationNo,
             "not_sure" => ParticipationType.RestorationUnsure,
-            _ => throw new ValidationException("Invalid restoration response value.", code: "validation.invalid_restoration_response"),
+            _ => throw new ValidationException("Invalid restoration response value.", code: ErrorCodes.ValidationInvalidRestorationResponse),
         };
         await RecordParticipationAsync(clusterId, deviceId, accountId, participationType, null, ct);
         await EvaluateRestorationAsync(clusterId, ct);

--- a/src/Hali.Application/Signals/SignalIngestionService.cs
+++ b/src/Hali.Application/Signals/SignalIngestionService.cs
@@ -51,11 +51,11 @@ public class SignalIngestionService : ISignalIngestionService
         NlpExtractionResultDto result = await _nlp.ExtractAsync(nlpRequest, ct);
         if ((object)result == null)
         {
-            throw new DependencyException("dependency.nlp_unavailable", "NLP extraction service is currently unavailable.");
+            throw new DependencyException(ErrorCodes.DependencyNlpUnavailable, "NLP extraction service is currently unavailable.");
         }
         if (!AllowedCategories.Contains(result.Category))
         {
-            throw new ValidationException("NLP returned an unrecognised category.", code: "validation.invalid_category");
+            throw new ValidationException("NLP returned an unrecognised category.", code: ErrorCodes.ValidationInvalidCategory);
         }
         bool requiresLocationFallback = LocationFallbackPolicy.RequiresFallback(result.Location);
         // C11: normalize the NLP-emitted locationSource through the
@@ -99,29 +99,29 @@ public class SignalIngestionService : ISignalIngestionService
             string idemKey = "idem:signal-submit:" + request.IdempotencyKey;
             if (await _repo.IdempotencyKeyExistsAsync(idemKey, ct))
             {
-                throw new ConflictException("signal.duplicate", "Signal already submitted with this idempotency key.");
+                throw new ConflictException(ErrorCodes.SignalDuplicate, "Signal already submitted with this idempotency key.");
             }
             if (!(await _repo.IsRateLimitAllowedAsync(request.DeviceHash, ct)))
             {
-                throw new RateLimitException("integrity.rate_limited", "Too many signals submitted. Please try again later.");
+                throw new RateLimitException(ErrorCodes.RateLimitExceeded, "Too many signals submitted. Please try again later.");
             }
             if (!AllowedCategories.Contains(request.Category))
             {
-                throw new ValidationException("Invalid signal category.", code: "validation.invalid_category");
+                throw new ValidationException("Invalid signal category.", code: ErrorCodes.ValidationInvalidCategory);
             }
             if (!Enum.TryParse<CivicCategory>(request.Category, ignoreCase: true, out var category))
             {
-                throw new ValidationException("Invalid signal category.", code: "validation.invalid_category");
+                throw new ValidationException("Invalid signal category.", code: ErrorCodes.ValidationInvalidCategory);
             }
             if (!request.Latitude.HasValue || !request.Longitude.HasValue)
             {
-                throw new ValidationException("latitude and longitude are required.", code: "validation.missing_coordinates");
+                throw new ValidationException("latitude and longitude are required.", code: ErrorCodes.ValidationMissingCoordinates);
             }
             double lat = request.Latitude.Value;
             double lng = request.Longitude.Value;
             if (lat < -90 || lat > 90 || lng < -180 || lng > 180)
             {
-                throw new ValidationException("Latitude must be between -90 and 90, longitude between -180 and 180.", code: "validation.invalid_coordinates");
+                throw new ValidationException("Latitude must be between -90 and 90, longitude between -180 and 180.", code: ErrorCodes.ValidationInvalidCoordinates);
             }
 
             string spatialCellId;
@@ -132,13 +132,13 @@ public class SignalIngestionService : ISignalIngestionService
             catch (Exception ex) when (ex is not OperationCanceledException)
             {
                 _logger?.LogWarning("{EventName}", ObservabilityEvents.SignalSpatialFailed);
-                throw new DependencyException("dependency.spatial_derivation_failed", "Unable to derive spatial cell from provided coordinates.", innerException: ex);
+                throw new DependencyException(ErrorCodes.DependencySpatialDerivationFailed, "Unable to derive spatial cell from provided coordinates.", innerException: ex);
             }
 
             if (string.IsNullOrEmpty(spatialCellId))
             {
                 _logger?.LogWarning("{EventName}", ObservabilityEvents.SignalSpatialFailed);
-                throw new DependencyException("dependency.spatial_derivation_failed", "Unable to derive spatial cell from provided coordinates.");
+                throw new DependencyException(ErrorCodes.DependencySpatialDerivationFailed, "Unable to derive spatial cell from provided coordinates.");
             }
 
             _logger?.LogInformation("{EventName} spatialCellId={SpatialCellId}",
@@ -148,7 +148,7 @@ public class SignalIngestionService : ISignalIngestionService
             if (locality is null)
             {
                 _logger?.LogWarning("{EventName}", ObservabilityEvents.SignalLocalityFailed);
-                throw new ValidationException("The provided coordinates do not fall within a known locality.", code: "validation.locality_unresolved");
+                throw new ValidationException("The provided coordinates do not fall within a known locality.", code: ErrorCodes.ValidationLocalityUnresolved);
             }
 
             _logger?.LogInformation("{EventName} localityId={LocalityId}",
@@ -158,7 +158,7 @@ public class SignalIngestionService : ISignalIngestionService
             {
                 throw new ValidationException(
                     $"Location label must not exceed {MaxLocationLabelLength} characters.",
-                    code: "validation.location_label_too_long");
+                    code: ErrorCodes.ValidationLocationLabelTooLong);
             }
 
             // C11: canonical LocationSource allowlist. Unknown values would
@@ -168,7 +168,7 @@ public class SignalIngestionService : ISignalIngestionService
             {
                 throw new ValidationException(
                     "locationSource must be one of: nlp, user_edit, place_search, map_pin.",
-                    code: "validation.invalid_location_source");
+                    code: ErrorCodes.ValidationInvalidLocationSource);
             }
 
             // C11 + C11.1: when the user selected a place from the fallback
@@ -184,7 +184,7 @@ public class SignalIngestionService : ISignalIngestionService
             {
                 throw new ValidationException(
                     $"locationLabel is required when locationSource is {request.LocationSource}.",
-                    code: "validation.location_label_required");
+                    code: ErrorCodes.ValidationLocationLabelRequired);
             }
 
             string temporalType = (AllowedTemporalTypes.Contains(request.TemporalType ?? "") ? request.TemporalType : "episodic_unknown");

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -114,12 +114,18 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
         // participation endpoint validates the request body before looking up
         // the cluster, so a random cluster id is sufficient — the validation
         // path is the only thing exercised.
+        //
+        // We populate `type` with a non-empty value so positional-record model
+        // binding succeeds, then leave `deviceHash` blank so the controller's
+        // in-method guard — not framework-level ModelState validation — is the
+        // first check to fire. That guard is the one whose code migrated
+        // from `validation.failed` to `validation.missing_field`.
         var jwt = MintJwt(Guid.NewGuid());
         using var authed = CreateAuthenticatedClient(jwt);
 
         var response = await authed.PostAsJsonAsync(
             $"/v1/clusters/{Guid.NewGuid()}/participation",
-            new { });
+            new { type = "affected", deviceHash = "", idempotencyKey = "irrelevant-for-pre-validation" });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "validation.missing_field");

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -138,23 +138,32 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
         // rename. The preview endpoint caps anonymous callers at 10/IP/10min;
         // the 11th call is the first to cross the threshold.
         //
-        // Redis state persists across tests in this collection, so clear any
-        // residual preview-rate-limit counter before counting — otherwise the
-        // outcome depends on the order xunit happens to pick.
+        // Redis state persists across tests in this collection. Clear any
+        // residual preview-rate-limit counter before AND after the test, so
+        // (a) this test is deterministic regardless of run order, and
+        // (b) the counter left behind at 11+ does not cause subsequent
+        // preview-using tests to spuriously return 429.
         await ClearPreviewRateLimitKeysAsync();
 
-        HttpResponseMessage? last = null;
-        for (var i = 0; i < 11; i++)
+        try
         {
-            last = await Client.PostAsJsonAsync("/v1/signals/preview", new
+            HttpResponseMessage? last = null;
+            for (var i = 0; i < 11; i++)
             {
-                freeText = $"rate-limit-probe-{i} there is no water in my area",
-            });
-        }
+                last = await Client.PostAsJsonAsync("/v1/signals/preview", new
+                {
+                    freeText = $"rate-limit-probe-{i} there is no water in my area",
+                });
+            }
 
-        Assert.NotNull(last);
-        Assert.Equal(HttpStatusCode.TooManyRequests, last!.StatusCode);
-        AssertErrorEnvelope(await last.Content.ReadFromJsonAsync<JsonElement>(_json), "rate_limit.exceeded");
+            Assert.NotNull(last);
+            Assert.Equal(HttpStatusCode.TooManyRequests, last!.StatusCode);
+            AssertErrorEnvelope(await last.Content.ReadFromJsonAsync<JsonElement>(_json), "rate_limit.exceeded");
+        }
+        finally
+        {
+            await ClearPreviewRateLimitKeysAsync();
+        }
     }
 
     private async Task ClearPreviewRateLimitKeysAsync()

--- a/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
+++ b/tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs
@@ -1,13 +1,16 @@
 using System;
 using System.IdentityModel.Tokens.Jwt;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
 using System.Security.Claims;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Hali.Tests.Integration.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Hali.Tests.Integration.Errors;
@@ -71,10 +74,27 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
     [Fact]
     public async Task ResolveCoordinates_OutOfRange_EmitsStandardErrorEnvelope()
     {
+        // H3 (#153): this path previously emitted the concept-collision code
+        // `locality.invalid_coordinates`. It is now the canonical
+        // `validation.invalid_coordinates` (merged with the parallel
+        // `places.invalid_coordinates` site).
         var response = await Client.GetAsync("/v1/localities/resolve-by-coordinates?latitude=999&longitude=0");
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
-        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "locality.invalid_coordinates");
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "validation.invalid_coordinates");
+    }
+
+    [Fact]
+    public async Task PlacesReverse_OutOfRange_EmitsValidationInvalidCoordinates()
+    {
+        // H3 (#153): proves the `places.invalid_coordinates` rename to the
+        // canonical `validation.invalid_coordinates` (the same wire code now
+        // returned by `/v1/localities/resolve-by-coordinates` for out-of-range
+        // input). Asserts the collision was truly collapsed on the wire.
+        var response = await Client.GetAsync("/v1/places/reverse?latitude=999&longitude=0");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "validation.invalid_coordinates");
     }
 
     [Fact]
@@ -84,6 +104,63 @@ public sealed class StandardizedErrorEnvelopeTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "places.query_too_short");
+    }
+
+    [Fact]
+    public async Task ClusterParticipation_MissingDeviceHash_EmitsValidationMissingField()
+    {
+        // H3 (#153): proves the `validation.failed` -> `validation.missing_field`
+        // rename for discriminable missing-required-field cases. The cluster-
+        // participation endpoint validates the request body before looking up
+        // the cluster, so a random cluster id is sufficient — the validation
+        // path is the only thing exercised.
+        var jwt = MintJwt(Guid.NewGuid());
+        using var authed = CreateAuthenticatedClient(jwt);
+
+        var response = await authed.PostAsJsonAsync(
+            $"/v1/clusters/{Guid.NewGuid()}/participation",
+            new { });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        AssertErrorEnvelope(await response.Content.ReadFromJsonAsync<JsonElement>(_json), "validation.missing_field");
+    }
+
+    [Fact]
+    public async Task SignalsPreview_RateLimited_EmitsRateLimitExceeded()
+    {
+        // H3 (#153): proves the `integrity.rate_limited` -> `rate_limit.exceeded`
+        // rename. The preview endpoint caps anonymous callers at 10/IP/10min;
+        // the 11th call is the first to cross the threshold.
+        //
+        // Redis state persists across tests in this collection, so clear any
+        // residual preview-rate-limit counter before counting — otherwise the
+        // outcome depends on the order xunit happens to pick.
+        await ClearPreviewRateLimitKeysAsync();
+
+        HttpResponseMessage? last = null;
+        for (var i = 0; i < 11; i++)
+        {
+            last = await Client.PostAsJsonAsync("/v1/signals/preview", new
+            {
+                freeText = $"rate-limit-probe-{i} there is no water in my area",
+            });
+        }
+
+        Assert.NotNull(last);
+        Assert.Equal(HttpStatusCode.TooManyRequests, last!.StatusCode);
+        AssertErrorEnvelope(await last.Content.ReadFromJsonAsync<JsonElement>(_json), "rate_limit.exceeded");
+    }
+
+    private async Task ClearPreviewRateLimitKeysAsync()
+    {
+        // Under the WebApplicationFactory TestServer the remote IP is
+        // unset, so SignalsController.Preview builds the key as
+        // `rl:signal-preview:unknown`. Deleting that single key is
+        // sufficient and avoids requiring `allowAdmin` on the Redis
+        // connection just to enumerate matching keys.
+        using var scope = Factory.Services.CreateScope();
+        var mux = scope.ServiceProvider.GetRequiredService<IConnectionMultiplexer>();
+        await mux.GetDatabase().KeyDeleteAsync("rl:signal-preview:unknown");
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/ClusteringServiceTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
+using Hali.Application.Errors;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Signals;
 using Hali.Domain.Enums;
@@ -83,8 +84,12 @@ public class ClusteringServiceTests
         var (svc, repo, h3, civis) = Build();
         var signal = MakeSignal(spatialCellId: null);
 
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => svc.RouteSignalAsync(signal));
-        Assert.Equal("CLUSTERING_NO_SPATIAL_CELL", ex.Message);
+        // H3 (#153): retyped from InvalidOperationException to a typed
+        // InvariantViolationException carrying ErrorCodes.ClusteringNoSpatialCell.
+        // Wire behaviour is unchanged (redacted to server.internal_error by
+        // ExceptionToApiErrorMapper for ErrorCategory.Unexpected).
+        var ex = await Assert.ThrowsAsync<InvariantViolationException>(() => svc.RouteSignalAsync(signal));
+        Assert.Equal(ErrorCodes.ClusteringNoSpatialCell, ex.Code);
 
         h3.DidNotReceive().GetKRingCells(Arg.Any<string>(), Arg.Any<int>());
         await repo.DidNotReceive().FindCandidateClustersAsync(

--- a/tests/Hali.Tests.Unit/Errors/ErrorCodeCatalogTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ErrorCodeCatalogTests.cs
@@ -1,0 +1,332 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using Hali.Application.Errors;
+using Xunit;
+
+namespace Hali.Tests.Unit.Errors;
+
+/// <summary>
+/// H3 (#153) drift-prevention guardrail. These tests fail if any of the
+/// following regress:
+///
+///  1. A constant in <see cref="ErrorCodes"/> stops matching the
+///     <c>namespace.reason</c> snake_case wire convention.
+///  2. A typed <see cref="AppException"/> subclass's constructor default
+///     <c>code</c> value is not present in the catalog.
+///  3. A new <c>throw new XxxException("literal.code", ...)</c> slips into
+///     <c>src/Hali.Api/Controllers/**</c> or <c>src/Hali.Application/**</c>
+///     without going through the catalog.
+///  4. The published <c>ErrorCode</c> enum in <c>02_openapi.yaml</c> drifts
+///     out of parity with the public (non-internal-only) subset of the
+///     catalog.
+///
+/// Rationale: pure reflection cannot introspect string-literal arguments at
+/// a throw site (they become IL operands). A source-file scan is the
+/// strongest practical expression of the "reflection-based guard" the issue
+/// calls for. It reads the <c>src/</c> tree at test time from the solution
+/// root located by walking up from the test assembly's output directory.
+/// </summary>
+public class ErrorCodeCatalogTests
+{
+    private static readonly Regex CodeFormat = new(
+        @"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$",
+        RegexOptions.Compiled);
+
+    private static readonly string[] TypedExceptionNames =
+    {
+        "ValidationException",
+        "NotFoundException",
+        "ConflictException",
+        "UnauthorizedException",
+        "ForbiddenException",
+        "RateLimitException",
+        "DependencyException",
+        "InvariantViolationException",
+    };
+
+    /// <summary>
+    /// Each <c>public const string</c> on <see cref="ErrorCodes"/> must be a
+    /// valid <c>namespace.reason</c> wire code. This catches typos and
+    /// accidental non-snake_case entries before they reach a review.
+    /// </summary>
+    [Fact]
+    public void CatalogConstants_FollowWireFormatConvention()
+    {
+        foreach (var (name, value) in GetCatalogConstants())
+        {
+            Assert.True(
+                CodeFormat.IsMatch(value),
+                $"ErrorCodes.{name} = \"{value}\" does not match the expected \"namespace.reason\" snake_case format.");
+        }
+    }
+
+    /// <summary>
+    /// Default <c>code</c> parameter values baked into exception-class
+    /// constructors must come from the catalog — otherwise a rename in the
+    /// catalog would silently skip a throw site that relies on the default.
+    /// Only checks concrete <see cref="AppException"/> subclasses loaded in
+    /// the Hali.Application assembly.
+    /// </summary>
+    [Fact]
+    public void ExceptionConstructorDefaults_UseCatalogValues()
+    {
+        var catalog = new HashSet<string>(
+            GetCatalogConstants().Select(c => c.value),
+            StringComparer.Ordinal);
+
+        var subclasses = typeof(AppException).Assembly
+            .GetTypes()
+            .Where(t => t.IsClass && !t.IsAbstract && typeof(AppException).IsAssignableFrom(t))
+            .ToList();
+
+        Assert.NotEmpty(subclasses);
+
+        foreach (var type in subclasses)
+        {
+            foreach (var ctor in type.GetConstructors(BindingFlags.Public | BindingFlags.Instance))
+            {
+                foreach (var p in ctor.GetParameters())
+                {
+                    if (p.Name != "code" || p.ParameterType != typeof(string))
+                    {
+                        continue;
+                    }
+
+                    if (!p.HasDefaultValue)
+                    {
+                        continue;
+                    }
+
+                    if (p.DefaultValue is not string defaultCode)
+                    {
+                        continue;
+                    }
+
+                    Assert.True(
+                        catalog.Contains(defaultCode),
+                        $"{type.Name} ctor '{ctor}' has default code \"{defaultCode}\" which is not present in ErrorCodes.");
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Every typed throw in the scoped source directories must pass an
+    /// <see cref="ErrorCodes"/> reference as its code — not a bare string
+    /// literal. This is the guardrail the issue body specifically calls out.
+    /// </summary>
+    [Fact]
+    public void ScopedSources_HaveNoBareStringLiteralCodesInTypedThrows()
+    {
+        var repoRoot = FindRepoRoot();
+        var scopeRoots = new[]
+        {
+            Path.Combine(repoRoot, "src", "Hali.Api", "Controllers"),
+            Path.Combine(repoRoot, "src", "Hali.Application"),
+        };
+
+        var violations = new List<string>();
+
+        foreach (var root in scopeRoots)
+        {
+            Assert.True(Directory.Exists(root), $"Expected scope root not found: {root}");
+
+            foreach (var file in Directory.EnumerateFiles(root, "*.cs", SearchOption.AllDirectories))
+            {
+                // Skip the catalog itself and the exception-class definitions —
+                // those legitimately carry the canonical string literals.
+                var rel = Path.GetRelativePath(repoRoot, file).Replace('\\', '/');
+                if (rel.StartsWith("src/Hali.Application/Errors/", StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
+                var content = File.ReadAllText(file);
+                foreach (var exName in TypedExceptionNames)
+                {
+                    // Match: throw new XxxException(
+                    //           <first-arg>  <- code-position
+                    // where <first-arg> can be either a positional string
+                    // literal or a named argument (`code: "..."` or
+                    // `message: "..."`). We reject the case where a bare
+                    // string literal is passed as the code position
+                    // (positional first arg, or named `code: "..."`).
+                    // ValidationException places `message` first and `code`
+                    // second, so we also look for `code: "literal"`.
+
+                    // Flag: code: "literal"
+                    var namedCode = new Regex(
+                        $@"throw\s+new\s+{Regex.Escape(exName)}\s*\([^;]{{0,1500}}?\bcode\s*:\s*""[^""]+""",
+                        RegexOptions.Multiline | RegexOptions.Singleline);
+                    foreach (Match m in namedCode.Matches(content))
+                    {
+                        violations.Add($"{rel}: bare literal in `code:` named arg -> {Snippet(m.Value)}");
+                    }
+
+                    // Flag: positional first-arg literal for types whose
+                    // first ctor parameter is the code (NotFoundException,
+                    // ConflictException, DependencyException,
+                    // InvariantViolationException).
+                    if (exName is "NotFoundException"
+                        or "ConflictException"
+                        or "DependencyException"
+                        or "InvariantViolationException")
+                    {
+                        var positional = new Regex(
+                            $@"throw\s+new\s+{Regex.Escape(exName)}\s*\(\s*""[^""]+""",
+                            RegexOptions.Multiline | RegexOptions.Singleline);
+                        foreach (Match m in positional.Matches(content))
+                        {
+                            violations.Add($"{rel}: bare literal in positional code arg -> {Snippet(m.Value)}");
+                        }
+                    }
+                }
+            }
+        }
+
+        Assert.True(
+            violations.Count == 0,
+            "Found bare string-literal error codes in scoped source files. "
+            + "All codes must be passed as ErrorCodes.* constants. Violations:\n  - "
+            + string.Join("\n  - ", violations));
+    }
+
+    /// <summary>
+    /// The <c>ErrorCode</c> enum published in <c>02_openapi.yaml</c> must be
+    /// in exact parity with the public (non-internal-only) subset of the
+    /// catalog. Internal-only codes (see <see cref="ErrorCodes.InternalOnlyCodes"/>)
+    /// are redacted by <c>ExceptionToApiErrorMapper</c> and must NOT appear
+    /// on the wire or in the spec.
+    /// </summary>
+    [Fact]
+    public void OpenApiErrorCodeEnum_MatchesCatalogPublicSubset()
+    {
+        var repoRoot = FindRepoRoot();
+        var specPath = Path.Combine(repoRoot, "02_openapi.yaml");
+        Assert.True(File.Exists(specPath), $"02_openapi.yaml not found at {specPath}");
+
+        var specEnum = ReadOpenApiErrorCodeEnum(specPath);
+        Assert.NotEmpty(specEnum);
+
+        var catalogPublic = new HashSet<string>(
+            GetCatalogConstants()
+                .Select(c => c.value)
+                .Where(v => !ErrorCodes.InternalOnlyCodes.Contains(v)),
+            StringComparer.Ordinal);
+
+        var missingFromSpec = catalogPublic.Except(specEnum, StringComparer.Ordinal).OrderBy(s => s).ToList();
+        var missingFromCatalog = specEnum.Except(catalogPublic, StringComparer.Ordinal).OrderBy(s => s).ToList();
+        var leakedInternal = specEnum.Intersect(ErrorCodes.InternalOnlyCodes, StringComparer.Ordinal).OrderBy(s => s).ToList();
+
+        Assert.True(
+            missingFromSpec.Count == 0,
+            "Codes present in ErrorCodes but missing from 02_openapi.yaml:ErrorCode enum:\n  - "
+            + string.Join("\n  - ", missingFromSpec));
+
+        Assert.True(
+            missingFromCatalog.Count == 0,
+            "Codes present in 02_openapi.yaml:ErrorCode enum but missing from ErrorCodes:\n  - "
+            + string.Join("\n  - ", missingFromCatalog));
+
+        Assert.True(
+            leakedInternal.Count == 0,
+            "Internal-only codes must NOT be published in the OpenAPI ErrorCode enum (they are redacted to server.internal_error on the wire):\n  - "
+            + string.Join("\n  - ", leakedInternal));
+    }
+
+    private static IEnumerable<(string name, string value)> GetCatalogConstants()
+    {
+        return typeof(ErrorCodes)
+            .GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
+            .Where(f => f.IsLiteral && !f.IsInitOnly && f.FieldType == typeof(string))
+            .Select(f => (f.Name, (string)f.GetRawConstantValue()!));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null)
+        {
+            if (File.Exists(Path.Combine(dir.FullName, "Hali.sln")))
+            {
+                return dir.FullName;
+            }
+
+            dir = dir.Parent;
+        }
+
+        throw new DirectoryNotFoundException(
+            "Could not locate repo root (Hali.sln) walking up from " + AppContext.BaseDirectory);
+    }
+
+    private static HashSet<string> ReadOpenApiErrorCodeEnum(string specPath)
+    {
+        // The spec file uses a fixed shape for ErrorCode that we can parse
+        // with straightforward line iteration — adding a full YAML parser
+        // dependency just for this would be overkill and slows test startup.
+        var result = new HashSet<string>(StringComparer.Ordinal);
+        var lines = File.ReadAllLines(specPath);
+
+        var inErrorCode = false;
+        var inEnum = false;
+
+        foreach (var raw in lines)
+        {
+            var line = raw.TrimEnd();
+
+            if (!inErrorCode)
+            {
+                if (Regex.IsMatch(line, @"^\s{4}ErrorCode:\s*$"))
+                {
+                    inErrorCode = true;
+                }
+                continue;
+            }
+
+            // A new top-level schema key starts at the same indent (4 spaces)
+            // ending with `:` — that terminates the ErrorCode block.
+            if (Regex.IsMatch(line, @"^\s{4}\S.*:\s*$") && !line.TrimStart().StartsWith('-'))
+            {
+                if (!line.TrimStart().StartsWith("ErrorCode:", StringComparison.Ordinal))
+                {
+                    break;
+                }
+            }
+
+            if (!inEnum)
+            {
+                if (Regex.IsMatch(line, @"^\s{6}enum:\s*$"))
+                {
+                    inEnum = true;
+                }
+                continue;
+            }
+
+            // Enum items are `        - some.code`
+            var m = Regex.Match(line, @"^\s{8}-\s*([A-Za-z0-9_.]+)\s*$");
+            if (m.Success)
+            {
+                result.Add(m.Groups[1].Value);
+                continue;
+            }
+
+            // Anything else at depth <= 6 ends the enum block.
+            if (line.Length > 0 && !line.StartsWith("        ", StringComparison.Ordinal))
+            {
+                break;
+            }
+        }
+
+        return result;
+    }
+
+    private static string Snippet(string value)
+    {
+        value = value.Replace('\n', ' ').Replace('\r', ' ');
+        return value.Length > 160 ? value.Substring(0, 160) + "…" : value;
+    }
+}

--- a/tests/Hali.Tests.Unit/Errors/ErrorCodeCatalogTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ErrorCodeCatalogTests.cs
@@ -149,16 +149,15 @@ public class ErrorCodeCatalogTests
                 foreach (var exName in TypedExceptionNames)
                 {
                     // Match: throw new XxxException(
-                    //           <first-arg>  <- code-position
-                    // where <first-arg> can be either a positional string
-                    // literal or a named argument (`code: "..."` or
-                    // `message: "..."`). We reject the case where a bare
-                    // string literal is passed as the code position
-                    // (positional first arg, or named `code: "..."`).
-                    // ValidationException places `message` first and `code`
-                    // second, so we also look for `code: "literal"`.
+                    //           <first-arg>  <- code-position for most
+                    // where the code value can reach the throw in one of
+                    // three syntactic shapes. Each shape must use an
+                    // ErrorCodes.* reference (or any non-literal expression),
+                    // never a bare string literal.
 
-                    // Flag: code: "literal"
+                    // Shape A: `code: "literal"` — named argument.
+                    // Applies to every exception class that has a `code`
+                    // parameter, regardless of its ordinal position.
                     var namedCode = new Regex(
                         $@"throw\s+new\s+{Regex.Escape(exName)}\s*\([^;]{{0,1500}}?\bcode\s*:\s*""[^""]+""",
                         RegexOptions.Multiline | RegexOptions.Singleline);
@@ -167,19 +166,39 @@ public class ErrorCodeCatalogTests
                         violations.Add($"{rel}: bare literal in `code:` named arg -> {Snippet(m.Value)}");
                     }
 
-                    // Flag: positional first-arg literal for types whose
-                    // first ctor parameter is the code (NotFoundException,
-                    // ConflictException, DependencyException,
-                    // InvariantViolationException).
-                    if (exName is "NotFoundException"
-                        or "ConflictException"
-                        or "DependencyException"
-                        or "InvariantViolationException")
+                    // Shape B: positional first-arg literal. For every
+                    // AppException subclass except ValidationException,
+                    // `code` is the first ctor parameter, so a positional
+                    // call `new XxxException("literal.code", ...)` passes
+                    // the literal as the code. ValidationException is
+                    // excluded here because its ctor is
+                    // `(string message, string code = ..., ...)` and the
+                    // first positional argument is the message — not the
+                    // code. Shape C below covers ValidationException's
+                    // second positional slot.
+                    if (exName != "ValidationException")
                     {
                         var positional = new Regex(
                             $@"throw\s+new\s+{Regex.Escape(exName)}\s*\(\s*""[^""]+""",
                             RegexOptions.Multiline | RegexOptions.Singleline);
                         foreach (Match m in positional.Matches(content))
+                        {
+                            violations.Add($"{rel}: bare literal in positional code arg -> {Snippet(m.Value)}");
+                        }
+                    }
+
+                    // Shape C: ValidationException-specific — positional
+                    // 2nd-arg literal (message first, code second). Matches
+                    // `new ValidationException("msg", "literal.code", ...)`.
+                    if (exName == "ValidationException")
+                    {
+                        // Use \\"[^\"]*\\"  for the first (message) slot,
+                        // then a comma, then a literal in the second slot.
+                        // Allow whitespace/newlines between slots.
+                        var validationPositional = new Regex(
+                            $@"throw\s+new\s+ValidationException\s*\(\s*""[^""]*""\s*,\s*""[^""]+""",
+                            RegexOptions.Multiline | RegexOptions.Singleline);
+                        foreach (Match m in validationPositional.Matches(content))
                         {
                             violations.Add($"{rel}: bare literal in positional code arg -> {Snippet(m.Value)}");
                         }
@@ -306,9 +325,13 @@ public class ErrorCodeCatalogTests
                 continue;
             }
 
-            // Enum items are `        - some.code`
-            var m = Regex.Match(line, @"^\s{8}-\s*([A-Za-z0-9_.]+)\s*$");
-            if (m.Success)
+            // Enum items are `        - some.code`. Accept any non-whitespace
+            // token on the value side and then validate against the canonical
+            // wire-code format, so the parity test proves both that the spec's
+            // enum items are discovered AND that they conform to the
+            // `namespace.reason` snake_case convention.
+            var m = Regex.Match(line, @"^\s{8}-\s*(\S+)\s*$");
+            if (m.Success && CodeFormat.IsMatch(m.Groups[1].Value))
             {
                 result.Add(m.Groups[1].Value);
                 continue;

--- a/tests/Hali.Tests.Unit/Errors/ExceptionHandlingMiddlewareTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ExceptionHandlingMiddlewareTests.cs
@@ -126,7 +126,9 @@ public class ExceptionHandlingMiddlewareTests
 
         Assert.Equal(429, context.Response.StatusCode);
         var doc = await ReadResponseBody(context);
-        Assert.Equal("integrity.rate_limited", doc.RootElement.GetProperty("error").GetProperty("code").GetString());
+        // H3 (#153): default RateLimitException code renamed from
+        // `integrity.rate_limited` to `rate_limit.exceeded`.
+        Assert.Equal(ErrorCodes.RateLimitExceeded, doc.RootElement.GetProperty("error").GetProperty("code").GetString());
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Errors/ExceptionToApiErrorMapperTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ExceptionToApiErrorMapperTests.cs
@@ -62,7 +62,9 @@ public class ExceptionToApiErrorMapperTests
         var ex = new RateLimitException();
         var result = _mapper.Map(ex);
         Assert.Equal(429, result.StatusCode);
-        Assert.Equal("integrity.rate_limited", result.Code);
+        // H3 (#153): default RateLimitException code renamed from
+        // `integrity.rate_limited` to `rate_limit.exceeded`.
+        Assert.Equal(ErrorCodes.RateLimitExceeded, result.Code);
         Assert.Equal(LogLevel.Warning, result.LogLevel);
     }
 

--- a/tests/Hali.Tests.Unit/Errors/ExceptionToApiErrorMapperTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ExceptionToApiErrorMapperTests.cs
@@ -119,4 +119,29 @@ public class ExceptionToApiErrorMapperTests
         Assert.Equal("auth.unauthorized", result.Code);
         Assert.Equal(LogLevel.Warning, result.LogLevel);
     }
+
+    [Fact]
+    public void Map_InvariantViolationException_RedactsInternalCodeOnTheWire()
+    {
+        // H3 (#153): typed AppException carrying ErrorCategory.Unexpected
+        // (internal invariant violation) MUST be redacted on the wire to
+        // server.internal_error — the typed Code is a log/trace identifier
+        // only and must never leak the internal invariant name (e.g.
+        // clustering.no_spatial_cell) to clients. This is security-sensitive
+        // and the catch-all unknown-exception path does the same thing
+        // (Map_UnknownException_Returns500WithSafeMessage above); this test
+        // pins the typed-exception path specifically so regressions here
+        // can't be masked by that one.
+        var ex = new InvariantViolationException(
+            ErrorCodes.ClusteringNoSpatialCell,
+            "Signal reached clustering without spatial cell.");
+
+        var result = _mapper.Map(ex);
+
+        Assert.Equal(500, result.StatusCode);
+        Assert.Equal(ErrorCodes.ServerInternalError, result.Code);
+        Assert.NotEqual(ErrorCodes.ClusteringNoSpatialCell, result.Code);
+        Assert.Equal("An unexpected error occurred.", result.Message);
+        Assert.Equal(LogLevel.Error, result.LogLevel);
+    }
 }

--- a/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/PlacesControllerTests.cs
@@ -184,7 +184,10 @@ public class PlacesControllerTests
 
         var ex = await Assert.ThrowsAsync<ValidationException>(
             () => controller.Reverse(lat, lng, CancellationToken.None));
-        Assert.Equal("places.invalid_coordinates", ex.Code);
+        // H3 (#153): `places.invalid_coordinates` collapsed to the canonical
+        // `validation.invalid_coordinates` alongside the parallel
+        // `locality.invalid_coordinates` site.
+        Assert.Equal(ErrorCodes.ValidationInvalidCoordinates, ex.Code);
     }
 
     [Fact]
@@ -196,7 +199,9 @@ public class PlacesControllerTests
         PlacesController controller = CreateController();
         var ex = await Assert.ThrowsAsync<NotFoundException>(
             () => controller.Reverse(-1.3, 36.8, CancellationToken.None));
-        Assert.Equal("places.locality_not_found", ex.Code);
+        // H3 (#153): `places.locality_not_found` collapsed to the canonical
+        // `locality.not_found` (same concept as the locality-resolve endpoint).
+        Assert.Equal(ErrorCodes.LocalityNotFound, ex.Code);
         await _geocoding.DidNotReceive().ReverseGeocodeAsync(Arg.Any<double>(), Arg.Any<double>(), Arg.Any<CancellationToken>());
     }
 

--- a/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/SignalIngestionServiceTests.cs
@@ -236,7 +236,8 @@ public class SignalIngestionServiceTests
         _repo.IsRateLimitAllowedAsync(Arg.Any<string>(), Arg.Any<CancellationToken>()).Returns(false);
         SignalIngestionService svc = CreateService();
         var ex = await Assert.ThrowsAsync<RateLimitException>(() => svc.SubmitAsync(MakeSubmitRequest(), null, null));
-        Assert.Equal("integrity.rate_limited", ex.Code);
+        // H3 (#153): renamed from `integrity.rate_limited`.
+        Assert.Equal(ErrorCodes.RateLimitExceeded, ex.Code);
     }
 
     [Fact]


### PR DESCRIPTION
## Problem

After H1 (#106) and H2 (#134, #148, #151), every error on the wire uses the canonical `ErrorResponse` envelope with a `namespace.reason` `code`. But the code layer itself was left untouched: 40+ magic-string literals sprinkled across controllers and services, no catalog, no compile-time typo guard, no OpenAPI enum, and several concept collisions that H3 was meant to resolve (PR #134 explicitly deferred the catalog to H3). Closes #153.

## Root cause

H1 delivered the typed-exception model and envelope shape; H2 unified the wire. Neither touched the identifier layer. Codes are passed as strings at each throw site, so typos compile, renames silently drift, and mobile has no source of truth to match against.

## What changed

### 1. Canonical catalog
`src/Hali.Application/Errors/ErrorCodes.cs` — a `public static class` with a `public const string` for every code in use, organized by namespace and documented. Includes a small `InternalOnlyCodes` set for codes that exist in logs/traces but are redacted before the wire.

### 2. Magic-string replacement across scope
Every `throw new XxxException(...)` in `src/Hali.Api/Controllers/**` and `src/Hali.Application/**` now passes an `ErrorCodes.*` constant. Exception-class constructor defaults (`ValidationException`, `UnauthorizedException`, `ForbiddenException`, `RateLimitException`) reference the catalog as well. Local coherence: `ExceptionToApiErrorMapper.cs` and the `Program.cs` JwtBearer 401/403 handlers were also migrated since they emit wire codes.

### 3. Collision resolution
Three concept collisions resolved to one code each; see table below.

### 4. `integrity.rate_limited` rename
`RateLimitException` default and the handful of explicit call sites moved to `rate_limit.exceeded`. The `integrity.*` namespace had only this one code and it was semantically mislabelled.

### 5. `validation.failed` → `validation.missing_field`
Missing-required-field sites in `ClustersController` (5) and `SignalsController` (3, included for local coherence — same pattern, same fix, adjacent code) now emit `validation.missing_field` with a discriminable code, preserving the existing `fieldErrors` payload. `validation.failed` remains as the `ValidationException` default for less-specific cases.

### 6. `CLUSTERING_NO_SPATIAL_CELL` retype
Was a bare `throw new InvalidOperationException("CLUSTERING_NO_SPATIAL_CELL")` at `src/Hali.Application/Clusters/ClusteringService.cs:40`, deferred from PR #134. Now a typed `InvariantViolationException(ErrorCodes.ClusteringNoSpatialCell, ...)` carrying `ErrorCategory.Unexpected`.

**Deliberate wire-behaviour decision:** `ExceptionToApiErrorMapper` now explicitly handles `ErrorCategory.Unexpected` by redacting to `server.internal_error` on the wire (the same response as the pre-H3 catch-all fallback). The internal code `clustering.no_spatial_cell` is retained for logs/traces only and is listed in `ErrorCodes.InternalOnlyCodes` — the drift-guard test enforces that it must NOT appear in the OpenAPI enum. Net wire change: none.

## Renamed / deduplicated wire codes

| Old code | New code | Where (was -> is) | Why |
|---|---|---|---|
| `locality.invalid_coordinates` | `validation.invalid_coordinates` | `LocalitiesController.ResolveByCoordinates` | Collision: three codes for the same concept |
| `places.invalid_coordinates` | `validation.invalid_coordinates` | `PlacesController.Reverse` | Same collision |
| `places.locality_not_found` | `locality.not_found` | `PlacesController.Reverse` | Same concept as the locality-resolve path |
| `integrity.rate_limited` | `rate_limit.exceeded` | `RateLimitException` default; `SignalsController.Preview`; `SignalIngestionService.SubmitAsync` | `integrity.*` had only this one code; `rate_limit.*` is the correct namespace |
| `validation.failed` (missing-field sites) | `validation.missing_field` | `ClustersController.RecordParticipation`, `AddContext`, `RecordRestorationResponse`; `SignalsController.Preview`, `Submit` | Discriminable — mobile can now branch on the code instead of parsing message text. `fieldErrors` payload preserved. |

`validation.failed` is NOT removed — it remains as the `ValidationException` default for cases that are not a missing-field.

### Internal-only (never on the wire)
| Code | Used where | Wire response |
|---|---|---|
| `clustering.no_spatial_cell` | `ClusteringService.RouteSignalAsync` (invariant guard) | Redacted to `server.internal_error` by `ExceptionToApiErrorMapper` for `ErrorCategory.Unexpected` |

## OpenAPI contract changes

- Adds a new named `ErrorCode` string schema at `#/components/schemas/ErrorCode` with a full `enum` of all wire-visible codes. Internal-only codes are excluded from the enum.
- `ErrorResponse.properties.error.properties.code` now references `#/components/schemas/ErrorCode` (was untyped `{ type: string }`).
- Description text updated to note the `auth.role_insufficient` code (framework-403 path, already shipping since #151), document the new `ErrorCode` surface, and remove the stale PR reference.

## Tests added / updated

### New
- `tests/Hali.Tests.Unit/Errors/ErrorCodeCatalogTests.cs` — four `[Fact]`s that fail if drift reappears:
  1. Every `ErrorCodes` constant matches the `namespace.reason` snake_case regex.
  2. Every `AppException` subclass's ctor `code`-parameter default is present in the catalog (reflection).
  3. No bare string-literal codes remain in typed throws across the scoped source dirs (source-file scan — the strongest practical expression of the issue's "reflection-based" ask, since IL operands are not introspectable).
  4. OpenAPI `ErrorCode` enum is in exact parity with the catalog's public (non-internal-only) subset.

### Extended
- `tests/Hali.Tests.Integration/Errors/StandardizedErrorEnvelopeTests.cs` — one assertion per renamed/deduplicated wire pair that is observable end-to-end in the test environment:
  - `ResolveCoordinates_OutOfRange` asserts `validation.invalid_coordinates` (was `locality.invalid_coordinates`).
  - `PlacesReverse_OutOfRange_EmitsValidationInvalidCoordinates` — new; proves the `places.invalid_coordinates` collapse.
  - `ClusterParticipation_MissingDeviceHash_EmitsValidationMissingField` — new; proves `validation.failed` → `validation.missing_field`.
  - `SignalsPreview_RateLimited_EmitsRateLimitExceeded` — new; proves `integrity.rate_limited` → `rate_limit.exceeded`.

  The `places.locality_not_found` → `locality.not_found` rename is asserted by the existing `PlacesControllerTests.Reverse_PointOutsideKnownLocality_ThrowsNotFoundException` unit test (updated); the fake locality repository always returns a non-null locality so this specific wire path is not reachable from integration without infra changes that are out of scope.

### Existing tests updated for renamed codes
- `ExceptionToApiErrorMapperTests` — RateLimit default.
- `ExceptionHandlingMiddlewareTests` — RateLimit envelope code.
- `SignalIngestionServiceTests` — rate-limit Code assertion.
- `PlacesControllerTests` — invalid-coords + no-locality Code assertions.
- `ClusteringServiceTests.RouteSignal_WhenSpatialCellIdIsNull_Throws` — now asserts `InvariantViolationException` + `ErrorCodes.ClusteringNoSpatialCell`.

## Out of scope (per issue body)

- Mobile-side discriminated `ErrorCode` union — tracked as #154.
- Localization / i18n of `message` text.
- Rate-limiting behaviour changes beyond the code-name normalization.
- Auto-generating the mobile enum from OpenAPI.

## Risk assessment

**Breaking wire changes:** yes, by design. Any client that matched on `integrity.rate_limited`, `locality.invalid_coordinates`, `places.invalid_coordinates`, `places.locality_not_found`, or `validation.failed` in `/v1/clusters/*` or `/v1/signals/*` request-validation paths will need to update.

**Mitigation:** The mobile parser fix (#152, merged to develop) ensures the mobile client now reads `error.code` from the canonical envelope but does not yet discriminate on specific code values (that's #154). So the rename is observable end-to-end but does not break any existing mobile branch. No other known consumers.

**Internal impact:** zero wire change for `CLUSTERING_NO_SPATIAL_CELL`; the typed `InvariantViolationException` preserves the internal code for debuggability but the mapper redacts `ErrorCategory.Unexpected` to `server.internal_error`.

**Test coverage:** Unit suite: 357 passed, 0 failed. Format: clean on all modified files. Integration suite runs in CI (requires Postgres + Redis).

## Follow-up notes

- #154 (mobile `ErrorCode` union) can now consume the OpenAPI enum or a manual mirror.
- `locality.not_found` wire path via `/v1/places/reverse` has a coverage gap in integration tests because the fake locality lookup always returns a non-null match; enforced at the unit-test layer instead. Closing this would require either a configurable fake or a real locality-seed strategy — not in scope for H3.
- Pre-existing whitespace drift in `tests/Hali.Tests.Integration/Infrastructure/{IntegrationTestBase.cs,TestConstants.cs}` and `Participation/ParticipationIntegrationTests.cs` — left alone per PR scope discipline; can be swept in a dedicated formatting pass.

## Test plan

- [x] `dotnet build Hali.sln` — 0 errors
- [x] `dotnet test tests/Hali.Tests.Unit/Hali.Tests.Unit.csproj` — 357 passed, 0 failed
- [x] `dotnet format` clean on all modified files
- [ ] Integration tests pass in CI
- [ ] OpenAPI Dredd / contract hooks pass in CI
- [ ] Copilot review comments resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)