### PR TITLE
[Issue #166] Add home feed observability metrics

### DIFF
--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -78,13 +78,20 @@ public class HomeController : ControllerBase
         var sw = Stopwatch.StartNew();
         _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeRequestStarted);
 
-        // Captured for the latency-histogram tag set, set inside the try block
-        // once we have resolved auth posture and locality scope. Defaults are
-        // safe fall-throughs if the request fails before the decision is made
-        // (e.g. an exception during follow lookup) — the histogram still emits
-        // so failed-request latency stays observable.
-        bool isAuthenticated = false;
-        string localityScope = HomeMetrics.LocalityScopeGuestEmpty;
+        // Captured for the latency-histogram tag set. `isAuthenticated` and
+        // the initial `localityScope` are set from cheap input inspection
+        // before the follow lookup runs so that an exception during that
+        // lookup (e.g. dependency outage) still tags the histogram with the
+        // correct resolution-mode — the failure mode itself is the operational
+        // signal we care about. `localityScope` is refined to `guest_empty`
+        // after the lookup only when the followed-localities set is actually
+        // empty.
+        bool isAuthenticated = User.Identity?.IsAuthenticated == true;
+        string localityScope = localityId.HasValue
+            ? HomeMetrics.LocalityScopeExplicit
+            : isAuthenticated
+                ? HomeMetrics.LocalityScopeFallback
+                : HomeMetrics.LocalityScopeGuestEmpty;
 
         try
         {
@@ -92,22 +99,23 @@ public class HomeController : ControllerBase
             // an explicit locality via ?localityId.  When omitted,
             // authenticated users fall back to their followed-localities set;
             // anonymous callers receive empty sections (no followed wards).
-            isAuthenticated = User.Identity?.IsAuthenticated == true;
             var localityIds = localityId.HasValue
                 ? new List<Guid> { localityId.Value }
                 : await GetFollowedLocalityIdsAsync(ct);
             var cursorDt = DecodeCursor(cursor);
 
-            // Log locality scoping mode and auth posture
+            // Log locality scoping mode and auth posture. The scope tag is
+            // refined here if the authenticated caller's follow set resolved
+            // empty — the request is no longer in "fallback" mode in any
+            // operationally useful sense, it matches the `guest_empty`
+            // resolution outcome (no localities available).
             if (localityId.HasValue)
             {
-                localityScope = HomeMetrics.LocalityScopeExplicit;
                 _logger?.LogInformation("{EventName} localityId={LocalityId} isAuthenticated={IsAuthenticated}",
                     ObservabilityEvents.HomeLocalityScopeExplicit, localityId.Value, isAuthenticated);
             }
             else if (localityIds.Count > 0)
             {
-                localityScope = HomeMetrics.LocalityScopeFallback;
                 _logger?.LogInformation("{EventName} localityCount={LocalityCount}",
                     ObservabilityEvents.HomeLocalityScopeFallback, localityIds.Count);
             }

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -1,12 +1,14 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Api.Observability;
 using Hali.Application.Errors;
 using Hali.Application.Home;
 using Hali.Application.Notifications;
@@ -36,6 +38,7 @@ public class HomeController : ControllerBase
     private readonly IHomeFeedQueryService _feedQuery;
     private readonly IFollowService _follows;
     private readonly IDatabase _redis;
+    private readonly HomeMetrics _metrics;
     private readonly ILogger<HomeController>? _logger;
 
     /// <summary>
@@ -53,12 +56,14 @@ public class HomeController : ControllerBase
         IFollowService follows,
         IDatabase redis,
         IOptions<Microsoft.AspNetCore.Mvc.JsonOptions> mvcJsonOptions,
+        HomeMetrics metrics,
         ILogger<HomeController>? logger = null)
     {
         _feedQuery = feedQuery;
         _follows = follows;
         _redis = redis;
         _cacheJsonOptions = mvcJsonOptions.Value.JsonSerializerOptions;
+        _metrics = metrics;
         _logger = logger;
     }
 
@@ -73,13 +78,21 @@ public class HomeController : ControllerBase
         var sw = Stopwatch.StartNew();
         _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeRequestStarted);
 
