### PR TITLE
[Issue #164] Add error-code metrics to exception middleware

### DIFF
--- a/src/Hali.Api/Errors/ApiErrorMapping.cs
+++ b/src/Hali.Api/Errors/ApiErrorMapping.cs
@@ -1,3 +1,4 @@
+using Hali.Domain.Errors;
 using Microsoft.Extensions.Logging;
 
 namespace Hali.Api.Errors;
@@ -9,4 +10,13 @@ public sealed class ApiErrorMapping
     public string Message { get; init; } = default!;
     public object? Details { get; init; }
     public LogLevel LogLevel { get; init; }
+
+    /// <summary>
+    /// Category of the mapped (wire-visible) error. For redacted internal
+    /// invariant violations this is <see cref="ErrorCategory.Unexpected"/>,
+    /// matching the redacted wire code. Used by <c>ApiMetrics</c> to tag
+    /// the <c>api_exceptions_total</c> counter without re-deriving category
+    /// from the raw exception.
+    /// </summary>
+    public ErrorCategory Category { get; init; }
 }

--- a/src/Hali.Api/Errors/ExceptionToApiErrorMapper.cs
+++ b/src/Hali.Api/Errors/ExceptionToApiErrorMapper.cs
@@ -19,7 +19,8 @@ public sealed class ExceptionToApiErrorMapper
                 Details = ve.FieldErrors is { Count: > 0 }
                     ? new { fields = ve.FieldErrors }
                     : null,
-                LogLevel = LogLevel.Information
+                LogLevel = LogLevel.Information,
+                Category = ErrorCategory.Validation
             },
 
             NotFoundException nfe => new ApiErrorMapping
@@ -27,7 +28,8 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 404,
                 Code = nfe.Code,
                 Message = nfe.Message,
-                LogLevel = LogLevel.Information
+                LogLevel = LogLevel.Information,
+                Category = ErrorCategory.NotFound
             },
 
             ConflictException ce => new ApiErrorMapping
@@ -35,7 +37,8 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 409,
                 Code = ce.Code,
                 Message = ce.Message,
-                LogLevel = LogLevel.Information
+                LogLevel = LogLevel.Information,
+                Category = ErrorCategory.Conflict
             },
 
             RateLimitException rle => new ApiErrorMapping
@@ -43,7 +46,8 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 429,
                 Code = rle.Code,
                 Message = rle.Message,
-                LogLevel = LogLevel.Warning
+                LogLevel = LogLevel.Warning,
+                Category = ErrorCategory.RateLimit
             },
 
             DependencyException de => new ApiErrorMapping
@@ -51,7 +55,8 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 503,
                 Code = de.Code,
                 Message = de.Message,
-                LogLevel = LogLevel.Warning
+                LogLevel = LogLevel.Warning,
+                Category = ErrorCategory.Dependency
             },
 
             UnauthorizedException ue => new ApiErrorMapping
@@ -59,7 +64,8 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 401,
                 Code = ue.Code,
                 Message = ue.Message,
-                LogLevel = LogLevel.Warning
+                LogLevel = LogLevel.Warning,
+                Category = ErrorCategory.Unauthorized
             },
 
             AppException ae => MapByCategory(ae),
@@ -69,7 +75,8 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 500,
                 Code = ErrorCodes.ServerInternalError,
                 Message = "An unexpected error occurred.",
-                LogLevel = LogLevel.Error
+                LogLevel = LogLevel.Error,
+                Category = ErrorCategory.Unexpected
             }
         };
     }
@@ -88,7 +95,11 @@ public sealed class ExceptionToApiErrorMapper
                 StatusCode = 500,
                 Code = ErrorCodes.ServerInternalError,
                 Message = "An unexpected error occurred.",
-                LogLevel = LogLevel.Error
+                LogLevel = LogLevel.Error,
+                // Category reflects the redacted wire outcome, not the
+                // (identical) raw exception category — keeping this in the
+                // mapping makes ApiMetrics agnostic to redaction semantics.
+                Category = ErrorCategory.Unexpected
             };
         }
 
@@ -112,7 +123,8 @@ public sealed class ExceptionToApiErrorMapper
             StatusCode = statusCode,
             Code = ae.Code,
             Message = ae.Message,
-            LogLevel = logLevel
+            LogLevel = logLevel,
+            Category = ae.Category
         };
     }
 }

