### PR TITLE
[Issue #165] Reduce CS8600 nullable warnings

### DIFF
--- a/tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs
+++ b/tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs
@@ -17,7 +17,7 @@ internal sealed class FakeParticipationRepo : IParticipationRepository
 
 	public Task<Hali.Domain.Entities.Participation.Participation?> GetByDeviceAsync(Guid clusterId, Guid deviceId, CancellationToken ct)
 	{
-		Hali.Domain.Entities.Participation.Participation result = (from x in _store
+		Hali.Domain.Entities.Participation.Participation? result = (from x in _store
 			where x.ClusterId == clusterId && x.DeviceId == deviceId
 			orderby x.CreatedAt descending
 			select x).FirstOrDefault();
@@ -26,7 +26,7 @@ internal sealed class FakeParticipationRepo : IParticipationRepository
 
 	public Task<Hali.Domain.Entities.Participation.Participation?> GetMostRecentByAccountAsync(Guid clusterId, Guid accountId, CancellationToken ct)
 	{
-		Hali.Domain.Entities.Participation.Participation result = (from x in _store
+		Hali.Domain.Entities.Participation.Participation? result = (from x in _store
 			where x.ClusterId == clusterId && x.AccountId == accountId
 			orderby x.CreatedAt descending
 			select x).FirstOrDefault();
@@ -47,7 +47,7 @@ internal sealed class FakeParticipationRepo : IParticipationRepository
 
 	public Task UpdateContextAsync(Guid participationId, string contextText, CancellationToken ct)
 	{
-		Hali.Domain.Entities.Participation.Participation participation = _store.FirstOrDefault((Hali.Domain.Entities.Participation.Participation x) => x.Id == participationId);
+		Hali.Domain.Entities.Participation.Participation? participation = _store.FirstOrDefault((Hali.Domain.Entities.Participation.Participation x) => x.Id == participationId);
 		if (participation != null)
 		{
 			participation.ContextText = contextText;

--- a/tests/Hali.Tests.Unit/Signals/GeocodingServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/GeocodingServiceTests.cs
@@ -36,7 +36,7 @@ public class GeocodingServiceTests
 	{
 		FakeRedisDatabase fakeDb = new FakeRedisDatabase();
 		NominatimGeocodingService svc = CreateService(HttpStatusCode.OK, NominatimResponse, fakeDb);
-		GeocodingResult result = await svc.ReverseGeocodeAsync(-1.3, 36.8);
+		GeocodingResult? result = await svc.ReverseGeocodeAsync(-1.3, 36.8);
 		Assert.NotNull(result);
 		Assert.Contains("Nairobi", result.DisplayName);
 		Assert.Equal("Lusaka Road", result.Road);
@@ -55,7 +55,7 @@ public class GeocodingServiceTests
 		FakeHttpMessageHandler handler = new FakeHttpMessageHandler(HttpStatusCode.InternalServerError, "should not be called");
 		HttpClient http = new HttpClient(handler);
 		NominatimGeocodingService svc = new NominatimGeocodingService(http, db, NullLogger<NominatimGeocodingService>.Instance);
-		GeocodingResult result = await svc.ReverseGeocodeAsync(-1.3, 36.8);
+		GeocodingResult? result = await svc.ReverseGeocodeAsync(-1.3, 36.8);
 		Assert.NotNull(result);
 		Assert.Equal("Cached Display", result.DisplayName);
 		Assert.Equal("Cached Road", result.Road);

--- a/tests/Hali.Tests.Unit/Signals/NlpExtractionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Signals/NlpExtractionServiceTests.cs
@@ -36,7 +36,7 @@ public class NlpExtractionServiceTests
 		string nlpJson = "{\n  \"category\": \"roads\",\n  \"subcategory\": \"potholes\",\n  \"condition_level\": \"difficult\",\n  \"condition_confidence\": 0.85,\n  \"location\": {\n    \"area_name\": \"Nairobi West\",\n    \"road_name\": null,\n    \"junction_name\": null,\n    \"landmark_name\": \"National Oil\",\n    \"facility_name\": null,\n    \"location_label\": \"Potholes near National Oil, Nairobi West\",\n    \"location_precision_type\": \"road_landmark\",\n    \"location_confidence\": 0.80,\n    \"location_source\": \"nlp\"\n  },\n  \"temporal_hint\": { \"type\": \"temporary\", \"confidence\": 0.70 },\n  \"summary\": \"Potholes reported near National Oil in Nairobi West.\",\n  \"should_suggest_join\": true,\n  \"reasoning_notes\": [\"Detected road condition\", \"Detected landmark\"]\n}";
 		string anthropicResponse = WrapInAnthropicResponse(nlpJson);
 		AnthropicNlpExtractionService svc = CreateService(anthropicResponse);
-		NlpExtractionResultDto result = await svc.ExtractAsync(MakeRequest());
+		NlpExtractionResultDto? result = await svc.ExtractAsync(MakeRequest());
 		Assert.NotNull(result);
 		Assert.Equal("roads", result.Category);
 		Assert.Equal("potholes", result.Subcategory);
@@ -79,7 +79,7 @@ public class NlpExtractionServiceTests
 		string nlpJson = "{\n  \"category\": \"water\",\n  \"subcategory\": \"outage\",\n  \"condition_level\": \"none\",\n  \"condition_confidence\": 1.5,\n  \"location\": {\n    \"location_confidence\": -0.2,\n    \"location_source\": \"nlp\"\n  },\n  \"summary\": \"No water in South B.\",\n  \"should_suggest_join\": false\n}";
 		string anthropicResponse = WrapInAnthropicResponse(nlpJson);
 		AnthropicNlpExtractionService svc = CreateService(anthropicResponse);
-		NlpExtractionResultDto result = await svc.ExtractAsync(MakeRequest("No water in South B"));
+		NlpExtractionResultDto? result = await svc.ExtractAsync(MakeRequest("No water in South B"));
 		Assert.NotNull(result);
 		Assert.Equal(1.0, result.ConditionConfidence);
 		Assert.Equal(0.0, result.Location.LocationConfidence);
@@ -91,7 +91,7 @@ public class NlpExtractionServiceTests
 		string nlpJson = "```json\n{\n  \"category\": \"electricity\",\n  \"subcategory\": \"outage\",\n  \"condition_level\": \"complete_outage\",\n  \"condition_confidence\": 0.90,\n  \"location\": {\n    \"area_name\": \"South B\",\n    \"location_confidence\": 0.75,\n    \"location_source\": \"nlp\"\n  },\n  \"summary\": \"Power outage in South B.\",\n  \"should_suggest_join\": true\n}\n```";
 		string anthropicResponse = WrapInAnthropicResponse(nlpJson);
 		AnthropicNlpExtractionService svc = CreateService(anthropicResponse);
-		NlpExtractionResultDto result = await svc.ExtractAsync(MakeRequest("No power in South B"));
+		NlpExtractionResultDto? result = await svc.ExtractAsync(MakeRequest("No power in South B"));
 		Assert.NotNull(result);
 		Assert.Equal("electricity", result.Category);
 	}


### PR DESCRIPTION
Closes #165

## Problem
`dotnet build` was emitting 8 `CS8600 — Converting null literal or possible null value to non-nullable type` warnings. Accumulated nullable-safety warnings numb reviewers to real null issues on new PRs, and Phase 2 work will only add more DI-heavy code.

## Root cause
Eight test-file locals were typed as non-nullable but assigned the result of a method whose declared return type is `T?`:

- `FirstOrDefault()` on a `List<T>` of reference types
- `Task<GeocodingResult?>` from `NominatimGeocodingService.ReverseGeocodeAsync`
- `Task<NlpExtractionResultDto?>` from `AnthropicNlpExtractionService.ExtractAsync`

In each case the test follows the assignment with `Assert.NotNull(result)`, which the compiler uses to narrow the local for the rest of the test body.

## Warning baseline
The audit cited in #165 (`docs/audits/post_run_rebaseline_audit.md`) recorded 37 CS8600 warnings clustered in `src/Hali.Application/**` and `src/Hali.Infrastructure/**`. Those have all already been resolved by intervening PRs that touched those files (#157, #158, #161, #162, #163, #164). The current baseline on `develop` (commit `2a85839`) is **8 CS8600 warnings, all in test files**:

| File | Sites |
|---|---|
| `tests/Hali.Tests.Unit/Participation/FakeParticipationRepo.cs` | lines 20, 29, 50 |
| `tests/Hali.Tests.Unit/Signals/GeocodingServiceTests.cs` | lines 39, 58 |
| `tests/Hali.Tests.Unit/Signals/NlpExtractionServiceTests.cs` | lines 39, 82, 94 |

## What changed
8 character-level edits — appended `?` to the local-variable type at each warning site. No method signatures, no production code, no test logic, no assertions changed.

```diff
- GeocodingResult result = await svc.ReverseGeocodeAsync(-1.3, 36.8);
+ GeocodingResult? result = await svc.ReverseGeocodeAsync(-1.3, 36.8);
  Assert.NotNull(result);  // Assert.NotNull narrows for downstream reads
```

This expresses the truth of the API (it can return null) and lets the existing `Assert.NotNull` carry its weight.

No `!` null-forgiving operators were introduced. No `#pragma` suppressions. No method-signature changes.

## Warning count before vs after

| Code | Before | After |
|---|---|---|
| **CS8600** | **8** | **0** ✅ |

Other unrelated warnings (CS8603 / CS8613 / CS8619 / CS8767 / CS8620) live in `tests/Hali.Tests.Unit/Signals/FakeRedisDatabase.cs`, which is the explicit R5 audit item (Redis test-double drift). They were intentionally left unchanged — see "Out of scope" below.

## Tests added/updated
None. Each site is already covered by the test it lives in; the type change is invisible at runtime. `dotnet test` still passes — **369 unit + 60 integration tests, 0 failures**.

## Out of scope
- **R5 — `FakeRedisDatabase` interface-implementation nullability mismatches** (CS8603/8613/8619/8767/8620). Different warning codes, different audit item, much larger surface (~118 method overrides). The post-run audit explicitly classifies R5 as "test hardening (minor)… may be folded into R1 if convenient; otherwise defer indefinitely — not load-bearing." Folding it in here would balloon a 3-file 8-character PR into a 1700-line interface re-annotation. Left as-is.
- The `xUnit1026` warning on `CivisCalculatorTests.cs` (unused theory parameter). Unrelated.
- Pre-existing `dotnet format` whitespace violations on the touched files (tabs vs spaces). Verified to exist on `develop` independent of this change; cleaning them would be opportunistic churn outside the issue scope.
- Any production-code refactor — explicitly forbidden by issue #165.

## Risk assessment
**Minimal.** Eight character changes in test files. No production code, no method signatures, no test assertions, no runtime behaviour changes. The only observable effect is on the C# compiler's nullable-flow analysis. Full test suite passes.