+        // Captured for the latency-histogram tag set, set inside the try block
+        // once we have resolved auth posture and locality scope. Defaults are
+        // safe fall-throughs if the request fails before the decision is made
+        // (e.g. an exception during follow lookup) — the histogram still emits
+        // so failed-request latency stays observable.
+        bool isAuthenticated = false;
+        string localityScope = HomeMetrics.LocalityScopeGuestEmpty;
+
         try
         {
             // Both authenticated and anonymous callers may scope the feed to
             // an explicit locality via ?localityId.  When omitted,
             // authenticated users fall back to their followed-localities set;
             // anonymous callers receive empty sections (no followed wards).
-            bool isAuthenticated = User.Identity?.IsAuthenticated == true;
+            isAuthenticated = User.Identity?.IsAuthenticated == true;
             var localityIds = localityId.HasValue
                 ? new List<Guid> { localityId.Value }
                 : await GetFollowedLocalityIdsAsync(ct);
@@ -87,14 +100,23 @@ public class HomeController : ControllerBase
 
             // Log locality scoping mode and auth posture
             if (localityId.HasValue)
+            {
+                localityScope = HomeMetrics.LocalityScopeExplicit;
                 _logger?.LogInformation("{EventName} localityId={LocalityId} isAuthenticated={IsAuthenticated}",
                     ObservabilityEvents.HomeLocalityScopeExplicit, localityId.Value, isAuthenticated);
+            }
             else if (localityIds.Count > 0)
+            {
+                localityScope = HomeMetrics.LocalityScopeFallback;
                 _logger?.LogInformation("{EventName} localityCount={LocalityCount}",
                     ObservabilityEvents.HomeLocalityScopeFallback, localityIds.Count);
+            }
             else
+            {
+                localityScope = HomeMetrics.LocalityScopeGuestEmpty;
                 _logger?.LogInformation("{EventName} isAuthenticated={IsAuthenticated}",
                     ObservabilityEvents.HomeLocalityScopeGuestEmpty, isAuthenticated);
+            }
 
             // Section-specific paginated request — skip cache, return single section
             if (section is not null)
@@ -103,14 +125,12 @@ public class HomeController : ControllerBase
                 string safeSection = ObservabilityEvents.SanitizeForLog(section);
                 if (paged is null)
                 {
-                    sw.Stop();
                     _logger?.LogInformation(
                         "{EventName} section={Section} statusCode={StatusCode} durationMs={DurationMs}",
                         ObservabilityEvents.HomeRequestCompleted, safeSection, 400, sw.ElapsedMilliseconds);
                     throw new ValidationException("Unknown section name.", code: ErrorCodes.ValidationInvalidSection);
                 }
 
-                sw.Stop();
                 _logger?.LogInformation(
                     "{EventName} section={Section} durationMs={DurationMs}",
                     ObservabilityEvents.HomeRequestCompleted, safeSection, sw.ElapsedMilliseconds);
@@ -126,7 +146,11 @@ public class HomeController : ControllerBase
                 RedisValue cached = await _redis.StringGetAsync(cacheKey);
                 if (cached.HasValue)
                 {
-                    sw.Stop();
+                    // Hit/miss counters fire exactly once per cache-eligible
+                    // request — recorded immediately after the Redis lookup
+                    // resolves so the metric reflects what actually happened
+                    // even if response serialization later fails.
+                    _metrics.HomeFeedCacheHitsTotal.Add(1);
                     _logger?.LogInformation("{EventName} durationMs={DurationMs}",
                         ObservabilityEvents.HomeCacheHit, sw.ElapsedMilliseconds);
                     _logger?.LogInformation(
@@ -135,6 +159,7 @@ public class HomeController : ControllerBase
                     return Content(cached!, "application/json");
                 }
 
+                _metrics.HomeFeedCacheMissesTotal.Add(1);
                 _logger?.LogInformation("{EventName}", ObservabilityEvents.HomeCacheMiss);
 
                 var response = await BuildFullResponseAsync(localityIds, ct);
@@ -150,7 +175,6 @@ public class HomeController : ControllerBase
                     await _redis.StringSetAsync(cacheKey, json, CacheTtl);
                 }
 
-                sw.Stop();
                 _logger?.LogInformation(
                     "{EventName} durationMs={DurationMs} cacheHit={CacheHit}",
                     ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds, false);
@@ -158,7 +182,6 @@ public class HomeController : ControllerBase
             }
 
             var fullResponse = await BuildFullResponseAsync(localityIds, ct);
-            sw.Stop();
             _logger?.LogInformation(
                 "{EventName} durationMs={DurationMs}",
                 ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds);
@@ -166,11 +189,25 @@ public class HomeController : ControllerBase
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
-            sw.Stop();
             _logger?.LogError(ex,
                 "{EventName} durationMs={DurationMs}",
                 ObservabilityEvents.HomeRequestFailed, sw.ElapsedMilliseconds);
             throw;
+        }
+        finally
+        {
+            // Stop the stopwatch and emit the latency histogram exactly once
+            // per request, on every path (cache-hit, cache-miss, full assembly,
+            // section-paged, validation/throw). Tag values are set above before
+            // the request can branch; the defaults used if an exception fires
+            // before the decision is made are still bounded by the catalog.
+            sw.Stop();
+            var tags = new TagList
+            {
+                { HomeMetrics.TagAuthenticated, isAuthenticated ? "true" : "false" },
+                { HomeMetrics.TagLocalityScope, localityScope }
+            };
+            _metrics.HomeFeedRequestDuration.Record(sw.Elapsed.TotalSeconds, tags);
         }
     }
 