--- a/src/Hali.Api/Middleware/ExceptionHandlingMiddleware.cs
+++ b/src/Hali.Api/Middleware/ExceptionHandlingMiddleware.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Hali.Api.Errors;
+using Hali.Api.Observability;
 using Hali.Application.Errors;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
@@ -13,15 +15,18 @@ public class ExceptionHandlingMiddleware
     private readonly RequestDelegate _next;
     private readonly ILogger<ExceptionHandlingMiddleware> _logger;
     private readonly ExceptionToApiErrorMapper _mapper;
+    private readonly ApiMetrics _metrics;
 
     public ExceptionHandlingMiddleware(
         RequestDelegate next,
         ILogger<ExceptionHandlingMiddleware> logger,
-        ExceptionToApiErrorMapper mapper)
+        ExceptionToApiErrorMapper mapper,
+        ApiMetrics metrics)
     {
         _next = next;
         _logger = logger;
         _mapper = mapper;
+        _metrics = metrics;
     }
 
     public async Task InvokeAsync(HttpContext context)
@@ -33,7 +38,8 @@ public class ExceptionHandlingMiddleware
         catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)
         {
             // Client disconnected — not an error. Let the framework handle
-            // the abort without emitting a 500 envelope or error-level log.
+            // the abort without emitting a 500 envelope, error-level log, or
+            // metric: the cancellation is not a handled API exception.
         }
         catch (Exception ex)
         {
@@ -56,6 +62,13 @@ public class ExceptionHandlingMiddleware
             context.Items["CorrelationId"] as string
             ?? context.TraceIdentifier);
 
+        // Emit the metric before writing the response so an exception during
+        // serialization does not drop the observation. Tags are read from
+        // `mapping` (the post-redaction wire outcome) so internal-only codes
+        // never appear as metric values — they bucket into `server.internal_error`
+        // just like the wire body.
+        RecordExceptionMetric(mapping);
+
         LogException(exception, mapping);
 
         var response = new ApiErrorResponse
@@ -72,6 +85,20 @@ public class ExceptionHandlingMiddleware
         context.Response.StatusCode = mapping.StatusCode;
         context.Response.ContentType = "application/json";
         await context.Response.WriteAsync(JsonSerializer.Serialize(response, ApiErrorJsonOptions.Default));
+    }
+
+    private void RecordExceptionMetric(ApiErrorMapping mapping)
+    {
+        // Lowercase the category for a stable cardinality-controlled tag
+        // value ("unexpected", "validation", ...) so consumers aren't split
+        // across casing variants over time.
+        var tags = new TagList
+        {
+            { ApiMetrics.TagErrorCode, mapping.Code },
+            { ApiMetrics.TagErrorCategory, mapping.Category.ToString().ToLowerInvariant() },
+            { ApiMetrics.TagStatusCode, mapping.StatusCode }
+        };
+        _metrics.ApiExceptionsTotal.Add(1, tags);
     }
 
     /// <summary>

