### PR TITLE
[Issue #154] Add typed mobile ErrorCode support

### DIFF
--- a/apps/citizen-mobile/__tests__/api/errorCodes.test.ts
+++ b/apps/citizen-mobile/__tests__/api/errorCodes.test.ts
@@ -1,0 +1,151 @@
+// apps/citizen-mobile/__tests__/api/errorCodes.test.ts
+//
+// Type-guard + parser-integration tests for the mobile ErrorCode
+// discriminated union introduced by issue #154.
+//
+// Two contracts under test:
+//
+//   1. `isKnownErrorCode` recognises the wire-visible backend codes
+//      mirrored in `ERROR_CODES`, and rejects everything else
+//      (mobile-side sentinels, unknown future codes, non-strings).
+//
+//   2. `buildApiError` preserves the verbatim `code` string from the
+//      canonical envelope, so unknown future backend codes still flow
+//      end-to-end at runtime — the type's `(string & {})` escape hatch
+//      is not a runtime lie.
+
+import {
+  ERROR_CODES,
+  isKnownErrorCode,
+  type ErrorCode,
+} from '../../src/types/api';
+import { buildApiError } from '../../src/api/client';
+
+describe('isKnownErrorCode — known wire codes', () => {
+  it.each(Object.values(ERROR_CODES))(
+    'recognises %s as a known ErrorCode',
+    (code) => {
+      expect(isKnownErrorCode(code)).toBe(true);
+    },
+  );
+});
+
+describe('isKnownErrorCode — client-side sentinels (NOT known wire codes)', () => {
+  it.each([
+    'unknown_error',
+    'network_error',
+    'no_refresh_token',
+    'session_expired',
+  ])('rejects mobile sentinel %s', (sentinel) => {
+    expect(isKnownErrorCode(sentinel)).toBe(false);
+  });
+});
+
+describe('isKnownErrorCode — unknown / future backend codes', () => {
+  it('rejects an unknown backend code (forward compatibility)', () => {
+    // A future backend release might emit `quota.daily_exceeded` before the
+    // mobile mirror catches up. The runtime must still see the verbatim
+    // string, but the guard must report it as unknown so callers route
+    // through their generic fallback path.
+    expect(isKnownErrorCode('quota.daily_exceeded')).toBe(false);
+  });
+
+  it('rejects a code that almost matches but has a typo', () => {
+    expect(isKnownErrorCode('rate_limit.exceededd')).toBe(false);
+    expect(isKnownErrorCode('signal.duplicates')).toBe(false);
+  });
+});
+
+describe('isKnownErrorCode — malformed / non-string values', () => {
+  it.each<[string, unknown]>([
+    ['undefined', undefined],
+    ['null', null],
+    ['number', 429],
+    ['boolean true', true],
+    ['boolean false', false],
+    ['empty string', ''],
+    ['object', { code: 'rate_limit.exceeded' }],
+    ['array', ['rate_limit.exceeded']],
+  ])('rejects %s', (_label, value) => {
+    expect(isKnownErrorCode(value)).toBe(false);
+  });
+});
+
+describe('buildApiError + isKnownErrorCode — parser integration', () => {
+  it('preserves a known canonical code; guard recognises it', () => {
+    const result = buildApiError(429, {
+      error: {
+        code: 'rate_limit.exceeded',
+        message: 'Slow down.',
+        traceId: '00-trace-1',
+      },
+    });
+
+    expect(result.code).toBe('rate_limit.exceeded');
+    expect(isKnownErrorCode(result.code)).toBe(true);
+
+    // Narrowing flow that downstream call sites use.
+    if (isKnownErrorCode(result.code)) {
+      // After narrowing, comparison against a constant is valid.
+      const isRateLimit: boolean =
+        result.code === ERROR_CODES.RATE_LIMIT_EXCEEDED;
+      expect(isRateLimit).toBe(true);
+    }
+  });
+
+  it('preserves an unknown future backend code verbatim; guard rejects it', () => {
+    const result = buildApiError(400, {
+      error: {
+        code: 'quota.daily_exceeded',
+        message: 'Future code the app does not yet model.',
+      },
+    });
+
+    // Runtime truth: the verbatim string survives the parser.
+    expect(result.code).toBe('quota.daily_exceeded');
+    // Type safety: the guard refuses to narrow.
+    expect(isKnownErrorCode(result.code)).toBe(false);
+  });
+
+  it('regression (issue 152) — canonical envelope still carries message + traceId + details', () => {
+    const result = buildApiError(400, {
+      error: {
+        code: 'validation.failed',
+        message: 'Request is invalid.',
+        details: { fields: { freeText: ['Required.'] } },
+        traceId: '00-trace-regress',
+      },
+    });
+
+    expect(result).toEqual({
+      status: 400,
+      code: 'validation.failed',
+      message: 'Request is invalid.',
+      details: { fields: { freeText: ['Required.'] } },
+      traceId: '00-trace-regress',
+    });
+    expect(isKnownErrorCode(result.code)).toBe(true);
+  });
+
+  it('non-string code in envelope degrades to unknown_error sentinel; guard rejects', () => {
+    const result = buildApiError(500, {
+      error: { code: 42, message: 'Numeric code is malformed.' },
+    });
+
+    // Non-string `code` is treated as absent; parser falls back to its
+    // own sentinel — which is intentionally NOT a known wire code.
+    expect(result.code).toBe('unknown_error');
+    expect(isKnownErrorCode(result.code)).toBe(false);
+  });
+});
+
+describe('ErrorCode union — compile-time exhaustiveness aid', () => {
+  it('every ERROR_CODES value is a member of the ErrorCode type', () => {
+    // This runs at runtime but the assignment exists to lock in the
+    // structural relationship: if a future edit accidentally widens
+    // ERROR_CODES beyond the union, `tsc --noEmit` will fail here too.
+    const allValues: ErrorCode[] = Object.values(ERROR_CODES);
+    expect(allValues.length).toBeGreaterThan(0);
+    expect(new Set(allValues).size).toBe(allValues.length);
+  });
+});

--- a/apps/citizen-mobile/__tests__/api/openapiErrorCodeParity.test.ts
+++ b/apps/citizen-mobile/__tests__/api/openapiErrorCodeParity.test.ts
@@ -1,0 +1,118 @@
+// apps/citizen-mobile/__tests__/api/openapiErrorCodeParity.test.ts
+//
+// Drift guard: the mobile `ERROR_CODES` mirror in
+// `apps/citizen-mobile/src/types/api.ts` MUST equal the canonical
+// `ErrorCode` enum published in `02_openapi.yaml#/components/schemas/ErrorCode`.
+//
+// The server-side catalog (`src/Hali.Application/Errors/ErrorCodes.cs`) is
+// the source of truth; the OpenAPI enum is the wire-visible subset; this
+// mirror is the mobile-visible subset. By construction all three should
+// be identical for wire-visible codes — the matching backend test
+// (`ErrorCodeCatalogTests`) enforces server↔OpenAPI parity, and this
+// test enforces mobile↔OpenAPI parity, transitively closing the loop.
+//
+// Implementation note: this test reads `02_openapi.yaml` from the repo
+// root with a tiny line-based scanner instead of pulling in a full YAML
+// parser. The relevant block is a single named enum with a fixed shape,
+// so a 15-line scanner is the lowest-friction approach.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import { ERROR_CODES } from '../../src/types/api';
+
+/**
+ * Extract the string values listed under the named `ErrorCode:` schema
+ * in `02_openapi.yaml`. The block looks like:
+ *
+ *     ErrorCode:
+ *       type: string
+ *       description: |
+ *         …
+ *       enum:
+ *         - account.not_found
+ *         - auth.forbidden
+ *         …
+ *
+ *     ErrorResponse:
+ *
+ * Scanning rules:
+ *   1. Find the line `    ErrorCode:` (4-space indent under `schemas:`).
+ *   2. Then find the `enum:` line under it.
+ *   3. Collect each subsequent `- value` line until indentation drops
+ *      back to the parent schema column (next sibling schema starts).
+ */
+function readOpenApiErrorCodes(): string[] {
+  const yamlPath = path.resolve(__dirname, '../../../../02_openapi.yaml');
+  const lines = fs.readFileSync(yamlPath, 'utf8').split('\n');
+
+  const ERROR_CODE_HEADER = /^    ErrorCode:\s*$/;
+  const ENUM_LINE = /^      enum:\s*$/;
+  const ENUM_ITEM = /^        - (\S+)\s*$/;
+  const NEXT_SIBLING_SCHEMA = /^    \S/;
+
+  let i = 0;
+  while (i < lines.length && !ERROR_CODE_HEADER.test(lines[i])) i++;
+  if (i === lines.length) {
+    throw new Error(
+      'Could not locate `    ErrorCode:` block in 02_openapi.yaml — ' +
+        'either the schema was renamed or its indentation changed. ' +
+        'Update the scanner in openapiErrorCodeParity.test.ts.',
+    );
+  }
+  i++;
+
+  while (i < lines.length && !ENUM_LINE.test(lines[i])) {
+    if (NEXT_SIBLING_SCHEMA.test(lines[i])) {
+      throw new Error(
+        'ErrorCode schema has no `enum:` block — OpenAPI structure changed.',
+      );
+    }
+    i++;
+  }
+  i++;
+
+  const codes: string[] = [];
+  while (i < lines.length) {
+    const m = ENUM_ITEM.exec(lines[i]);
+    if (m) {
+      codes.push(m[1]);
+      i++;
+      continue;
+    }
+    if (lines[i].trim() === '') {
+      i++;
+      continue;
+    }
+    // Reached the next sibling schema (or any line at parent indent).
+    break;
+  }
+
+  if (codes.length === 0) {
+    throw new Error('OpenAPI ErrorCode enum scanner returned zero entries.');
+  }
+  return codes;
+}
+
+describe('OpenAPI ↔ mobile ErrorCode parity', () => {
+  // Use plain `string[]` for both sides — Set comparison is symmetric and
+  // ErrorCode's literal-union type would otherwise reject the OpenAPI
+  // strings (which are typed `string`, not `ErrorCode`, by construction).
+  const openApiCodes: string[] = readOpenApiErrorCodes();
+  const mobileCodes: string[] = Object.values(ERROR_CODES);
+
+  it('every OpenAPI ErrorCode value is mirrored in mobile ERROR_CODES', () => {
+    const mobileSet = new Set<string>(mobileCodes);
+    const missing = openApiCodes.filter((c) => !mobileSet.has(c));
+    expect(missing).toEqual([]);
+  });
+
+  it('every mobile ERROR_CODES value exists in the OpenAPI ErrorCode enum', () => {
+    const openApiSet = new Set<string>(openApiCodes);
+    const extra = mobileCodes.filter((c) => !openApiSet.has(c));
+    expect(extra).toEqual([]);
+  });
+
+  it('mobile mirror is exactly the same size as the OpenAPI enum', () => {
+    expect(mobileCodes.length).toBe(openApiCodes.length);
+  });
+});

--- a/apps/citizen-mobile/app/(app)/compose/submit.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/submit.tsx
@@ -19,6 +19,7 @@ import type {
   SignalSubmitRequest,
   SignalPreviewResponse,
 } from '../../../src/types/api';
+import { ERROR_CODES, isKnownErrorCode } from '../../../src/types/api';
 
 type ScreenState = 'idle' | 'loading' | 'error';
 
@@ -132,6 +133,24 @@ function SubmitScreenContent({
     if (result.ok) { onSuccess(result.value.clusterId); return; }
     setScreenState('error');
     if (result.error.status === 409) { onSuccess(undefined); return; }
+
+    // Discriminable validation messaging — branch on the typed wire code
+    // first so the user sees a specific call-to-action for the two
+    // composer-affecting validation failures, then fall back to status
+    // and finally the server message.
+    if (isKnownErrorCode(result.error.code)) {
+      switch (result.error.code) {
+        case ERROR_CODES.VALIDATION_LOCALITY_UNRESOLVED:
+          setErrorMessage('We could not match this report to a ward. Tap back and refine the location.');
+          return;
+        case ERROR_CODES.VALIDATION_INVALID_CATEGORY:
+          setErrorMessage('The selected category is not recognised. Tap back and choose a different one.');
+          return;
+        case ERROR_CODES.RATE_LIMIT_EXCEEDED:
+          setErrorMessage('Too many signals submitted. Please wait a moment and try again.');
+          return;
+      }
+    }
     if (result.error.status === 429) {
       setErrorMessage('Too many signals submitted. Please wait a moment and try again.');
     } else if (result.error.status === 422) {

--- a/apps/citizen-mobile/app/(app)/compose/text.tsx
+++ b/apps/citizen-mobile/app/(app)/compose/text.tsx
@@ -14,6 +14,7 @@ import { previewSignal } from '../../../src/api/signals';
 import { useComposerContext } from '../../../src/context/ComposerContext';
 import { Button } from '../../../src/components/common/Button';
 import { SIGNAL_TEXT_MAX_LENGTH } from '../../../src/config/constants';
+import { ERROR_CODES, isKnownErrorCode } from '../../../src/types/api';
 import {
   Colors, FontFamily, FontSize, Spacing, Radius, ScreenPaddingH,
 } from '../../../src/theme';
@@ -70,7 +71,14 @@ export default function ComposerTextScreen(): React.ReactElement {
       return;
     }
     setScreenState('error');
-    if (result.error.status === 429 || result.error.code === 'rate_limited') {
+    // Branch on the canonical wire code first; status 429 stays as a
+    // belt-and-braces fallback for any rate-limited response that does
+    // not carry the typed code.
+    const isRateLimited =
+      (isKnownErrorCode(result.error.code) &&
+        result.error.code === ERROR_CODES.RATE_LIMIT_EXCEEDED) ||
+      result.error.status === 429;
+    if (isRateLimited) {
       setErrorMessage('Too many preview requests. Please wait a moment and try again.');
     } else if (result.error.status === 502) {
       setErrorMessage('The signal analysis service is temporarily unavailable. Please try again shortly.');

--- a/apps/citizen-mobile/app/(modals)/restoration/[clusterId].tsx
+++ b/apps/citizen-mobile/app/(modals)/restoration/[clusterId].tsx
@@ -37,6 +37,7 @@ import * as Device from 'expo-device';
 import * as Application from 'expo-application';
 import { submitRestorationResponse } from '../../../src/api/clusters';
 import type { RestorationResponseValue } from '../../../src/types/api';
+import { ERROR_CODES, isKnownErrorCode } from '../../../src/types/api';
 
 type ScreenState = 'idle' | 'loading' | 'error';
 
@@ -136,7 +137,10 @@ export default function RestorationPromptModal(): React.ReactElement {
 
       setScreenState('error');
       setPendingKey(null);
-      if (result.error.code === 'invalid_restoration_response') {
+      if (
+        isKnownErrorCode(result.error.code) &&
+        result.error.code === ERROR_CODES.VALIDATION_INVALID_RESTORATION_RESPONSE
+      ) {
         setErrorMessage(
           'That response is no longer valid. Please try again.',
         );

--- a/apps/citizen-mobile/src/types/api.ts
+++ b/apps/citizen-mobile/src/types/api.ts
@@ -1,6 +1,159 @@
 // ─── Result + Error (canonical location — do not redeclare elsewhere) ───────
 
 /**
+ * Canonical wire-visible backend error codes.
+ *
+ * Mirrors `02_openapi.yaml#/components/schemas/ErrorCode` exactly. The
+ * server-side source of truth is `src/Hali.Application/Errors/ErrorCodes.cs`.
+ * Drift between this mirror and the OpenAPI enum is enforced by
+ * `apps/citizen-mobile/__tests__/api/openapiErrorCodeParity.test.ts`.
+ *
+ * Internal-only codes used by the server for log/trace correlation
+ * (e.g. `clustering.no_spatial_cell`) are intentionally NOT listed —
+ * the backend redacts those to `server.internal_error` on the wire.
+ *
+ * Adding a new entry: copy the wire literal from the OpenAPI enum and
+ * pick a SCREAMING_SNAKE_CASE constant key. Keep the lists alphabetised
+ * by wire value within their grouping so diffs are reviewable.
+ */
+export const ERROR_CODES = {
+  // account.*
+  ACCOUNT_NOT_FOUND: 'account.not_found',
+
+  // auth.*
+  AUTH_FORBIDDEN: 'auth.forbidden',
+  AUTH_INSTITUTION_ID_MISSING: 'auth.institution_id_missing',
+  AUTH_OTP_INVALID: 'auth.otp_invalid',
+  AUTH_OTP_RATE_LIMITED: 'auth.otp_rate_limited',
+  AUTH_REFRESH_TOKEN_INVALID: 'auth.refresh_token_invalid',
+  AUTH_ROLE_INSUFFICIENT: 'auth.role_insufficient',
+  AUTH_UNAUTHENTICATED: 'auth.unauthenticated',
+  AUTH_UNAUTHORIZED: 'auth.unauthorized',
+
+  // cluster.*
+  CLUSTER_NOT_FOUND: 'cluster.not_found',
+
+  // dependency.*
+  DEPENDENCY_NLP_UNAVAILABLE: 'dependency.nlp_unavailable',
+  DEPENDENCY_SPATIAL_DERIVATION_FAILED: 'dependency.spatial_derivation_failed',
+
+  // device.*
+  DEVICE_MISSING_FIELDS: 'device.missing_fields',
+  DEVICE_NOT_FOUND: 'device.not_found',
+
+  // institution.*
+  INSTITUTION_MISSING_FIELDS: 'institution.missing_fields',
+
+  // invite.*
+  INVITE_ALREADY_ACCEPTED: 'invite.already_accepted',
+  INVITE_EXPIRED: 'invite.expired',
+  INVITE_INVALID: 'invite.invalid',
+
+  // locality.*
+  LOCALITY_NOT_FOUND: 'locality.not_found',
+  LOCALITY_QUERY_TOO_LONG: 'locality.query_too_long',
+  LOCALITY_QUERY_TOO_SHORT: 'locality.query_too_short',
+  LOCALITY_SEARCH_RATE_LIMITED: 'locality.search_rate_limited',
+
+  // official_post.*
+  OFFICIAL_POST_INVALID_CATEGORY: 'official_post.invalid_category',
+  OFFICIAL_POST_INVALID_TYPE: 'official_post.invalid_type',
+  OFFICIAL_POST_MISSING_FIELDS: 'official_post.missing_fields',
+  OFFICIAL_POST_OUTSIDE_JURISDICTION: 'official_post.outside_jurisdiction',
+
+  // participation.*
+  PARTICIPATION_CONTEXT_REQUIRES_AFFECTED:
+    'participation.context_requires_affected',
+  PARTICIPATION_CONTEXT_WINDOW_EXPIRED:
+    'participation.context_window_expired',
+  PARTICIPATION_RESTORATION_REQUIRES_AFFECTED:
+    'participation.restoration_requires_affected',
+
+  // places.*
+  PLACES_QUERY_TOO_LONG: 'places.query_too_long',
+  PLACES_QUERY_TOO_SHORT: 'places.query_too_short',
+  PLACES_REVERSE_RATE_LIMITED: 'places.reverse_rate_limited',
+  PLACES_SEARCH_RATE_LIMITED: 'places.search_rate_limited',
+
+  // rate_limit.*
+  RATE_LIMIT_EXCEEDED: 'rate_limit.exceeded',
+
+  // server.*
+  SERVER_INTERNAL_ERROR: 'server.internal_error',
+
+  // signal.*
+  SIGNAL_DUPLICATE: 'signal.duplicate',
+
+  // validation.*
+  VALIDATION_DEVICE_NOT_FOUND: 'validation.device_not_found',
+  VALIDATION_FAILED: 'validation.failed',
+  VALIDATION_INVALID_CATEGORY: 'validation.invalid_category',
+  VALIDATION_INVALID_COORDINATES: 'validation.invalid_coordinates',
+  VALIDATION_INVALID_LOCATION_SOURCE: 'validation.invalid_location_source',
+  VALIDATION_INVALID_PARTICIPATION_TYPE:
+    'validation.invalid_participation_type',
+  VALIDATION_INVALID_RESTORATION_RESPONSE:
+    'validation.invalid_restoration_response',
+  VALIDATION_INVALID_SECTION: 'validation.invalid_section',
+  VALIDATION_LOCALITY_UNRESOLVED: 'validation.locality_unresolved',
+  VALIDATION_LOCATION_LABEL_REQUIRED: 'validation.location_label_required',
+  VALIDATION_LOCATION_LABEL_TOO_LONG: 'validation.location_label_too_long',
+  VALIDATION_MAX_FOLLOWED_LOCALITIES_EXCEEDED:
+    'validation.max_followed_localities_exceeded',
+  VALIDATION_MISSING_COORDINATES: 'validation.missing_coordinates',
+  VALIDATION_MISSING_FIELD: 'validation.missing_field',
+} as const;
+
+/**
+ * Discriminated union of every known backend wire code. Derived from
+ * `ERROR_CODES` so the union and the constants table cannot drift.
+ */
+export type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES];
+
+const KNOWN_ERROR_CODES: ReadonlySet<string> = new Set<string>(
+  Object.values(ERROR_CODES),
+);
+
+/**
+ * Mobile-side sentinels emitted by `src/api/client.ts`. These are NOT
+ * codes the backend ever sends — they represent client-local conditions
+ * surfaced through the same `ApiError` shape so call sites only deal
+ * with one error type:
+ *   - `unknown_error`     — parser fallback when the body is malformed,
+ *                           empty, or carries a non-string `code` field
+ *   - `network_error`     — fetch threw (offline, DNS, TLS, abort)
+ *   - `no_refresh_token`  — silent-refresh path with no stored refresh
+ *   - `session_expired`   — silent-refresh attempt failed
+ */
+export type ClientErrorCode =
+  | 'unknown_error'
+  | 'network_error'
+  | 'no_refresh_token'
+  | 'session_expired';
+
+/**
+ * Type guard that narrows an arbitrary value to the known wire-visible
+ * `ErrorCode` set. Returns `false` for:
+ *   - mobile-side `ClientErrorCode` sentinels
+ *   - unknown / future backend codes the app version hasn't learned yet
+ *   - non-string values (`null`, `undefined`, numbers, objects)
+ *
+ * Use this BEFORE comparing `error.code` to a specific `ERROR_CODES.*`
+ * literal so unknown-code paths are explicit at the call site:
+ *
+ * ```ts
+ * if (isKnownErrorCode(err.code) && err.code === ERROR_CODES.RATE_LIMIT_EXCEEDED) { … }
+ * ```
+ *
+ * Runtime truth is preserved: the parser stores `error.code` verbatim
+ * so unknown future backend codes pass through end-to-end. This guard
+ * is the explicit opt-in for safe narrowing.
+ */
+export function isKnownErrorCode(value: unknown): value is ErrorCode {
+  return typeof value === 'string' && KNOWN_ERROR_CODES.has(value);
+}
+
+/**
  * Normalised error shape surfaced by the mobile API client.
  *
  * The wire contract is the canonical backend envelope:
@@ -11,15 +164,21 @@
  * `code: 'unknown_error'` and a generic message. `traceId` and `details`
  * are only set when the canonical envelope provides them.
  *
+ * `code` is typed as `ErrorCode | ClientErrorCode | (string & {})`. The
+ * `(string & {})` escape hatch keeps the union open at runtime so a
+ * backend code unknown to this app version is still representable
+ * verbatim — preserving truth over a forced-exhaustive lie. Autocomplete
+ * still surfaces the named literals; use `isKnownErrorCode(code)` to
+ * narrow safely before branching on a specific `ERROR_CODES.*` value.
+ *
  * `details` is `unknown` on purpose: today it can be a keyed field-errors
  * object (`{ fields: { fieldName: [...] } }` from `ValidationException`),
  * a string, an array, or absent. Consumers that need to read it should
- * narrow it at the use site — do not widen this type into a union here
- * (that is tracked separately; see the mobile `ErrorCode` follow-up).
+ * narrow it at the use site — do not widen this type into a union here.
  */
 export interface ApiError {
   status: number;
-  code: string;
+  code: ErrorCode | ClientErrorCode | (string & {});
   message: string;
   traceId?: string;
   details?: unknown;


### PR DESCRIPTION
Closes #154.

## Problem

After PR #157 fixed canonical envelope parsing (issue #152) and PR #158 normalised the backend code catalog (issue #153), the mobile side was still typed as `ApiError.code: string`. Any screen branching on a specific `error.code` did so with magic-string literals — typos compile, renames silently drift, and the new backend contract delivered most of its value invisibly to TypeScript.

A pre-implementation audit also found four screens (`(auth)/otp.tsx`, `(modals)/restoration/[clusterId].tsx`, `(app)/compose/text.tsx`, `(app)/settings/wards.tsx`) carrying _stale_ string-literal branches on pre-#158 codes (`'invalid_otp'`, `'rate_limited'`, `'invalid_restoration_response'`, `'max_followed_localities_exceeded'`, …) that no longer match anything the backend emits. Two of those four are in scope for this issue (composer + cluster-detail restoration); the other two are tracked as a follow-up (see _Follow-up_ below).

## Root cause

H1 + H2 + H3 (#106, #134, #158) delivered the typed-exception model, the unified envelope, and the canonical wire-code catalog on the backend. The mobile mirror — `ErrorCode` union, narrowing helper, `ApiError.code` typing — was deferred to this issue per the audit's _Proposed Next Execution Order → 3_.

## What changed

### `apps/citizen-mobile/src/types/api.ts`
- Added `ERROR_CODES` — a `const`-asserted object mirroring the 49 wire-visible codes from `02_openapi.yaml#/components/schemas/ErrorCode`. Server-side source of truth is `Hali.Application.Errors.ErrorCodes`. Internal-only codes (`clustering.no_spatial_cell`) are intentionally excluded — the backend redacts them to `server.internal_error` on the wire.
- Derived `type ErrorCode = (typeof ERROR_CODES)[keyof typeof ERROR_CODES]` so the union and the constants table cannot drift.
- Added `type ClientErrorCode = 'unknown_error' | 'network_error' | 'no_refresh_token' | 'session_expired'` for the four sentinels emitted by `client.ts` itself (parser fallback, fetch failure, missing refresh, refresh failure).
- Added `isKnownErrorCode(value: unknown): value is ErrorCode` — the explicit narrowing helper.
- Widened `ApiError.code` to `ErrorCode | ClientErrorCode | (string & {})`. The `(string & {})` escape hatch keeps the union open at runtime so unknown future backend codes are representable verbatim; autocomplete on the named literals is preserved.

### `apps/citizen-mobile/app/(app)/compose/text.tsx`
Composer preview rate-limit branch now keys off `ERROR_CODES.RATE_LIMIT_EXCEEDED` via `isKnownErrorCode` (was the stale `'rate_limited'`, which #158 renamed to `rate_limit.exceeded`). HTTP 429 fallback retained as belt-and-braces.

### `apps/citizen-mobile/app/(app)/compose/submit.tsx`
Discriminable composer-submit messaging for `VALIDATION_LOCALITY_UNRESOLVED` and `VALIDATION_INVALID_CATEGORY` (the issue's named pair), plus `RATE_LIMIT_EXCEEDED`. The user now gets a specific call-to-action ("refine the location" / "choose a different category") instead of the generic server message.

### `apps/citizen-mobile/app/(modals)/restoration/[clusterId].tsx`
Restoration response branch now keys off `ERROR_CODES.VALIDATION_INVALID_RESTORATION_RESPONSE` (was the stale `'invalid_restoration_response'`).

### Tests
- **`__tests__/api/errorCodes.test.ts`** (~70 assertions, mostly parametrised):
  - Every `ERROR_CODES` value is recognised by `isKnownErrorCode`.
  - All four client-side sentinels are rejected.
  - Unknown future codes (`quota.daily_exceeded`) and typos (`rate_limit.exceededd`) are rejected.
  - Non-string values (`undefined`, `null`, `number`, `boolean`, `''`, object, array) are rejected.
  - Parser integration: known canonical code is preserved verbatim and the guard recognises it; unknown future code is preserved verbatim and the guard rejects it.
  - Regression assertion that the issue 152 canonical envelope still carries `message` / `details` / `traceId` end-to-end.
- **`__tests__/api/openapiErrorCodeParity.test.ts`**: drift guard that parses the `ErrorCode` enum from `02_openapi.yaml` with a tiny line-based scanner (no new YAML dependency) and asserts set-equality with the mobile mirror in both directions plus equal length.

## Known vs unknown code handling strategy

This PR deliberately preserves runtime truth — the type system reflects what _can_ happen, not what we _want_ to happen.

- **Known codes** (those listed in `02_openapi.yaml#/components/schemas/ErrorCode` at this app version's build time): typed as `ErrorCode`, get autocomplete on `ERROR_CODES.*`, and `isKnownErrorCode` narrows to them.
- **Client-side sentinels** (`unknown_error`, `network_error`, `no_refresh_token`, `session_expired`): typed as `ClientErrorCode`, get autocomplete, and are explicitly NOT considered "known wire codes" by the guard. They're emitted by `client.ts` itself, never by the backend.
- **Unknown future backend codes** (anything the backend may emit before this app version learns about it): pass through the parser verbatim into `ApiError.code`. The `(string & {})` arm keeps the union open at runtime so call sites can still log and surface the raw string. `isKnownErrorCode` returns `false`, routing the call site through its generic-fallback branch.

The chosen pattern follows the user's stated rule: "parser returns a string as received; helper/type guard narrows whether it is a known `ErrorCode`; app code can opt into safe narrowing."

## Tests added/updated

- `apps/citizen-mobile/__tests__/api/errorCodes.test.ts` (NEW)
- `apps/citizen-mobile/__tests__/api/openapiErrorCodeParity.test.ts` (NEW)
- No existing tests modified or removed.

Full mobile suite: **349/349 passing**. `npx tsc --noEmit`: **clean**.

## Out of scope

Per issue #154:
- Auto-generation tooling from OpenAPI to mobile types — manual mirror is acceptable; the parity test catches drift.
- Screen-level UX redesign or generic API-client refactor.
- Backend changes of any kind (no `02_openapi.yaml`, `src/`, or schema edits).
- Issues #155 / #156.

## Risk assessment

**Low.**
- `ApiError.code` widens, not narrows — no existing consumer is broken because every prior `code: string` value still satisfies the new union via the `(string & {})` arm.
- Parser behaviour is unchanged: the verbatim wire string is still surfaced. Existing tests for `buildApiError` continue to pass.
- The two screens whose stale branches were corrected today silently no-op'd before (their string literals matched nothing the backend emits post-#158); the corrected branches now actually fire for the renamed wire codes.
- Pre-commit grep checks (hex colours / icons / Animated / `any`) clean on all changed files.

## Follow-up notes

- Two stale string-literal branches surfaced during the pre-implementation audit are out of scope for this issue (issue #154 explicitly limits screen-level changes to composer + cluster-detail restoration):
  - `app/(auth)/otp.tsx:118,120` still branches on `'invalid_otp'` / `'otp_expired'` (renamed to `auth.otp_invalid`).
  - `app/(app)/settings/wards.tsx:113` still branches on `'max_followed_localities_exceeded'` (renamed to `validation.max_followed_localities_exceeded`).
  These will be filed as a separate cleanup issue and linked here before merge.
- Auto-generating the mobile mirror from OpenAPI is a future enhancement; the parity test makes the manual mirror cheap to maintain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)