--- a/src/Hali.Api/Observability/HomeMetrics.cs
+++ b/src/Hali.Api/Observability/HomeMetrics.cs
@@ -1,0 +1,131 @@
+using System;
+using System.Diagnostics.Metrics;
+
+namespace Hali.Api.Observability;
+
+/// <summary>
+/// Hosts the <c>Hali.Home</c> <see cref="Meter"/> and the instruments emitted
+/// from <c>HomeController</c>. The home feed is the single hottest read
+/// endpoint for the citizen mobile app, so this meter is the operational
+/// signal Phase 1 pilot readiness depends on:
+/// <list type="bullet">
+///   <item><description><c>home_feed_request_duration_seconds</c> — request
+///     latency histogram covering the controller handler from dispatch through
+///     response build (cache and assembly paths both included).</description></item>
+///   <item><description><c>home_feed_cache_hits_total</c> /
+///     <c>home_feed_cache_misses_total</c> — Redis cache outcome counters for
+///     the cache-eligible path (no cursor, at least one locality).</description></item>
+/// </list>
+///
+/// The meter is registered on the OpenTelemetry meter provider in
+/// <c>Program.cs</c> under the name <see cref="MeterName"/>. When
+/// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is unset the meter and its instruments
+/// still exist in-process (zero-cost, non-exported) and no behaviour regresses.
+///
+/// Tag values are bounded by static catalogs (no localityId, accountId, path,
+/// or request-derived strings) so cardinality stays controlled at scale —
+/// see the per-instrument summaries below.
+/// </summary>
+public sealed class HomeMetrics : IDisposable
+{
+    /// <summary>
+    /// Name of the home-feed <see cref="Meter"/>. Mirrored by
+    /// <c>AddMeter(HomeMetrics.MeterName)</c> on the OpenTelemetry meter
+    /// provider so instruments export through the existing OTLP transport.
+    /// </summary>
+    public const string MeterName = "Hali.Home";
+
+    /// <summary>Histogram name — request latency in seconds.</summary>
+    public const string HomeFeedRequestDurationName = "home_feed_request_duration_seconds";
+
+    /// <summary>Counter name — cache-eligible requests served from Redis.</summary>
+    public const string HomeFeedCacheHitsTotalName = "home_feed_cache_hits_total";
+
+    /// <summary>Counter name — cache-eligible requests that missed Redis.</summary>
+    public const string HomeFeedCacheMissesTotalName = "home_feed_cache_misses_total";
+
+    /// <summary>
+    /// Tag key carrying authentication posture. Values: <c>"true"</c> or
+    /// <c>"false"</c> (string, not bool, so OTLP exporters render the tag
+    /// consistently across backends).
+    /// </summary>
+    public const string TagAuthenticated = "authenticated";
+
+    /// <summary>
+    /// Tag key carrying locality-resolution mode. Values:
+    /// <c>"explicit"</c> (caller passed <c>?localityId</c>),
+    /// <c>"fallback"</c> (authenticated caller's followed-localities used),
+    /// <c>"guest_empty"</c> (anonymous caller with no explicit locality).
+    /// </summary>
+    public const string TagLocalityScope = "locality_scope";
+
+    // Locality-scope tag values — re-exported as constants so call sites and
+    // tests never duplicate string literals. Keep these in lockstep with the
+    // ObservabilityEvents.HomeLocalityScope* log event suffixes.
+    public const string LocalityScopeExplicit = "explicit";
+    public const string LocalityScopeFallback = "fallback";
+    public const string LocalityScopeGuestEmpty = "guest_empty";
+
+    private readonly Meter _meter;
+
+    /// <summary>
+    /// <c>home_feed_request_duration_seconds</c> — total controller handler
+    /// duration recorded once per request (success and failure). The recorded
+    /// span starts at controller dispatch and ends after the response is built
+    /// (both cache-hit and cache-miss/assembly paths are included), giving a
+    /// single operationally meaningful "what the caller waited for" signal
+    /// without coupling the metric to any internal sub-step.
+    ///
+    /// Tags (bounded — 2 × 3 = 6 combinations max):
+    /// <list type="bullet">
+    ///   <item><description><see cref="TagAuthenticated"/> —
+    ///     <c>"true"</c> or <c>"false"</c>.</description></item>
+    ///   <item><description><see cref="TagLocalityScope"/> —
+    ///     <c>"explicit" | "fallback" | "guest_empty"</c>.</description></item>
+    /// </list>
+    /// No request-derived value (path, method, locality id, account id,
+    /// correlation id, cursor, section name) is ever attached.
+    /// </summary>
+    public Histogram<double> HomeFeedRequestDuration { get; }
+
+    /// <summary>
+    /// <c>home_feed_cache_hits_total</c> — incremented exactly once per
+    /// cache-eligible request that was served from Redis. Cache eligibility
+    /// matches <c>HomeController</c>: no cursor and at least one resolved
+    /// locality. Untagged: a single counter aligned with the alert query
+    /// <c>rate(home_feed_cache_hits_total) /
+    ///       (rate(home_feed_cache_hits_total) + rate(home_feed_cache_misses_total))</c>.
+    /// </summary>
+    public Counter<long> HomeFeedCacheHitsTotal { get; }
+
+    /// <summary>
+    /// <c>home_feed_cache_misses_total</c> — incremented exactly once per
+    /// cache-eligible request that did not find a cached entry. Counterpart
+    /// of <see cref="HomeFeedCacheHitsTotal"/>; together they cover every
+    /// cache-eligible request exactly once.
+    /// </summary>
+    public Counter<long> HomeFeedCacheMissesTotal { get; }
+
+    public HomeMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+        _meter = meterFactory.Create(MeterName);
+
+        HomeFeedRequestDuration = _meter.CreateHistogram<double>(
+            name: HomeFeedRequestDurationName,
+            unit: "s",
+            description: "End-to-end home feed request duration as observed by HomeController.");
+
+        HomeFeedCacheHitsTotal = _meter.CreateCounter<long>(
+            name: HomeFeedCacheHitsTotalName,
+            unit: "{request}",
+            description: "Cache-eligible home feed requests served from the Redis cache.");
+
+        HomeFeedCacheMissesTotal = _meter.CreateCounter<long>(
+            name: HomeFeedCacheMissesTotalName,
+            unit: "{request}",
+            description: "Cache-eligible home feed requests that missed the Redis cache.");
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Hali.Api/Observability/HomeMetrics.cs
+++ b/src/Hali.Api/Observability/HomeMetrics.cs
@@ -52,10 +52,20 @@ public sealed class HomeMetrics : IDisposable
     public const string TagAuthenticated = "authenticated";
 
     /// <summary>
-    /// Tag key carrying locality-resolution mode. Values:
-    /// <c>"explicit"</c> (caller passed <c>?localityId</c>),
-    /// <c>"fallback"</c> (authenticated caller's followed-localities used),
-    /// <c>"guest_empty"</c> (anonymous caller with no explicit locality).
+    /// Tag key carrying locality-resolution outcome. Values:
+    /// <list type="bullet">
+    ///   <item><description><c>"explicit"</c> — caller passed <c>?localityId</c>.</description></item>
+    ///   <item><description><c>"fallback"</c> — authenticated caller with a
+    ///     non-empty followed-localities set. Also used on the exception path
+    ///     when the follow lookup throws for an authenticated caller without
+    ///     an explicit locality, so dependency outages in that lookup stay
+    ///     observable as fallback-mode failures rather than being silently
+    ///     rebucketed as guest traffic.</description></item>
+    ///   <item><description><c>"guest_empty"</c> — no localities were
+    ///     resolved. Anonymous callers without an explicit locality, and
+    ///     authenticated callers whose follow set resolved empty, both bucket
+    ///     here.</description></item>
+    /// </list>
     /// </summary>
     public const string TagLocalityScope = "locality_scope";
 

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -42,6 +42,10 @@ builder.Services.AddSingleton<ExceptionToApiErrorMapper>();
 // ApiMetrics owns the Hali.Api Meter + the api_exceptions_total counter. The
 // instance is long-lived; IMeterFactory is registered by the hosting stack.
 builder.Services.AddSingleton<ApiMetrics>();
+// HomeMetrics owns the Hali.Home Meter + the home feed latency histogram and
+// cache-hit/miss counters used by HomeController. Registered alongside
+// ApiMetrics so both meters export through the same OTel pipeline.
+builder.Services.AddSingleton<HomeMetrics>();
 
 string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
@@ -175,6 +179,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
         .WithMetrics(m => m
             .AddAspNetCoreInstrumentation()
             .AddMeter(ApiMetrics.MeterName)
+            .AddMeter(HomeMetrics.MeterName)
             .AddOtlpExporter(o => o.Endpoint = new Uri(otelEndpoint)));
 }
 