--- a/src/Hali.Api/Observability/ApiMetrics.cs
+++ b/src/Hali.Api/Observability/ApiMetrics.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Diagnostics.Metrics;
+
+namespace Hali.Api.Observability;
+
+/// <summary>
+/// Host for the top-level <c>Hali.Api</c> <see cref="Meter"/> and the instruments
+/// emitted directly from API-tier cross-cutting concerns (middleware, filters).
+///
+/// The meter is registered on the OpenTelemetry meter provider in
+/// <c>Program.cs</c> under the name <see cref="MeterName"/>. When
+/// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is unset the meter and its instruments
+/// still exist in-process (zero-cost, non-exported) and no behaviour regresses.
+/// </summary>
+public sealed class ApiMetrics : IDisposable
+{
+    /// <summary>
+    /// Name of the application-wide <see cref="Meter"/>. Mirrored by
+    /// <c>AddMeter(ApiMetrics.MeterName)</c> on the OpenTelemetry meter provider.
+    /// </summary>
+    public const string MeterName = "Hali.Api";
+
+    /// <summary>
+    /// Name of the exception counter. Exposed as a const so tests and operators
+    /// can reference the wire name without duplicating a string literal.
+    /// </summary>
+    public const string ApiExceptionsTotalName = "api_exceptions_total";
+
+    /// <summary>Tag key carrying the mapped wire error code.</summary>
+    public const string TagErrorCode = "error_code";
+
+    /// <summary>Tag key carrying the mapped error category (lowercase).</summary>
+    public const string TagErrorCategory = "error_category";
+
+    /// <summary>Tag key carrying the HTTP status code written to the wire.</summary>
+    public const string TagStatusCode = "status_code";
+
+    private readonly Meter _meter;
+
+    /// <summary>
+    /// <c>api_exceptions_total</c> — incremented once per exception translated
+    /// by <c>ExceptionHandlingMiddleware</c> into the canonical error envelope.
+    ///
+    /// Tags reflect the <b>wire-visible</b> mapping outcome, not the raw
+    /// exception internals:
+    /// <list type="bullet">
+    ///   <item><description><c>error_code</c> — mapped <c>ErrorCodes</c> value.
+    ///     Internal-only codes (e.g. <c>clustering.no_spatial_cell</c>) are
+    ///     redacted to <c>server.internal_error</c> before tagging, matching
+    ///     what the client actually receives.</description></item>
+    ///   <item><description><c>error_category</c> — lowercase
+    ///     <c>ErrorCategory</c> value. Redacted and unmapped exceptions tag as
+    ///     <c>unexpected</c>.</description></item>
+    ///   <item><description><c>status_code</c> — HTTP status code on the wire
+    ///     (integer).</description></item>
+    /// </list>
+    ///
+    /// All three dimensions are bounded by static catalogs (≤51 codes,
+    /// 11 categories, a small set of status codes) so cardinality is
+    /// controlled. No request-derived value (path, method, account id,
+    /// correlation id) is ever attached.
+    /// </summary>
+    public Counter<long> ApiExceptionsTotal { get; }
+
+    public ApiMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+        _meter = meterFactory.Create(MeterName);
+        ApiExceptionsTotal = _meter.CreateCounter<long>(
+            name: ApiExceptionsTotalName,
+            unit: "{exception}",
+            description: "Number of exceptions translated into the canonical error envelope by ExceptionHandlingMiddleware.");
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Hali.Api.Errors;
 using Hali.Api.Middleware;
+using Hali.Api.Observability;
 using Hali.Application.Auth;
 using Hali.Application.Errors;
 using Hali.Application.Notifications;
@@ -38,6 +39,9 @@ builder.Services.AddScoped<IOfficialPostsService, OfficialPostsService>();
 builder.Services.AddScoped<IFollowService, FollowService>();
 builder.Services.AddScoped<INotificationQueueService, NotificationQueueService>();
 builder.Services.AddSingleton<ExceptionToApiErrorMapper>();
+// ApiMetrics owns the Hali.Api Meter + the api_exceptions_total counter. The
+// instance is long-lived; IMeterFactory is registered by the hosting stack.
+builder.Services.AddSingleton<ApiMetrics>();
 
 string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
@@ -170,6 +174,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
             .AddOtlpExporter(o => o.Endpoint = new Uri(otelEndpoint)))
         .WithMetrics(m => m
             .AddAspNetCoreInstrumentation()
+            .AddMeter(ApiMetrics.MeterName)
             .AddOtlpExporter(o => o.Endpoint = new Uri(otelEndpoint)));
 }
 

--- a/tests/Hali.Tests.Unit/Errors/ExceptionHandlingMiddlewareTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ExceptionHandlingMiddlewareTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Hali.Api.Errors;
 using Hali.Api.Middleware;
 using Hali.Application.Errors;
+using Hali.Tests.Unit.Observability;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -20,7 +21,8 @@ public class ExceptionHandlingMiddlewareTests
         return new ExceptionHandlingMiddleware(
             next,
             NullLogger<ExceptionHandlingMiddleware>.Instance,
-            new ExceptionToApiErrorMapper());
+            new ExceptionToApiErrorMapper(),
+            TestMetrics.Create());
     }
 
     private static DefaultHttpContext CreateContext()

--- a/tests/Hali.Tests.Unit/Errors/ExceptionHandlingMiddlewareTests.cs
+++ b/tests/Hali.Tests.Unit/Errors/ExceptionHandlingMiddlewareTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 using System.Threading;
@@ -14,15 +15,32 @@ using Xunit;
 
 namespace Hali.Tests.Unit.Errors;
 
