### PR TITLE
[Issue #155] Exclude cancellation from LocalitiesController catch-all

### DIFF
--- a/src/Hali.Api/Controllers/LocalitiesController.cs
+++ b/src/Hali.Api/Controllers/LocalitiesController.cs
@@ -202,7 +202,7 @@ public class LocalitiesController : ControllerBase
         {
             candidates = (await _geocoding.SearchAsync(query, ct)).ToList();
         }
-        catch (Exception ex)
+        catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger.LogWarning(ex, "Locality search geocoding failed for query (length={QueryLength})", query.Length);
             return Ok(Array.Empty<LocalitySearchResultDto>());

--- a/tests/Hali.Tests.Unit/Localities/LocalitiesControllerTests.cs
+++ b/tests/Hali.Tests.Unit/Localities/LocalitiesControllerTests.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Auth;
+using Hali.Application.Notifications;
+using Hali.Application.Signals;
+using Hali.Contracts.Notifications;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Hali.Tests.Unit.Localities;
+
+/// <summary>
+/// Narrow unit coverage for the catch-all around
+/// <c>LocalitiesController.Search</c>'s geocoding call. Issue #155 required
+/// that <see cref="OperationCanceledException"/> NOT be absorbed into a
+/// fail-closed empty 200 response; ordinary exceptions must still produce
+/// that fail-closed behavior unchanged.
+/// </summary>
+public class LocalitiesControllerTests
+{
+    private readonly IFollowService _follows = Substitute.For<IFollowService>();
+    private readonly IGeocodingService _geocoding = Substitute.For<IGeocodingService>();
+    private readonly ILocalityLookupRepository _localities = Substitute.For<ILocalityLookupRepository>();
+    private readonly IDatabase _redis = Substitute.For<IDatabase>();
+    private readonly IRateLimiter _rateLimiter = Substitute.For<IRateLimiter>();
+
+    private LocalitiesController CreateController(string clientIp = "203.0.113.1")
+    {
+        _rateLimiter.IsAllowedAsync(Arg.Any<string>(), Arg.Any<int>(), Arg.Any<TimeSpan>(), Arg.Any<CancellationToken>())
+            .Returns(true);
+        _redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>()).Returns(RedisValue.Null);
+        _redis.StringSetAsync(
+                Arg.Any<RedisKey>(),
+                Arg.Any<RedisValue>(),
+                Arg.Any<TimeSpan?>(),
+                Arg.Any<bool>(),
+                Arg.Any<When>(),
+                Arg.Any<CommandFlags>())
+            .Returns(true);
+
+        IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> mvcOptions =
+            Options.Create(new Microsoft.AspNetCore.Mvc.JsonOptions());
+
+        var controller = new LocalitiesController(
+            _follows,
+            _geocoding,
+            _localities,
+            _redis,
+            _rateLimiter,
+            mvcOptions,
+            NullLogger<LocalitiesController>.Instance);
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Connection.RemoteIpAddress = IPAddress.Parse(clientIp);
+        controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+
+        return controller;
+    }
+
+    [Fact]
+    public async Task Search_GeocodingCanceled_PropagatesOperationCanceledException()
+    {
+        // OperationCanceledException must NOT be absorbed into an empty 200;
+        // the catch-all filter lets it flow to the framework so
+        // ExceptionHandlingMiddleware's client-disconnect path handles it.
+        _geocoding.SearchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<GeocodingCandidate>>(_ => throw new OperationCanceledException());
+
+        LocalitiesController controller = CreateController();
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => controller.Search("Ngong Road", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Search_GeocodingThrows_FailsClosedWithEmptyList()
+    {
+        // Ordinary (non-cancellation) exceptions must continue to fail closed
+        // with an empty 200 — the filter must not change this behavior.
+        _geocoding.SearchAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns<IReadOnlyList<GeocodingCandidate>>(_ => throw new InvalidOperationException("boom"));
+
+        LocalitiesController controller = CreateController();
+        IActionResult result = await controller.Search("Ngong Road", CancellationToken.None);
+
+        OkObjectResult ok = Assert.IsType<OkObjectResult>(result);
+        IEnumerable<LocalitySearchResultDto> payload =
+            Assert.IsAssignableFrom<IEnumerable<LocalitySearchResultDto>>(ok.Value);
+        Assert.Empty(payload);
+    }
+}


### PR DESCRIPTION
Closes #155.

## Problem
`LocalitiesController.Search` wrapped `_geocoding.SearchAsync` in a bare `catch (Exception ex)` that had no filter for `OperationCanceledException`. A client that cancelled mid-request (network loss, navigation away) was being logged as a geocoding warning and returned an empty-list HTTP 200 — obscuring the cancellation in telemetry and masking genuine geocoding failures that share the same log bucket.

## Root cause
The catch at `src/Hali.Api/Controllers/LocalitiesController.cs:205` missed the standing rule in `docs/arch/CODING_STANDARDS.md` → *C# Conventions → Exception handling* and Copilot recurring pattern #2 (`docs/arch/COPILOT_LESSONS.md`). Sibling code paths (`PlacesController.cs:127`, `HomeController.cs:167`, all workers) already use the correct filter.

## What changed
One-line catch-filter addition, matching the idiomatic repo pattern:

```csharp
catch (Exception ex) when (ex is not OperationCanceledException)
```

`OperationCanceledException` now propagates so `ExceptionHandlingMiddleware`'s existing cancellation filter handles the client-disconnect semantics without writing an error-level log or a response.

## Tests
New `tests/Hali.Tests.Unit/Localities/LocalitiesControllerTests.cs` with two targeted tests:

- `Search_GeocodingCanceled_PropagatesOperationCanceledException` — asserts the cancel is not absorbed into an empty 200.
- `Search_GeocodingThrows_FailsClosedWithEmptyList` — asserts ordinary (non-cancellation) exceptions still return the fail-closed empty 200 (behavior preservation).

Result: 360/360 unit tests pass (`dotnet test tests/Hali.Tests.Unit`).

## Out of scope
- Any other controller audit (D2 is the only instance flagged in `docs/audits/refactor_path_post_pr151_audit.md`).
- Changes to `GeocodingService` or its abstractions.
- Global exception middleware or logging changes.
- Any cross-controller cleanup.

## Risk assessment
Very low.

- Non-cancellation error behavior unchanged (empty 200 + warning log).
- Cancellation path: the framework's existing middleware handles cancellation the same way it already does for every other controller that uses this pattern (`PlacesController`, `HomeController`, workers, `SignalIngestionService`).
- No API contract change, no OpenAPI change, no migration.
- `dotnet build` clean, `dotnet format --verify-no-changes` clean on touched files, `dotnet test` (unit) 360/360 pass.

## PR Quality Gates
- G1 build clean: ✅ `dotnet build` (0 errors; pre-existing warnings only), `dotnet format --verify-no-changes` clean on touched files, `dotnet test` 360/360.
- G2 API contract integrity: ✅ no contract surface changed.
- G3 test integrity: ✅ no tests removed; +2 tests added.
- G4 security: ✅ no new log-template inputs; existing `query.Length` log unchanged.
- G6 docs alignment: ✅ behavior aligns with `CODING_STANDARDS.md` exception-handling rule and Copilot lesson #2.

Self-validation: PASS