--- a/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
+++ b/tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs
@@ -17,6 +17,7 @@ using Hali.Contracts.Signals;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Notifications;
 using Hali.Domain.Enums;
+using Hali.Tests.Unit.Observability;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
@@ -321,11 +322,13 @@ public class ContractDriftTests
                 Arg.Any<CommandFlags>())
             .Returns(true);
 
+        using var metricsScope = TestHomeMetrics.Create();
         var controller = new HomeController(
             feedQuery,
             follows,
             redis,
             BuildMvcJsonOptions(),
+            metricsScope.Metrics,
             NullLogger<HomeController>.Instance);
         controller.ControllerContext = new ControllerContext
         {

--- a/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
+++ b/tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs
@@ -11,6 +11,7 @@ using Hali.Contracts.Home;
 using Hali.Domain.Entities.Clusters;
 using Hali.Domain.Entities.Notifications;
 using Hali.Domain.Enums;
+using Hali.Tests.Unit.Observability;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -24,7 +25,7 @@ namespace Hali.Tests.Unit.Home;
 /// Tests verifying B8 anonymous browse behavior on the HomeController.
 /// Anonymous users can pass ?localityId to scope the feed.
 /// </summary>
-public class HomeAnonymousBrowseTests
+public class HomeAnonymousBrowseTests : IDisposable
 {
     private static readonly Guid TestLocalityId = Guid.Parse("aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee");
     private static readonly Guid TestClusterId = Guid.Parse("11111111-2222-3333-4444-555555555555");
@@ -32,6 +33,9 @@ public class HomeAnonymousBrowseTests
     private readonly IHomeFeedQueryService _feedQuery = Substitute.For<IHomeFeedQueryService>();
     private readonly IFollowService _follows = Substitute.For<IFollowService>();
     private readonly IDatabase _redis = Substitute.For<IDatabase>();
+    private readonly TestHomeMetricsScope _metricsScope = TestHomeMetrics.Create();
+
+    public void Dispose() => _metricsScope.Dispose();
 
     private HomeController CreateController(ClaimsPrincipal? user = null)
     {
@@ -40,6 +44,7 @@ public class HomeAnonymousBrowseTests
             _follows,
             _redis,
             Microsoft.Extensions.Options.Options.Create(new Microsoft.AspNetCore.Mvc.JsonOptions()),
+            _metricsScope.Metrics,
             NullLogger<HomeController>.Instance);
 
         controller.ControllerContext = new ControllerContext

--- a/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Api.Observability;
+using Hali.Application.Errors;
+using Hali.Application.Home;
+using Hali.Application.Notifications;
+using Hali.Contracts.Advisories;
+using Hali.Contracts.Clusters;
+using Hali.Contracts.Home;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Entities.Notifications;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+/// <summary>
+/// Verifies that <c>HomeController</c> emits the home-feed observability
+/// instruments owned by <see cref="HomeMetrics"/>:
+/// <list type="bullet">
+///   <item><description>the <c>home_feed_request_duration_seconds</c>
+///     histogram fires exactly once per request, on every code path,
+///     with the intended bounded tag set;</description></item>
+///   <item><description>the <c>home_feed_cache_hits_total</c> /
+///     <c>home_feed_cache_misses_total</c> counters increment exactly once
+///     per cache-eligible request and never on the cache-bypass paths.</description></item>
+/// </list>
+///
+/// Each test owns an isolated <see cref="HomeMetrics"/> via
+/// <see cref="TestHomeMetrics"/> so the <see cref="MeterListener"/> only
+/// observes measurements from that test's meter — keeping the suite
+/// parallel-safe.
+/// </summary>
+public class HomeMetricsTests
+{
+    private sealed record DoubleMeasurement(double Value, Dictionary<string, object?> Tags);
+    private sealed record LongMeasurement(long Value, Dictionary<string, object?> Tags);
+
+    /// <summary>
+    /// Captures every measurement emitted by the three home-feed instruments
+    /// for the lifetime of the listener. The listener filters by reference
+    /// equality on the test-owned <see cref="HomeMetrics"/> instruments so
+    /// other meters in-process cannot pollute the recorded measurements.
+    /// </summary>
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<DoubleMeasurement> DurationMeasurements { get; } = new();
+        public List<LongMeasurement> CacheHitMeasurements { get; } = new();
+        public List<LongMeasurement> CacheMissMeasurements { get; } = new();
+
+        public MetricCapture(HomeMetrics metrics)
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(instrument, metrics.HomeFeedRequestDuration)
+                    || ReferenceEquals(instrument, metrics.HomeFeedCacheHitsTotal)
+                    || ReferenceEquals(instrument, metrics.HomeFeedCacheMissesTotal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+            {
+                if (ReferenceEquals(instrument, metrics.HomeFeedRequestDuration))
+                {
+                    DurationMeasurements.Add(new DoubleMeasurement(measurement, ToDict(tags)));
+                }
+            });
+
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                var dict = ToDict(tags);
+                if (ReferenceEquals(instrument, metrics.HomeFeedCacheHitsTotal))
+                {
+                    CacheHitMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+                else if (ReferenceEquals(instrument, metrics.HomeFeedCacheMissesTotal))
+                {
+                    CacheMissMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+            });
+
+            _listener.Start();
+        }
+
+        private static Dictionary<string, object?> ToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            foreach (var tag in tags)
+            {
+                dict[tag.Key] = tag.Value;
+            }
+            return dict;
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    private static readonly Guid TestLocalityId = Guid.Parse("c0c0c0c0-1111-2222-3333-444455556666");
+    private static readonly Guid TestAccountId = Guid.Parse("a0a0a0a0-1111-2222-3333-444455556666");
+
+    private static HomeController CreateController(
+        HomeMetrics metrics,
+        IHomeFeedQueryService feedQuery,
+        IFollowService follows,
+        IDatabase redis,
+        bool authenticated)
+    {
+        var controller = new HomeController(
+            feedQuery,
+            follows,
+            redis,
+            Microsoft.Extensions.Options.Options.Create(new Microsoft.AspNetCore.Mvc.JsonOptions()),
+            metrics,
+            NullLogger<HomeController>.Instance);
+
+        var context = new DefaultHttpContext();
+        if (authenticated)
+        {
+            var claims = new[]
+            {
+                new System.Security.Claims.Claim(
+                    "http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier",
+                    TestAccountId.ToString())
+            };
+            var identity = new System.Security.Claims.ClaimsIdentity(claims, "test");
+            context.User = new System.Security.Claims.ClaimsPrincipal(identity);
+        }
+        controller.ControllerContext = new ControllerContext { HttpContext = context };
+        return controller;
+    }
+
+    private static (IHomeFeedQueryService feedQuery, IFollowService follows, IDatabase redis) BuildEmptyDeps(
+        bool followsLocality = true)
+    {
+        var feedQuery = Substitute.For<IHomeFeedQueryService>();
+        var follows = Substitute.For<IFollowService>();
+        var redis = Substitute.For<IDatabase>();
+
+        follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(followsLocality
+                ? new List<Follow> { new() { LocalityId = TestLocalityId } }
+                : new List<Follow>());
+
+        feedQuery.GetActiveByLocalitiesPagedAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<bool?>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
+        feedQuery.GetAllActivePagedAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<int>(),
+                Arg.Any<DateTime?>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<SignalCluster>)Array.Empty<SignalCluster>());
+        feedQuery.GetOfficialPostsByLocalitiesAsync(
+                Arg.Any<IEnumerable<Guid>>(), Arg.Any<CancellationToken>())
+            .Returns((IReadOnlyList<OfficialPostResponseDto>)Array.Empty<OfficialPostResponseDto>());
+
+        redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(RedisValue.Null);
+
+        return (feedQuery, follows, redis);
+    }
+
+    // ── Histogram tests ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetHome_AuthenticatedFallback_EmitsHistogramOnce_WithFallbackTag()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.True(m.Value >= 0);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeFallback, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
+    [Fact]
+    public async Task GetHome_AnonymousExplicitLocality_EmitsHistogramOnce_WithExplicitTag()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps(followsLocality: false);
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: false);
+
+        await controller.GetHome(null, null, TestLocalityId, CancellationToken.None);
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal("false", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeExplicit, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
+    [Fact]
+    public async Task GetHome_AnonymousNoLocality_EmitsHistogramOnce_WithGuestEmptyTag()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps(followsLocality: false);
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: false);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal("false", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeGuestEmpty, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
+    [Fact]
+    public async Task GetHome_TwoConsecutiveRequests_EmitsHistogramTwice()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        Assert.Equal(2, capture.DurationMeasurements.Count);
+    }
+
+    [Fact]
+    public async Task GetHome_InvalidSection_StillEmitsHistogramOnce_OnExceptionPath()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await Assert.ThrowsAsync<ValidationException>(
+            () => controller.GetHome("not_a_real_section", null, null, CancellationToken.None));
+
+        // Histogram emits once even when the handler throws, so failed-request
+        // latency stays observable. Cache counters do not fire on the section
+        // path because section requests bypass the Redis cache by design.
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeFallback, m.Tags[HomeMetrics.TagLocalityScope]);
+        Assert.Empty(capture.CacheHitMeasurements);
+        Assert.Empty(capture.CacheMissMeasurements);
+    }
+
+    // ── Cache hit/miss counter tests ─────────────────────────────────────────
+
+    [Fact]
+    public async Task GetHome_CacheMiss_IncrementsMissCounterExactlyOnce_AndNoHit()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        var miss = Assert.Single(capture.CacheMissMeasurements);
+        Assert.Equal(1L, miss.Value);
+        Assert.Empty(capture.CacheHitMeasurements);
+    }
+
+    [Fact]
+    public async Task GetHome_CacheHit_IncrementsHitCounterExactlyOnce_AndNoMiss()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(new RedisValue("{}"));
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        var hit = Assert.Single(capture.CacheHitMeasurements);
+        Assert.Equal(1L, hit.Value);
+        Assert.Empty(capture.CacheMissMeasurements);
+    }
+
+    [Fact]
+    public async Task GetHome_AnonymousNoLocality_CacheBypass_NoCacheCounters()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps(followsLocality: false);
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: false);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        // Cache is only consulted when there is at least one resolved
+        // locality. Anonymous + no localityId means the cache path is
+        // bypassed entirely; neither counter should fire.
+        Assert.Empty(capture.CacheHitMeasurements);
+        Assert.Empty(capture.CacheMissMeasurements);
+        // Histogram still fires for the bypass path.
+        Assert.Single(capture.DurationMeasurements);
+    }
+
+    [Fact]
+    public async Task GetHome_PaginatedSection_BypassesCache_NoCacheCountersFire()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome("active_now", null, null, CancellationToken.None);
+
+        // Section requests skip the cache entirely; counters must not fire,
+        // but the histogram still observes the request.
+        Assert.Empty(capture.CacheHitMeasurements);
+        Assert.Empty(capture.CacheMissMeasurements);
+        Assert.Single(capture.DurationMeasurements);
+    }
+
+    [Fact]
+    public async Task GetHome_CursorPaginated_BypassesCache_NoCacheCountersFire()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        // Encode a non-null cursor — any base64 of ticks works.
+        var cursor = Convert.ToBase64String(
+            System.Text.Encoding.UTF8.GetBytes(DateTime.UtcNow.Ticks.ToString()));
+
+        await controller.GetHome(null, cursor, null, CancellationToken.None);
+
+        Assert.Empty(capture.CacheHitMeasurements);
+        Assert.Empty(capture.CacheMissMeasurements);
+        Assert.Single(capture.DurationMeasurements);
+    }
+
+    [Fact]
+    public async Task GetHome_CacheHitAndMiss_AreMutuallyExclusivePerRequest()
+    {
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps();
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        // First request: cache miss.
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        // Second request: simulate a cache hit by flipping the mock.
+        redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .Returns(new RedisValue("{}"));
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        // Exactly one miss (request 1) + exactly one hit (request 2) — the
+        // implementation never counts both for the same request.
+        Assert.Single(capture.CacheMissMeasurements);
+        Assert.Single(capture.CacheHitMeasurements);
+        Assert.Equal(2, capture.DurationMeasurements.Count);
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
@@ -18,6 +18,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using StackExchange.Redis;
 using Xunit;
 
@@ -217,6 +218,54 @@ public class HomeMetricsTests
         var m = Assert.Single(capture.DurationMeasurements);
         Assert.Equal("false", m.Tags[HomeMetrics.TagAuthenticated]);
         Assert.Equal(HomeMetrics.LocalityScopeGuestEmpty, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
+    [Fact]
+    public async Task GetHome_AuthenticatedNoFollows_RefinesScopeToGuestEmpty()
+    {
+        // An authenticated caller with zero followed localities is
+        // operationally equivalent to "no resolved localities" — the scope
+        // tag is refined from the initial `fallback` to `guest_empty` after
+        // the follow lookup returns. This mirrors the existing
+        // ObservabilityEvents.HomeLocalityScopeGuestEmpty structured log
+        // event, which fires under the same condition regardless of auth.
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps(followsLocality: false);
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome(null, null, null, CancellationToken.None);
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeGuestEmpty, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
+    [Fact]
+    public async Task GetHome_FollowLookupThrows_TagsAsFallback_NotGuestEmpty()
+    {
+        // Regression guard for the Copilot finding on PR #173: if the follow
+        // lookup throws (e.g. dependency outage) on an authenticated caller
+        // without an explicit localityId, the request was in `fallback`
+        // resolution mode at the moment of failure — the histogram must
+        // reflect that, not silently rebucket the failure as guest traffic.
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var feedQuery = Substitute.For<IHomeFeedQueryService>();
+        var follows = Substitute.For<IFollowService>();
+        var redis = Substitute.For<IDatabase>();
+        follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("follow lookup dependency unavailable"));
+
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => controller.GetHome(null, null, null, CancellationToken.None));
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeFallback, m.Tags[HomeMetrics.TagLocalityScope]);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs
@@ -23,12 +23,15 @@ using Xunit;
 
 namespace Hali.Tests.Unit.Observability;
 
-public class HomeObservabilityTests
+public class HomeObservabilityTests : IDisposable
 {
     private readonly IHomeFeedQueryService _feedQuery = Substitute.For<IHomeFeedQueryService>();
     private readonly IFollowService _follows = Substitute.For<IFollowService>();
     private readonly IDatabase _redis = Substitute.For<IDatabase>();
     private readonly RecordingLogger<HomeController> _logger = new();
+    private readonly TestHomeMetricsScope _metricsScope = TestHomeMetrics.Create();
+
+    public void Dispose() => _metricsScope.Dispose();
 
     private HomeController CreateController(bool authenticated = true, Guid? accountId = null)
     {
@@ -37,6 +40,7 @@ public class HomeObservabilityTests
             _follows,
             _redis,
             Microsoft.Extensions.Options.Options.Create(new Microsoft.AspNetCore.Mvc.JsonOptions()),
+            _metricsScope.Metrics,
             _logger);
         var context = new DefaultHttpContext();
         if (authenticated)

--- a/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
+++ b/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
@@ -50,3 +50,45 @@ internal static class TestMetrics
         return new TestMetricsScope(provider, new ApiMetrics(factory));
     }
 }
