### PR TITLE
[Issue #156] Persist feedback submissions

### DIFF
--- a/src/Hali.Api/Controllers/FeedbackController.cs
+++ b/src/Hali.Api/Controllers/FeedbackController.cs
@@ -12,9 +12,11 @@ namespace Hali.Api.Controllers;
 
 /// <summary>
 /// POST /v1/feedback — anonymous in-app feedback capture.
-/// No auth required. Returns 202 immediately; persistence happens inline via
-/// <see cref="IFeedbackService"/>. Rate limiting is intentionally deferred
-/// (see PR for #156 — not re-added to OpenAPI until a limiter is wired in).
+/// No auth required. Persistence is synchronous via
+/// <see cref="IFeedbackService"/>; the response is <c>202 Accepted</c> to
+/// signal "recorded for later processing" semantics to the client, not
+/// asynchronous storage. Rate limiting is intentionally deferred (see PR
+/// for #156 — not re-added to OpenAPI until a limiter is wired in).
 /// </summary>
 [ApiController]
 [Route("v1/feedback")]

--- a/src/Hali.Api/Controllers/FeedbackController.cs
+++ b/src/Hali.Api/Controllers/FeedbackController.cs
@@ -1,3 +1,8 @@
+using System;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Feedback;
 using Hali.Contracts.Requests;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
@@ -7,20 +12,40 @@ namespace Hali.Api.Controllers;
 
 /// <summary>
 /// POST /v1/feedback — anonymous in-app feedback capture.
-/// No auth required. Full rate limiting and persistence in a later session.
+/// No auth required. Returns 202 immediately; persistence happens inline via
+/// <see cref="IFeedbackService"/>. Rate limiting is intentionally deferred
+/// (see PR for #156 — not re-added to OpenAPI until a limiter is wired in).
 /// </summary>
 [ApiController]
 [Route("v1/feedback")]
 [AllowAnonymous]
 public class FeedbackController : ControllerBase
 {
-    // TODO: inject IFeedbackService when implemented
+    private readonly IFeedbackService _feedback;
+
+    public FeedbackController(IFeedbackService feedback)
+    {
+        _feedback = feedback;
+    }
 
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
-    public IActionResult Submit([FromBody] SubmitFeedbackRequest request)
+    public async Task<IActionResult> Submit(
+        [FromBody] SubmitFeedbackRequest request,
+        CancellationToken ct)
     {
-        // TODO: persist to app_feedback table via IFeedbackService
+        await _feedback.SubmitAsync(request, GetAccountId(), ct);
         return Accepted();
+    }
+
+    /// <summary>
+    /// Returns the authenticated account id if the caller presented a valid
+    /// bearer token, otherwise null. The endpoint is anonymous, so an
+    /// unauthenticated caller is the normal path.
+    /// </summary>
+    private Guid? GetAccountId()
+    {
+        var raw = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+        return Guid.TryParse(raw, out var id) ? id : null;
     }
 }

--- a/src/Hali.Application/Feedback/IFeedbackService.cs
+++ b/src/Hali.Application/Feedback/IFeedbackService.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Contracts.Requests;
+
+namespace Hali.Application.Feedback;
+
+/// <summary>
+/// Application-layer service that persists anonymous in-app feedback
+/// submitted via <c>POST /v1/feedback</c>.
+///
+/// The endpoint is anonymous: <paramref name="accountId"/> is supplied only
+/// when the caller presents a valid bearer token, otherwise null. No
+/// exceptions are thrown for dropped optional fields — validation of the
+/// request shape is enforced at the controller boundary via
+/// <c>SubmitFeedbackRequest</c> DataAnnotations.
+/// </summary>
+public interface IFeedbackService
+{
+    /// <summary>
+    /// Persists a single feedback submission. Returns the assigned
+    /// <c>id</c> of the stored row.
+    /// </summary>
+    Task<Guid> SubmitAsync(
+        SubmitFeedbackRequest request,
+        Guid? accountId,
+        CancellationToken ct = default);
+}

--- a/src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Hali.Infrastructure/Extensions/ServiceCollectionExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using Hali.Application.Advisories;
 using Hali.Application.Auth;
 using Hali.Application.Clusters;
+using Hali.Application.Feedback;
 using Hali.Application.Home;
 using Hali.Application.Notifications;
 using Hali.Application.Participation;
@@ -19,6 +20,7 @@ using Hali.Infrastructure.Data.Feedback;
 using Hali.Infrastructure.Data.Notifications;
 using Hali.Infrastructure.Data.Participation;
 using Hali.Infrastructure.Data.Signals;
+using Hali.Infrastructure.Feedback;
 using Hali.Infrastructure.Notifications;
 using Hali.Infrastructure.Participation;
 using Hali.Infrastructure.Signals;
@@ -132,6 +134,7 @@ public static class ServiceCollectionExtensions
 		// Feedback
 		services.AddDbContext<FeedbackDbContext>((sp, opts) =>
 			opts.UseNpgsql(sp.GetRequiredService<HaliDataSources>().Feedback));
+		services.AddScoped<IFeedbackService, FeedbackService>();
 
 		return services;
 	}