-public class ExceptionHandlingMiddlewareTests
+public class ExceptionHandlingMiddlewareTests : IDisposable
 {
-    private static ExceptionHandlingMiddleware CreateMiddleware(RequestDelegate next)
+    // xUnit instantiates the test class once per [Fact], so tracking scopes on
+    // the instance gives a per-test lifetime. Dispose() runs after each test
+    // and tears down the TestMetricsScope(s) (ApiMetrics + ServiceProvider)
+    // created by CreateMiddleware — otherwise a fresh ServiceProvider would
+    // leak for every test in the class.
+    private readonly List<IDisposable> _disposables = new();
+
+    private ExceptionHandlingMiddleware CreateMiddleware(RequestDelegate next)
     {
+        var scope = TestMetrics.Create();
+        _disposables.Add(scope);
         return new ExceptionHandlingMiddleware(
             next,
             NullLogger<ExceptionHandlingMiddleware>.Instance,
             new ExceptionToApiErrorMapper(),
-            TestMetrics.Create());
+            scope.Metrics);
+    }
+
+    public void Dispose()
+    {
+        foreach (var d in _disposables)
+        {
+            d.Dispose();
+        }
     }
 
     private static DefaultHttpContext CreateContext()

--- a/tests/Hali.Tests.Unit/Observability/ApiExceptionMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/ApiExceptionMetricsTests.cs
@@ -1,0 +1,247 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Errors;
+using Hali.Api.Middleware;
+using Hali.Api.Observability;
+using Hali.Application.Errors;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+/// <summary>
+/// Verifies that <c>ExceptionHandlingMiddleware</c> emits the
+/// <c>api_exceptions_total</c> counter with the intended wire-visible tags,
+/// and that non-exception paths do not emit the metric.
+///
+/// Each test constructs an isolated <see cref="ApiMetrics"/> instance so the
+/// <see cref="MeterListener"/> only observes measurements from that test's
+/// meter. This keeps tests parallel-safe.
+/// </summary>
+public class ApiExceptionMetricsTests
+{
+    private sealed record Measurement(long Value, Dictionary<string, object?> Tags);
+
+    /// <summary>
+    /// Captures every <c>api_exceptions_total</c> measurement emitted by the
+    /// supplied <see cref="ApiMetrics"/> instance for the lifetime of the
+    /// listener.
+    /// </summary>
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<Measurement> Measurements { get; } = new();
+
+        public MetricCapture(ApiMetrics metrics)
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(instrument, metrics.ApiExceptionsTotal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((_, measurement, tags, _) =>
+            {
+                var dict = new Dictionary<string, object?>(tags.Length);
+                foreach (var tag in tags)
+                {
+                    dict[tag.Key] = tag.Value;
+                }
+                Measurements.Add(new Measurement(measurement, dict));
+            });
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private static ExceptionHandlingMiddleware CreateMiddleware(RequestDelegate next, ApiMetrics metrics)
+        => new(next, NullLogger<ExceptionHandlingMiddleware>.Instance, new ExceptionToApiErrorMapper(), metrics);
+
+    private static DefaultHttpContext CreateContext()
+    {
+        var context = new DefaultHttpContext();
+        context.Response.Body = new MemoryStream();
+        context.Items["CorrelationId"] = "trace-abc";
+        return context;
+    }
+
+    [Fact]
+    public async Task ValidationException_EmitsCounter_WithMappedCodeAndValidationCategory()
+    {
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(
+            _ => throw new ValidationException("Bad input", code: ErrorCodes.ValidationMissingField),
+            metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        var m = Assert.Single(capture.Measurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(ErrorCodes.ValidationMissingField, m.Tags[ApiMetrics.TagErrorCode]);
+        Assert.Equal("validation", m.Tags[ApiMetrics.TagErrorCategory]);
+        Assert.Equal(400, m.Tags[ApiMetrics.TagStatusCode]);
+    }
+
+    [Fact]
+    public async Task NotFoundException_EmitsCounter_With404()
+    {
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(
+            _ => throw new NotFoundException(ErrorCodes.ClusterNotFound, "Cluster not found."),
+            metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        var m = Assert.Single(capture.Measurements);
+        Assert.Equal(ErrorCodes.ClusterNotFound, m.Tags[ApiMetrics.TagErrorCode]);
+        Assert.Equal("notfound", m.Tags[ApiMetrics.TagErrorCategory]);
+        Assert.Equal(404, m.Tags[ApiMetrics.TagStatusCode]);
+    }
+
+    [Fact]
+    public async Task RateLimitException_EmitsCounter_With429()
+    {
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(_ => throw new RateLimitException(), metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        var m = Assert.Single(capture.Measurements);
+        Assert.Equal(ErrorCodes.RateLimitExceeded, m.Tags[ApiMetrics.TagErrorCode]);
+        Assert.Equal("ratelimit", m.Tags[ApiMetrics.TagErrorCategory]);
+        Assert.Equal(429, m.Tags[ApiMetrics.TagStatusCode]);
+    }
+
+    [Fact]
+    public async Task DependencyException_EmitsCounter_With503()
+    {
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(
+            _ => throw new DependencyException(ErrorCodes.DependencyNlpUnavailable, "NLP down."),
+            metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        var m = Assert.Single(capture.Measurements);
+        Assert.Equal(ErrorCodes.DependencyNlpUnavailable, m.Tags[ApiMetrics.TagErrorCode]);
+        Assert.Equal("dependency", m.Tags[ApiMetrics.TagErrorCategory]);
+        Assert.Equal(503, m.Tags[ApiMetrics.TagStatusCode]);
+    }
+
+    [Fact]
+    public async Task UnmappedException_EmitsCounter_TaggedAsRedactedServerError()
+    {
+        // A bare Exception never surfaces its internal details on the wire —
+        // the mapper returns ServerInternalError with ErrorCategory.Unexpected.
+        // The metric must reflect the redacted wire view, not the raw
+        // exception type, so dashboards count what users actually observed.
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(
+            _ => throw new Exception("Internal DB password leak: Host=secret.db;Password=abc"),
+            metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        var m = Assert.Single(capture.Measurements);
+        Assert.Equal(ErrorCodes.ServerInternalError, m.Tags[ApiMetrics.TagErrorCode]);
+        Assert.Equal("unexpected", m.Tags[ApiMetrics.TagErrorCategory]);
+        Assert.Equal(500, m.Tags[ApiMetrics.TagStatusCode]);
+    }
+
+    [Fact]
+    public async Task InvariantViolation_EmitsCounter_TaggedAsRedactedServerError_NotInternalCode()
+    {
+        // InvariantViolationException carries an internal-only code
+        // (e.g. "clustering.no_spatial_cell") for log/trace debuggability.
+        // The mapper redacts it to ServerInternalError on the wire; the
+        // metric MUST bucket with the wire outcome so alerts/dashboards stay
+        // truthful — an internal-only code never appears as a metric value.
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(
+            _ => throw new InvariantViolationException(
+                ErrorCodes.ClusteringNoSpatialCell,
+                "Signal reached clustering with no spatial cell."),
+            metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        var m = Assert.Single(capture.Measurements);
+        Assert.Equal(ErrorCodes.ServerInternalError, m.Tags[ApiMetrics.TagErrorCode]);
+        Assert.Equal("unexpected", m.Tags[ApiMetrics.TagErrorCategory]);
+        Assert.Equal(500, m.Tags[ApiMetrics.TagStatusCode]);
+    }
+
+    [Fact]
+    public async Task SuccessfulRequest_DoesNotEmitCounter()
+    {
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(ctx =>
+        {
+            ctx.Response.StatusCode = 200;
+            return Task.CompletedTask;
+        }, metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+
+        Assert.Empty(capture.Measurements);
+    }
+
+    [Fact]
+    public async Task ClientDisconnectCancellation_DoesNotEmitCounter()
+    {
+        // Client disconnects surface as OperationCanceledException when
+        // context.RequestAborted is signalled. That path is intentionally
+        // not a handled API exception — it must not pollute error metrics.
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var context = CreateContext();
+        context.RequestAborted = cts.Token;
+
+        var middleware = CreateMiddleware(_ => throw new OperationCanceledException(), metrics);
+
+        await middleware.InvokeAsync(context);
+
+        Assert.Empty(capture.Measurements);
+    }
+
+    [Fact]
+    public async Task TwoExceptions_EmitTwoMeasurements()
+    {
+        using var metrics = TestMetrics.Create();
+        using var capture = new MetricCapture(metrics);
+
+        var middleware = CreateMiddleware(
+            _ => throw new ValidationException("bad", code: ErrorCodes.ValidationFailed),
+            metrics);
+
+        await middleware.InvokeAsync(CreateContext());
+        await middleware.InvokeAsync(CreateContext());
+
+        Assert.Equal(2, capture.Measurements.Count);
+        Assert.All(capture.Measurements, m => Assert.Equal(1L, m.Value));
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/ApiExceptionMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/ApiExceptionMetricsTests.cs
@@ -75,12 +75,12 @@ public class ApiExceptionMetricsTests
     [Fact]
     public async Task ValidationException_EmitsCounter_WithMappedCodeAndValidationCategory()
     {
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(
             _ => throw new ValidationException("Bad input", code: ErrorCodes.ValidationMissingField),
-            metrics);
+            scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -94,12 +94,12 @@ public class ApiExceptionMetricsTests
     [Fact]
     public async Task NotFoundException_EmitsCounter_With404()
     {
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(
             _ => throw new NotFoundException(ErrorCodes.ClusterNotFound, "Cluster not found."),
-            metrics);
+            scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -112,10 +112,10 @@ public class ApiExceptionMetricsTests
     [Fact]
     public async Task RateLimitException_EmitsCounter_With429()
     {
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
-        var middleware = CreateMiddleware(_ => throw new RateLimitException(), metrics);
+        var middleware = CreateMiddleware(_ => throw new RateLimitException(), scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -128,12 +128,12 @@ public class ApiExceptionMetricsTests
     [Fact]
     public async Task DependencyException_EmitsCounter_With503()
     {
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(
             _ => throw new DependencyException(ErrorCodes.DependencyNlpUnavailable, "NLP down."),
-            metrics);
+            scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -150,12 +150,12 @@ public class ApiExceptionMetricsTests
         // the mapper returns ServerInternalError with ErrorCategory.Unexpected.
         // The metric must reflect the redacted wire view, not the raw
         // exception type, so dashboards count what users actually observed.
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(
             _ => throw new Exception("Internal DB password leak: Host=secret.db;Password=abc"),
-            metrics);
+            scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -173,14 +173,14 @@ public class ApiExceptionMetricsTests
         // The mapper redacts it to ServerInternalError on the wire; the
         // metric MUST bucket with the wire outcome so alerts/dashboards stay
         // truthful — an internal-only code never appears as a metric value.
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(
             _ => throw new InvariantViolationException(
                 ErrorCodes.ClusteringNoSpatialCell,
                 "Signal reached clustering with no spatial cell."),
-            metrics);
+            scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -193,14 +193,14 @@ public class ApiExceptionMetricsTests
     [Fact]
     public async Task SuccessfulRequest_DoesNotEmitCounter()
     {
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(ctx =>
         {
             ctx.Response.StatusCode = 200;
             return Task.CompletedTask;
-        }, metrics);
+        }, scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
 
@@ -213,15 +213,15 @@ public class ApiExceptionMetricsTests
         // Client disconnects surface as OperationCanceledException when
         // context.RequestAborted is signalled. That path is intentionally
         // not a handled API exception — it must not pollute error metrics.
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var cts = new CancellationTokenSource();
         cts.Cancel();
         var context = CreateContext();
         context.RequestAborted = cts.Token;
 
-        var middleware = CreateMiddleware(_ => throw new OperationCanceledException(), metrics);
+        var middleware = CreateMiddleware(_ => throw new OperationCanceledException(), scope.Metrics);
 
         await middleware.InvokeAsync(context);
 
@@ -231,12 +231,12 @@ public class ApiExceptionMetricsTests
     [Fact]
     public async Task TwoExceptions_EmitTwoMeasurements()
     {
-        using var metrics = TestMetrics.Create();
-        using var capture = new MetricCapture(metrics);
+        using var scope = TestMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
 
         var middleware = CreateMiddleware(
             _ => throw new ValidationException("bad", code: ErrorCodes.ValidationFailed),
-            metrics);
+            scope.Metrics);
 
         await middleware.InvokeAsync(CreateContext());
         await middleware.InvokeAsync(CreateContext());

--- a/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
+++ b/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.Metrics;
 using Hali.Api.Observability;
 using Microsoft.Extensions.DependencyInjection;
@@ -5,20 +6,47 @@ using Microsoft.Extensions.DependencyInjection;
 namespace Hali.Tests.Unit.Observability;
 
 /// <summary>
-/// Shared helper for constructing an <see cref="ApiMetrics"/> backed by a
-/// real <see cref="IMeterFactory"/>. Using the real factory (instead of a
-/// hand-rolled <c>Meter</c>) exercises the same registration path the
-/// production container uses, so <c>MeterListener</c> attaches to the same
-/// meter OTel would export in production.
+/// Disposable wrapper around a test-owned <see cref="ApiMetrics"/> and the
+/// <see cref="ServiceProvider"/> that hosts its <see cref="IMeterFactory"/>.
+///
+/// Using a real <c>IMeterFactory</c> (instead of a hand-rolled <c>Meter</c>)
+/// exercises the same registration path the production container uses, so
+/// <c>MeterListener</c> attaches to the same meter OTel would export in
+/// production. Disposing the scope tears down both the <see cref="Metrics"/>
+/// instance (and its underlying <see cref="Meter"/>) and the
+/// <see cref="ServiceProvider"/> so repeated test construction does not leak
+/// disposables across the test suite.
+/// </summary>
+internal sealed class TestMetricsScope : IDisposable
+{
+    private readonly ServiceProvider _provider;
+    public ApiMetrics Metrics { get; }
+
+    internal TestMetricsScope(ServiceProvider provider, ApiMetrics metrics)
+    {
+        _provider = provider;
+        Metrics = metrics;
+    }
+
+    public void Dispose()
+    {
+        Metrics.Dispose();
+        _provider.Dispose();
+    }
+}
+
+/// <summary>
+/// Factory for <see cref="TestMetricsScope"/>. Callers own the returned
+/// scope and must dispose it (via <c>using</c> or a fixture).
 /// </summary>
 internal static class TestMetrics
 {
-    public static ApiMetrics Create()
+    public static TestMetricsScope Create()
     {
         var services = new ServiceCollection();
         services.AddMetrics();
         var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IMeterFactory>();
-        return new ApiMetrics(factory);
+        return new TestMetricsScope(provider, new ApiMetrics(factory));
     }
 }

--- a/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
+++ b/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.Metrics;
+using Hali.Api.Observability;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Hali.Tests.Unit.Observability;
+
+/// <summary>
+/// Shared helper for constructing an <see cref="ApiMetrics"/> backed by a
+/// real <see cref="IMeterFactory"/>. Using the real factory (instead of a
+/// hand-rolled <c>Meter</c>) exercises the same registration path the
+/// production container uses, so <c>MeterListener</c> attaches to the same
+/// meter OTel would export in production.
+/// </summary>
+internal static class TestMetrics
+{
+    public static ApiMetrics Create()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IMeterFactory>();
+        return new ApiMetrics(factory);
+    }
+}


### PR DESCRIPTION
Closes #164

## Problem
`ExceptionHandlingMiddleware` emits a structured `api.exception_handled` log line tagged with `{ErrorCode, ErrorCategory, StatusCode}` but no metric. The 51-entry canonical `ErrorCodes` catalog (H3 / #153) is therefore not actionable for alerting on error distribution shift — there is no counter to alert against for an `auth.otp_invalid` volume spike, a sudden dominance of `signal.duplicate`, or a surge in `dependency.*`.

## Root cause
No `Meter`/`Counter` was registered anywhere in the API. OTel transport is wired conditionally on `OTEL_EXPORTER_OTLP_ENDPOINT` in `Program.cs`, but it has no application-defined instrument to export.

## What changed
- `src/Hali.Api/Observability/ApiMetrics.cs` — new class that owns the `Hali.Api` `Meter` and the `api_exceptions_total` `Counter<long>`. Registered as a singleton; built via `IMeterFactory`.
- `Program.cs` — registers `ApiMetrics` in DI and adds `.AddMeter(ApiMetrics.MeterName)` to the OTel `WithMetrics` pipeline so the counter exports through the existing OTLP transport.
- `ExceptionHandlingMiddleware` — increments the counter in `HandleExceptionAsync`, between mapping and response serialization. The cancellation (client-disconnect) path intentionally does not emit.
- `ApiErrorMapping` gains a `Category` field; `ExceptionToApiErrorMapper` sets it to reflect the **post-redaction wire outcome** (internal `ErrorCategory.Unexpected` codes bucket as `unexpected`). This keeps ApiMetrics agnostic of redaction semantics.

## Metric name and tags
- Name: `api_exceptions_total` (counter, unit `{exception}`)
- Tags:
  - `error_code` — mapped `ErrorCodes` value (string)
  - `error_category` — lowercase `ErrorCategory` value (string, e.g. `validation`, `dependency`, `unexpected`)
  - `status_code` — HTTP status written on the wire (int)

All three are emitted from the `ApiErrorMapping` that the middleware is about to honour on the wire. Tag keys are exposed as `ApiMetrics.TagErrorCode`/`TagErrorCategory`/`TagStatusCode` constants so consumers and tests never duplicate literals.

## Why the chosen tags are safe
- `error_code` is bounded by the `ErrorCodes` catalog (≤51 public codes). Internal-only codes (e.g. `clustering.no_spatial_cell`) are redacted to `server.internal_error` before tagging, so the cardinality never grows beyond the catalog.
- `error_category` is an 11-value enum.
- `status_code` is a small discrete set (~8 distinct values in practice).
- Theoretical product ≈ 4500 combinations, but real distribution is tight because categories map to status codes. No request-derived value is attached — no path, method, account id, device id, correlation id, or raw message.

## Where the metric is emitted
`ExceptionHandlingMiddleware.HandleExceptionAsync`, immediately after `ExceptionToApiErrorMapper.Map(exception)` resolves the wire mapping and **before** response serialization. Emitting before the write means a serialization failure does not drop the observation. The `OperationCanceledException` client-disconnect path is intentionally skipped — it is not a handled API exception.

## Redacted / internal exceptions
`InvariantViolationException` carries an internal-only code (e.g. `clustering.no_spatial_cell`) in logs and traces for debuggability. The mapper redacts it to `server.internal_error` with `ErrorCategory.Unexpected` on the wire, and the metric reflects the **wire view** — dashboards count what users actually observed, not an internal invariant name. Unmapped `Exception` subclasses follow the same path.

## Tests added
`tests/Hali.Tests.Unit/Observability/ApiExceptionMetricsTests.cs` (9 test methods) uses a `MeterListener` attached to the test's isolated `ApiMetrics` instance and asserts:

- `ValidationException` emits one measurement with the passed code, `validation` category, `400` status.
- `NotFoundException` → mapped code, `notfound`, `404`.
- `RateLimitException` → `rate_limit.exceeded`, `ratelimit`, `429`.
- `DependencyException` → mapped code, `dependency`, `503`.
- Bare `Exception` is redacted to `server.internal_error` / `unexpected` / `500` on the metric.
- `InvariantViolationException` with an internal-only code is redacted the same way — the internal code never appears as a tag value.
- Successful requests emit no measurement.
- `OperationCanceledException` on a disconnected context emits no measurement.
- Two consecutive exceptions emit two measurements (counter semantics).

`TestMetrics.cs` — small helper that builds an `ApiMetrics` via a real `IMeterFactory` so tests use the same registration path as production.

`ExceptionHandlingMiddlewareTests.cs` updated to supply the new required `ApiMetrics` parameter via the same helper; all existing assertions preserved.

Total: `dotnet test` — 369 passed, 0 failed, 0 skipped.

## Out of scope
- Business-logic module metrics (home, signals, clusters, participation, notifications) — R3.a–d.
- Dashboards, alert rules, Grafana config.
- New error codes or envelope shape changes.
- #165 nullable cleanup, #169 feedback rate limiting, #166–#170.
- OpenAPI / mobile changes (none).

## Risk assessment
- **Low.** No wire response shape changes; no error mapping behaviour change; the existing log line is preserved byte-for-byte (`error.code`, `error.category`, `http.status_code`). All 10 pre-existing `ExceptionHandlingMiddlewareTests` assertions still pass.
- `ApiErrorMapping.Category` is new but the only consumers are the mapper (sets it) and the middleware (reads it for the metric tag). Existing middleware tests do not inspect the Category field, so they remain valid.
- When OTel is disabled (env var absent), the meter and counter still exist in-process but nothing exports them — zero behaviour regression.
- Cardinality analysis above confirms the tag set stays bounded over time.

## Pattern-setting note for R3.a–d
Subsequent observability work (home/signals/notifications counters) should follow the same shape: a `FooMetrics` class owning a `Meter("Hali.*")` + named instrument, registered as a singleton with tag-key constants exposed for call sites and tests. Dimensions should stay bounded by static catalogs, never request-derived values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)