+
+/// <summary>
+/// Disposable wrapper around a test-owned <see cref="HomeMetrics"/> and the
+/// <see cref="ServiceProvider"/> that hosts its <see cref="IMeterFactory"/>.
+/// Mirrors <see cref="TestMetricsScope"/> for the home-feed meter so each
+/// test gets an isolated <see cref="System.Diagnostics.Metrics.Meter"/>
+/// instance and <see cref="System.Diagnostics.Metrics.MeterListener"/>
+/// observations stay scoped to that test.
+/// </summary>
+internal sealed class TestHomeMetricsScope : IDisposable
+{
+    private readonly ServiceProvider _provider;
+    public HomeMetrics Metrics { get; }
+
+    internal TestHomeMetricsScope(ServiceProvider provider, HomeMetrics metrics)
+    {
+        _provider = provider;
+        Metrics = metrics;
+    }
+
+    public void Dispose()
+    {
+        Metrics.Dispose();
+        _provider.Dispose();
+    }
+}
+
+/// <summary>
+/// Factory for <see cref="TestHomeMetricsScope"/>. Callers own the returned
+/// scope and must dispose it (via <c>using</c> or a fixture).
+/// </summary>
+internal static class TestHomeMetrics
+{
+    public static TestHomeMetricsScope Create()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IMeterFactory>();
+        return new TestHomeMetricsScope(provider, new HomeMetrics(factory));
+    }
+}