--- a/src/Hali.Infrastructure/Feedback/FeedbackService.cs
+++ b/src/Hali.Infrastructure/Feedback/FeedbackService.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Feedback;
+using Hali.Contracts.Requests;
+using Hali.Domain.Entities.Feedback;
+using Hali.Infrastructure.Data.Feedback;
+
+namespace Hali.Infrastructure.Feedback;
+
+/// <summary>
+/// Writes <see cref="AppFeedback"/> rows via <see cref="FeedbackDbContext"/>.
+///
+/// Deliberately thin: no business logic, no rate limiting, no side-effects.
+/// The controller enforces request-shape validation and the DB owns
+/// length/shape constraints through EF configuration.
+/// </summary>
+public sealed class FeedbackService : IFeedbackService
+{
+    private readonly FeedbackDbContext _db;
+
+    public FeedbackService(FeedbackDbContext db)
+    {
+        _db = db;
+    }
+
+    public async Task<Guid> SubmitAsync(
+        SubmitFeedbackRequest request,
+        Guid? accountId,
+        CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var entity = new AppFeedback
+        {
+            Id = Guid.NewGuid(),
+            Rating = request.Rating,
+            Text = request.Text,
+            Screen = request.Screen,
+            ClusterId = request.ClusterId,
+            AccountId = accountId,
+            AppVersion = request.AppVersion,
+            Platform = request.Platform,
+            SessionId = request.SessionId,
+            SubmittedAt = DateTimeOffset.UtcNow,
+        };
+
+        _db.AppFeedback.Add(entity);
+        await _db.SaveChangesAsync(ct);
+        return entity.Id;
+    }
+}

--- a/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
@@ -26,6 +26,10 @@ public sealed class FeedbackIntegrationTests : IntegrationTestBase
         var clusterId = Guid.NewGuid();
         var sessionId = Guid.NewGuid();
 
+        // Single, stable timestamp bounds to avoid drift from two UtcNow reads.
+        // Allow a small lower-bound skew for clock rounding between the client
+        // clock and Postgres' timestamptz resolution.
+        var before = DateTimeOffset.UtcNow.AddSeconds(-1);
         var response = await Client.PostAsJsonAsync("/v1/feedback", new
         {
             rating = "positive",
@@ -36,6 +40,7 @@ public sealed class FeedbackIntegrationTests : IntegrationTestBase
             platform = "android",
             sessionId,
         });
+        var after = DateTimeOffset.UtcNow.AddSeconds(1);
 
         Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
 
@@ -49,8 +54,7 @@ public sealed class FeedbackIntegrationTests : IntegrationTestBase
         Assert.Equal("1.2.3", row.AppVersion);
         Assert.Equal("android", row.Platform);
         Assert.Equal(sessionId, row.SessionId);
-        Assert.True(row.SubmittedAt <= DateTimeOffset.UtcNow);
-        Assert.True(row.SubmittedAt > DateTimeOffset.UtcNow.AddMinutes(-5));
+        Assert.InRange(row.SubmittedAt, before, after);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
@@ -1,0 +1,190 @@
+using System;
+using System.Net;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Hali.Tests.Integration.Infrastructure;
+using Npgsql;
+using Xunit;
+
+namespace Hali.Tests.Integration.Feedback;
+
+/// <summary>
+/// End-to-end coverage for <c>POST /v1/feedback</c> (issue #156).
+/// Proves that valid submissions persist an <c>app_feedback</c> row with the
+/// expected field mapping, that invalid bodies are rejected at the controller
+/// boundary, and that the endpoint remains anonymous.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class FeedbackIntegrationTests : IntegrationTestBase
+{
+    public FeedbackIntegrationTests(HaliWebApplicationFactory factory) : base(factory) { }
+
+    [Fact]
+    public async Task Submit_AnonymousValidRequest_PersistsAppFeedbackRow()
+    {
+        var clusterId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        var response = await Client.PostAsJsonAsync("/v1/feedback", new
+        {
+            rating = "positive",
+            text = "Clear, neutral, useful — keep it this way.",
+            screen = "home",
+            clusterId,
+            appVersion = "1.2.3",
+            platform = "android",
+            sessionId,
+        });
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        var row = await FetchLatestFeedbackRowAsync();
+        Assert.NotNull(row);
+        Assert.Equal("positive", row!.Rating);
+        Assert.Equal("Clear, neutral, useful — keep it this way.", row.Text);
+        Assert.Equal("home", row.Screen);
+        Assert.Equal(clusterId, row.ClusterId);
+        Assert.Null(row.AccountId); // anonymous — no bearer token
+        Assert.Equal("1.2.3", row.AppVersion);
+        Assert.Equal("android", row.Platform);
+        Assert.Equal(sessionId, row.SessionId);
+        Assert.True(row.SubmittedAt <= DateTimeOffset.UtcNow);
+        Assert.True(row.SubmittedAt > DateTimeOffset.UtcNow.AddMinutes(-5));
+    }
+
+    [Fact]
+    public async Task Submit_AuthenticatedRequest_StampsAccountId()
+    {
+        var (accountId, _, jwt) = await SeedVerifiedAccountAsync();
+        using var authed = CreateAuthenticatedClient(jwt);
+
+        var response = await authed.PostAsJsonAsync("/v1/feedback", new
+        {
+            rating = "neutral",
+            text = (string?)null,
+            screen = "profile",
+        });
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        var row = await FetchLatestFeedbackRowAsync();
+        Assert.NotNull(row);
+        Assert.Equal(accountId, row!.AccountId);
+        Assert.Equal("neutral", row.Rating);
+        Assert.Null(row.Text);
+        Assert.Equal("profile", row.Screen);
+    }
+
+    [Fact]
+    public async Task Submit_MinimalRequiredFieldsOnly_Persists()
+    {
+        var response = await Client.PostAsJsonAsync("/v1/feedback", new
+        {
+            rating = "negative",
+        });
+
+        Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+
+        var row = await FetchLatestFeedbackRowAsync();
+        Assert.NotNull(row);
+        Assert.Equal("negative", row!.Rating);
+        Assert.Null(row.Text);
+        Assert.Null(row.Screen);
+        Assert.Null(row.ClusterId);
+        Assert.Null(row.AccountId);
+        Assert.Null(row.Platform);
+        Assert.Null(row.AppVersion);
+        Assert.Null(row.SessionId);
+    }
+
+    [Fact]
+    public async Task Submit_MissingRating_Returns400AndDoesNotPersist()
+    {
+        var response = await Client.PostAsJsonAsync("/v1/feedback", new
+        {
+            text = "no rating field",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, await CountFeedbackAsync());
+    }
+
+    [Fact]
+    public async Task Submit_InvalidRatingValue_Returns400AndDoesNotPersist()
+    {
+        var response = await Client.PostAsJsonAsync("/v1/feedback", new
+        {
+            rating = "ecstatic",
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, await CountFeedbackAsync());
+    }
+
+    [Fact]
+    public async Task Submit_TextExceedsMaxLength_Returns400AndDoesNotPersist()
+    {
+        var response = await Client.PostAsJsonAsync("/v1/feedback", new
+        {
+            rating = "positive",
+            text = new string('x', 301),
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        Assert.Equal(0, await CountFeedbackAsync());
+    }
+
+    // ----------------------------------------------------------------------
+    // Helpers
+    // ----------------------------------------------------------------------
+
+    private sealed record FeedbackRow(
+        Guid Id,
+        string Rating,
+        string? Text,
+        string? Screen,
+        Guid? ClusterId,
+        Guid? AccountId,
+        string? AppVersion,
+        string? Platform,
+        Guid? SessionId,
+        DateTimeOffset SubmittedAt);
+
+    private static async Task<FeedbackRow?> FetchLatestFeedbackRowAsync()
+    {
+        await using var conn = new NpgsqlConnection(TestConstants.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(@"
+            SELECT id, rating, text, screen, cluster_id, account_id,
+                   app_version, platform, session_id, submitted_at
+            FROM app_feedback
+            ORDER BY submitted_at DESC
+            LIMIT 1", conn);
+
+        await using var reader = await cmd.ExecuteReaderAsync();
+        if (!await reader.ReadAsync())
+            return null;
+
+        return new FeedbackRow(
+            Id: reader.GetGuid(0),
+            Rating: reader.GetString(1),
+            Text: reader.IsDBNull(2) ? null : reader.GetString(2),
+            Screen: reader.IsDBNull(3) ? null : reader.GetString(3),
+            ClusterId: reader.IsDBNull(4) ? null : reader.GetGuid(4),
+            AccountId: reader.IsDBNull(5) ? null : reader.GetGuid(5),
+            AppVersion: reader.IsDBNull(6) ? null : reader.GetString(6),
+            Platform: reader.IsDBNull(7) ? null : reader.GetString(7),
+            SessionId: reader.IsDBNull(8) ? null : reader.GetGuid(8),
+            SubmittedAt: reader.GetFieldValue<DateTimeOffset>(9));
+    }
+
+    private static async Task<long> CountFeedbackAsync()
+    {
+        await using var conn = new NpgsqlConnection(TestConstants.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand("SELECT COUNT(*) FROM app_feedback", conn);
+        var result = await cmd.ExecuteScalarAsync();
+        return result is long l ? l : Convert.ToInt64(result);
+    }
+}

--- a/tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.cs
+++ b/tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.cs
@@ -42,6 +42,7 @@ public sealed class HaliWebApplicationFactory
         Environment.SetEnvironmentVariable("ConnectionStrings__Participation", connStr);
         Environment.SetEnvironmentVariable("ConnectionStrings__Advisories", connStr);
         Environment.SetEnvironmentVariable("ConnectionStrings__Notifications", connStr);
+        Environment.SetEnvironmentVariable("ConnectionStrings__Feedback", connStr);
         Environment.SetEnvironmentVariable("ConnectionStrings__Admin", connStr);
         Environment.SetEnvironmentVariable("Redis__Url", TestConstants.RedisUrl);
 
@@ -57,6 +58,7 @@ public sealed class HaliWebApplicationFactory
                 ["ConnectionStrings:Participation"]  = connStr,
                 ["ConnectionStrings:Advisories"]     = connStr,
                 ["ConnectionStrings:Notifications"]  = connStr,
+                ["ConnectionStrings:Feedback"]       = connStr,
                 ["ConnectionStrings:Admin"]          = connStr,
                 ["Redis:Url"]                        = TestConstants.RedisUrl,
                 ["Auth:JwtSecret"]                   = TestConstants.JwtSecret,
@@ -134,6 +136,7 @@ public sealed class HaliWebApplicationFactory
             "TRUNCATE signal_events CASCADE",
             "TRUNCATE official_post_scopes, official_posts, institution_jurisdictions, institutions CASCADE",
             "TRUNCATE notifications, follows CASCADE",
+            "TRUNCATE app_feedback CASCADE",
         };
 
         foreach (var sql in statements)
@@ -482,6 +485,25 @@ CREATE TABLE IF NOT EXISTS notifications (
     CONSTRAINT uq_notification_dedupe UNIQUE (dedupe_key)
 )");
         await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_notifications_queued_send_after ON notifications(send_after) WHERE status = 'queued'");
+
+        // Feedback table (EF migration 20260408100124_AddAppFeedbackTable) — mirrored
+        // here per the schema-bootstrap rule in docs/arch/CODING_STANDARDS.md.
+        await ExecAsync(conn, @"
+CREATE TABLE IF NOT EXISTS app_feedback (
+    id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    rating varchar(10) NOT NULL,
+    text varchar(300),
+    screen varchar(50),
+    cluster_id uuid,
+    account_id uuid,
+    app_version varchar(20),
+    platform varchar(10),
+    session_id uuid,
+    submitted_at timestamptz NOT NULL
+)");
+        await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_app_feedback_submitted_at ON app_feedback(submitted_at)");
+        await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_app_feedback_rating ON app_feedback(rating)");
+        await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_app_feedback_screen ON app_feedback(screen)");
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`POST /v1/feedback` was a persistence stub: the controller carried two
`TODO`s, injected nothing, and returned `202 Accepted` without writing
any row. User-submitted feedback was silently dropped while OpenAPI
advertised the route as functional.

Closes #156.

## Root cause

Phase 1 shipped the contract (`SubmitFeedbackRequest` + OpenAPI
`FeedbackRequest`) and later a preliminary data layer was added on
`develop` (entity `AppFeedback`, `FeedbackDbContext`, migration
`20260408100124_AddAppFeedbackTable`, `HaliDataSources.Feedback`
and `AddDbContext<FeedbackDbContext>`), but the application service
and the controller wiring were never completed — so the write path
had no component that actually called `SaveChangesAsync`.

## What changed

- Added `IFeedbackService` (`src/Hali.Application/Feedback/IFeedbackService.cs`).
- Added `FeedbackService` (`src/Hali.Infrastructure/Feedback/FeedbackService.cs`)
  as a thin writer on top of `FeedbackDbContext`.
- Registered `IFeedbackService` as scoped in `AddInfrastructure`.
- Rewrote `FeedbackController.Submit` to await the service; kept
  `[AllowAnonymous]` and the `202 Accepted` status contract.
- Stamped `AccountId` from `ClaimTypes.NameIdentifier` when the caller
  is authenticated; left null otherwise (OpenAPI explicitly states
  this behavior).
- Mirrored the EF migration in
  `HaliWebApplicationFactory.EnsureSchemaAsync()` using idempotent
  `CREATE TABLE IF NOT EXISTS` + index guards, per the schema-bootstrap
  rule in `docs/arch/CODING_STANDARDS.md`.
- Added `Feedback` connection string to the test factory env vars and
  in-memory config; added `TRUNCATE app_feedback CASCADE` to
  `CleanTablesAsync` to isolate tests.

## Persistence model / storage path

Controller → `IFeedbackService.SubmitAsync(request, accountId, ct)` →
`FeedbackDbContext.AppFeedback.Add(...)` → `SaveChangesAsync(ct)` →
PostgreSQL `app_feedback` row.

**No new migration added** — the EF migration `20260408100124_AddAppFeedbackTable`
and its snapshot already exist on `develop`; this PR is the first caller
that exercises them. The controller is the system boundary for request
validation (DataAnnotations on `SubmitFeedbackRequest`); the DB column
widths (set in `FeedbackDbContext`) provide defense in depth.

Table shape (unchanged from the existing migration):

| Column | Type | Nullable |
|---|---|---|
| `id` | `uuid` (default `gen_random_uuid()`) | no |
| `rating` | `varchar(10)` | no |
| `text` | `varchar(300)` | yes |
| `screen` | `varchar(50)` | yes |
| `cluster_id` | `uuid` | yes |
| `account_id` | `uuid` | yes |
| `app_version` | `varchar(20)` | yes |
| `platform` | `varchar(10)` | yes |
| `session_id` | `uuid` | yes |
| `submitted_at` | `timestamptz` | no |

Indexes: `ix_app_feedback_submitted_at`, `ix_app_feedback_rating`,
`ix_app_feedback_screen`. No FK constraints on `cluster_id` or
`account_id` — feedback must survive cluster/account deletion
(documented comment on the entity).

## Validation behavior

Enforced via DataAnnotations on `SubmitFeedbackRequest` (pre-existing;
exercised for the first time by this PR's integration tests):

- `rating` is `[Required]` and `[RegularExpression("^(positive|neutral|negative)$")]`.
- `text` is `[MaxLength(300)]`, nullable.
- `screen` is `[MaxLength(50)]`, nullable.
- `appVersion` is `[MaxLength(20)]`, nullable.
- `platform` is `[MaxLength(10)]`, nullable.
- `clusterId` and `sessionId` are `Guid?` — model binding rejects
  malformed input at the framework layer.

Invalid payloads are rejected with the standard `validation.failed`
canonical error envelope before reaching the service.

> Note: OpenAPI also declares narrower `enum` constraints on `screen`
> and `platform`. The existing DTO does not enforce those enums; since
> the mobile client passes free-form screen names not all of which appear
> in the published list, tightening this is a behavior change and is
> intentionally out of scope for a persistence PR. Logged as follow-up.

## Tests added/updated

Six new integration tests in
`tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs`:

1. Anonymous valid request → persists with expected field mapping and
   `AccountId == null`.
2. Authenticated request → `AccountId` stamped from the bearer token's
   `NameIdentifier` claim.
3. Minimal body (`rating` only) → persists with nulls for all optional
   fields.
4. Missing `rating` → `400` and zero rows.
5. Invalid `rating` (`"ecstatic"`) → `400` and zero rows.
6. `text` longer than 300 chars → `400` and zero rows.

Results: **60/60 integration** passing; **360/360 unit** passing.

## Out of scope

- Rate limiting on this endpoint (issue #156 permits deferring; OpenAPI
  does not advertise `429`, and `[ProducesResponseType(429)]` is not
  present on the controller).
- OpenAPI `enum` enforcement for `screen`/`platform` (pre-existing DTO
  drift vs spec — unrelated to persistence; would be a behavior change
  for the mobile client).
- Ops dashboard / moderation / analytics on feedback rows.

## Risk assessment

Low.

- No change to the OpenAPI contract (already reflected the persistence
  intent in the description text).
- No new migration; the existing migration is already in the schema
  snapshot chain on `develop` and is exercised by the test harness via
  idempotent raw SQL.
- Endpoint remains anonymous; `AccountId` is only stamped when a valid
  bearer token is presented.
- `HaliWebApplicationFactory` schema bootstrap uses `CREATE TABLE IF
  NOT EXISTS` guards, so it is safe for first-run and re-run against a
  warm test DB.
- `TRUNCATE app_feedback CASCADE` is a safe addition to `CleanTablesAsync`
  because no other test fixture inserts into this table.

## PR Quality Gates

- G1 Build clean: `dotnet build` 0 errors (93 pre-existing warnings,
  none introduced by this PR).
- G2 API contract integrity: OpenAPI unchanged; no new response codes
  advertised without a code path.
- G3 Test integrity: no tests removed; new behaviour is covered by
  integration tests.
- G4 Security surface: no request-derived values in log templates; no
  credentials in any file.
- G6 Documentation alignment: PR body describes the diff accurately.