### PR DESCRIPTION
Closes #166

## Problem
`HomeController` and `HomeFeedQueryService` already emit structured log events from `Hali.Application/Observability/ObservabilityEvents.cs`, but the home feed — the single hottest read endpoint for the Phase 1 citizen mobile app — has no Prometheus/OTel metrics. Latency regressions land invisibly, and the Redis cache hit-rate cannot be tracked from the metrics pipeline. Pilot readiness needs both signals before R3.b–d (#167–#170) build on top of the same pattern.

## Root cause
No `Meter` was registered for the home-feed module. Issue #164 introduced the FooMetrics convention for `ApiMetrics`; this PR is the first module-tier consumer of that pattern.

## What changed
- `src/Hali.Api/Observability/HomeMetrics.cs` — new class owning the `Hali.Home` `Meter` and three instruments. Built via `IMeterFactory`, registered as a singleton, exposes tag-key + tag-value constants so call sites and tests never duplicate string literals.
- `src/Hali.Api/Controllers/HomeController.cs`:
  - Constructor takes `HomeMetrics`.
  - The existing `Stopwatch` now lives across all paths; the histogram is recorded exactly once in a `finally` block so success, cache-hit, cache-miss, section-paged, and exception paths all emit one observation.
  - `isAuthenticated` and the initial `localityScope` are captured from cheap input inspection **before** the follow lookup runs, so an exception in `GetFollowedLocalityIdsAsync` on an authenticated fallback request stays tagged as `fallback` (the resolution mode at the moment of failure) rather than being silently rebucketed as `guest_empty`. The tag is refined to `guest_empty` only inside the try block, after the follow lookup confirms an empty follow set.
  - Cache-hit / cache-miss counters increment exactly once each on the cache-eligible path (`cursor is null && localityIds.Count > 0`), at the moment the Redis lookup result resolves and before any response serialization — so a write failure cannot drop the observation.
  - No behaviour change to: response shape, cache eligibility/TTL, locality resolution, ordering, or error envelope.
- `src/Hali.Api/Program.cs` — registers `HomeMetrics` as a singleton and adds `HomeMetrics.MeterName` to the OTel `WithMetrics` pipeline alongside the existing `ApiMetrics` meter.
- `tests/Hali.Tests.Unit/Observability/TestMetrics.cs` — adds `TestHomeMetricsScope` + `TestHomeMetrics.Create()` mirroring the existing `TestMetricsScope` for `ApiMetrics`. Each test gets an isolated `Meter` so `MeterListener` stays parallel-safe.
- `tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs` — new test class (13 methods) covering histogram tag values across the three locality scopes × two auth postures, exception-path emission, follow-lookup-failure resolution-mode preservation, authenticated-no-follows refinement, hit/miss exclusivity, cache-bypass paths, and counter semantics across consecutive requests.
- `tests/Hali.Tests.Unit/Observability/HomeObservabilityTests.cs`, `tests/Hali.Tests.Unit/Home/HomeAnonymousBrowseTests.cs`, `tests/Hali.Tests.Unit/Contracts/ContractDriftTests.cs` — updated `HomeController` construction sites to supply the new `HomeMetrics` parameter via `TestHomeMetrics.Create()`.

## Metric names and tags
| Name | Type | Unit | Tags |
|---|---|---|---|
| `home_feed_request_duration_seconds` | `Histogram<double>` | `s` | `authenticated` ∈ `{"true","false"}`, `locality_scope` ∈ `{"explicit","fallback","guest_empty"}` |
| `home_feed_cache_hits_total` | `Counter<long>` | `{request}` | (none) |
| `home_feed_cache_misses_total` | `Counter<long>` | `{request}` | (none) |

Tag keys are exposed as `HomeMetrics.TagAuthenticated` / `HomeMetrics.TagLocalityScope`; locality-scope tag values as `HomeMetrics.LocalityScopeExplicit` / `LocalityScopeFallback` / `LocalityScopeGuestEmpty` so callers and tests reference one source of truth.

`locality_scope` taxonomy:
- `explicit` — caller passed `?localityId`.
- `fallback` — authenticated caller with a non-empty followed-localities set. Also applied on the exception path when the follow lookup throws for an authenticated caller without an explicit locality, so dependency outages in that lookup stay observable as fallback-mode failures.
- `guest_empty` — no localities were resolved. Anonymous callers without an explicit locality, and authenticated callers whose follow set resolved empty, both bucket here.

## Where latency is measured
The histogram measures the full `HomeController.GetHome` handler from controller dispatch through response build. The stopwatch starts on the first line of the action; a `finally` block records the elapsed seconds on every exit path (cache hit, cache miss + assembly + cache write, full assembly without cache eligibility, section-paged, and exception). This is the narrowest operationally meaningful slice that still answers "what did the caller wait for?" without coupling the metric to any internal sub-step. Section-build durations are already tracked via the `home.section.built` log event; this metric is deliberately the request-level signal, not a per-section one.

## How cache hits / misses are represented
Two separate untagged counters (`home_feed_cache_hits_total`, `home_feed_cache_misses_total`) — chosen because:
- the issue body explicitly suggested both names;
- separate counters compose cleanly with the natural alert query `rate(hits) / (rate(hits) + rate(misses))` without a tag selector;
- they fire only on the cache-eligible path (`cursor is null && localityIds.Count > 0`); section-paged, cursor-paged, and anonymous-no-locality requests bypass the cache and emit neither counter — which matches the truth the metric is meant to convey;
- a hit and a miss are mutually exclusive within one request, asserted in `GetHome_CacheHitAndMiss_AreMutuallyExclusivePerRequest`.

## Why the chosen tags are safe
- `authenticated` is a 2-value enum (`"true" | "false"`).
- `locality_scope` is a 3-value enum (`"explicit" | "fallback" | "guest_empty"`) bounded by the existing `ObservabilityEvents.HomeLocalityScope*` log constants.
- Theoretical product: 2 × 3 = 6 combinations for the histogram. Cache counters carry no tags.
- No request-derived value is attached: no `localityId`, no `accountId`, no path, no method, no cursor, no section name, no correlation id, no User-Agent. This explicitly addresses the "no `localityId`, no `accountId`, no path parameters" cardinality requirement in the issue.

## Tests added/updated
**New:** `tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs` — 13 tests using `MeterListener` filtered by reference equality on the test-owned instruments:
- Histogram with `(authenticated=true, locality_scope=fallback)` on the followed-localities path.
- Histogram with `(authenticated=false, locality_scope=explicit)` on anonymous browse.
- Histogram with `(authenticated=false, locality_scope=guest_empty)` when no locality resolves.
- Histogram with `(authenticated=true, locality_scope=guest_empty)` when an authenticated caller has no follows (refinement path).
- Histogram with `(authenticated=true, locality_scope=fallback)` when the follow lookup throws (regression guard for the Copilot-identified bug — preserves resolution-mode tag through dependency outages).
- Two consecutive requests emit two histogram observations.
- Exception path (`ValidationException` for an unknown section) still emits the histogram exactly once with the correct tags; cache counters do not fire.
- Cache miss → `home_feed_cache_misses_total += 1` and no hit measurement.
- Cache hit → `home_feed_cache_hits_total += 1` and no miss measurement.
- Anonymous + no localityId → cache bypass, no cache counters, histogram still fires.
- Section-paged request → cache bypass, no cache counters, histogram still fires.
- Cursor-paginated request → cache bypass, no cache counters, histogram still fires.
- Hit and miss are mutually exclusive within a single request across two consecutive requests.

**Updated:** `HomeObservabilityTests`, `HomeAnonymousBrowseTests`, `ContractDriftTests` to construct `HomeController` with the new parameter via `TestHomeMetrics.Create()`. All prior assertions preserved.

`dotnet build` — 0 errors. `dotnet test tests/Hali.Tests.Unit` — **382 passed, 0 failed, 0 skipped** (369 prior + 13 new). `dotnet test tests/Hali.Tests.Integration --filter Home` — 7 passed, 0 failed. `dotnet format --verify-no-changes` on touched files — clean.

## Out of scope
- Dashboards, alert rule definitions, Grafana config (separate work after the pilot-readiness arc lands).
- Tracing spans for the home feed (the issue defers this).
- Per-locality cardinality (would explode cardinality — explicitly forbidden by the issue).
- Section-level latency metrics (already covered by the `home.section.built` structured log event; promoting to a metric is a separate decision).
- Signals metrics (#167), Participation/Clusters metrics (#168), Feedback hardening (#169), Notifications metrics (#170) — these are separate PRs in the same R3 arc and reuse this PR's pattern.
- OpenAPI changes, mobile changes, error model changes, cache redesign, nullable cleanup (#165), error-mapping changes (#164) — none touched.

## Risk assessment
- **Low.** No wire response shape changes, no cache eligibility/TTL change, no locality-resolution change, no ordering change, no error envelope change. The exception path still rethrows; the existing structured log lines (including `durationMs={DurationMs}`) are byte-for-byte preserved because the stopwatch is read before the finally block runs `Stop()` (which only sets the elapsed reading; subsequent reads return the same value).
- The only public surface change is the `HomeController` constructor signature; three test files were updated in lockstep. Production DI resolves the new singleton automatically.
- When OTel is disabled (env var absent), the meter and instruments still exist in-process but nothing exports them — zero behaviour regression.
- Cardinality analysis (above) keeps the histogram's tag product at 6 and the counters at 1 each — well within Prometheus best practice.

## Pattern-setting note for R3.b–d
This PR confirms the FooMetrics pattern transfers cleanly from the API tier (`ApiMetrics`, #164) to the module tier. Subsequent observability work (`SignalsMetrics`, `NotificationsMetrics`, etc.) should follow the same shape: a `FooMetrics` class owning a `Meter("Hali.<Module>")` + named instruments, registered as a singleton, with tag-key + tag-value constants exposed for call sites and tests. Dimensions stay bounded by static catalogs, never request-derived values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
