### PR TITLE
[Issue #167] Add signals observability metrics

### DIFF
--- a/src/Hali.Api/Controllers/SignalsController.cs
+++ b/src/Hali.Api/Controllers/SignalsController.cs
@@ -1,9 +1,11 @@
 using System;
+using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
 using Hali.Application.Errors;
+using Hali.Application.Observability;
 using Hali.Application.Signals;
 using Hali.Contracts.Signals;
 using Hali.Domain.Entities.Auth;
@@ -22,69 +24,185 @@ public class SignalsController : ControllerBase
 
     private readonly IAuthRepository _auth;
 
-    public SignalsController(ISignalIngestionService ingestion, IAuthRepository auth)
+    private readonly SignalsMetrics? _metrics;
+
+    public SignalsController(
+        ISignalIngestionService ingestion,
+        IAuthRepository auth,
+        SignalsMetrics? metrics = null)
     {
         _ingestion = ingestion;
         _auth = auth;
+        _metrics = metrics;
     }
 
     [HttpPost("preview")]
     [AllowAnonymous]
     public async Task<IActionResult> Preview([FromBody] SignalPreviewRequestDto dto, CancellationToken ct, [FromServices] IConnectionMultiplexer redis)
     {
-        // BLOCKING-4 fix: rate limit anonymous NLP previews (10/IP/10min)
-        var _previewIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
-        var _previewKey = $"rl:signal-preview:{_previewIp}";
-        var _previewDb = redis.GetDatabase();
-        var _previewCount = await _previewDb.StringIncrementAsync(_previewKey);
-        if (_previewCount == 1) await _previewDb.KeyExpireAsync(_previewKey, TimeSpan.FromMinutes(10));
-        if (_previewCount > 10)
-            throw new RateLimitException(ErrorCodes.RateLimitExceeded, "Too many preview requests.");
-
-        if (string.IsNullOrWhiteSpace(dto.FreeText))
+        // The request-outcome counter is incremented exactly once per non-
+        // cancellation call. `emit` stays true on every normal code path and
+        // flips to false only when OperationCanceledException propagates —
+        // client disconnects are not an operational signal about the endpoint
+        // itself, so they do not bias any bucket. The outcome string defaults
+        // to dependency_error and is tightened by the catch clauses when the
+        // exception kind is known; on the success path it is set just before
+        // the happy-path return.
+        string outcome = SignalsMetrics.OutcomeDependencyError;
+        bool emit = true;
+        try
         {
-            throw new ValidationException("free_text is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
-                {
-                    ["free_text"] = ["free_text is required."]
-                });
-        }
+            // BLOCKING-4 fix: rate limit anonymous NLP previews (10/IP/10min)
+            var _previewIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+            var _previewKey = $"rl:signal-preview:{_previewIp}";
+            var _previewDb = redis.GetDatabase();
+            var _previewCount = await _previewDb.StringIncrementAsync(_previewKey);
+            if (_previewCount == 1) await _previewDb.KeyExpireAsync(_previewKey, TimeSpan.FromMinutes(10));
+            if (_previewCount > 10)
+            {
+                // Rate limit → 429. Bucketed as validation_error so dashboards
+                // don't alert on user-behaviour-driven spikes; dependency_error
+                // is reserved for actual server/dependency failures.
+                outcome = SignalsMetrics.OutcomeValidationError;
+                throw new RateLimitException(ErrorCodes.RateLimitExceeded, "Too many preview requests.");
+            }
 
-        return Ok(await _ingestion.PreviewAsync(dto, ct));
+            if (string.IsNullOrWhiteSpace(dto.FreeText))
+            {
+                outcome = SignalsMetrics.OutcomeValidationError;
+                throw new ValidationException("free_text is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
+                    {
+                        ["free_text"] = ["free_text is required."]
+                    });
+            }
+
+            var response = await _ingestion.PreviewAsync(dto, ct);
+            outcome = SignalsMetrics.OutcomeSuccess;
+            return Ok(response);
+        }
+        catch (OperationCanceledException)
+        {
+            emit = false;
+            throw;
+        }
+        catch (ValidationException)
+        {
+            outcome = SignalsMetrics.OutcomeValidationError;
+            throw;
+        }
+        catch (RateLimitException)
+        {
+            outcome = SignalsMetrics.OutcomeValidationError;
+            throw;
+        }
+        catch (DependencyException)
+        {
+            outcome = SignalsMetrics.OutcomeDependencyError;
+            throw;
+        }
+        catch
+        {
+            // Any other exception (including unmapped AppException subclasses
+            // and non-AppException exceptions translated to 500 by
+            // ExceptionHandlingMiddleware) lands in the dependency bucket —
+            // the default already set above.
+            throw;
+        }
+        finally
+        {
+            if (emit)
+            {
+                _metrics?.SignalsPreviewRequestsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(SignalsMetrics.TagOutcome, outcome));
+            }
+        }
     }
 
     [HttpPost("submit")]
     [Authorize]
     public async Task<IActionResult> Submit([FromBody] SignalSubmitRequestDto dto, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(dto.IdempotencyKey))
+        // Same contract as Preview above — increment once, on every non-
+        // cancellation path, with a bounded outcome.
+        string outcome = SignalsMetrics.OutcomeDependencyError;
+        bool emit = true;
+        try
         {
-            throw new ValidationException("idempotency_key is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
-                {
-                    ["idempotency_key"] = ["idempotency_key is required."]
-                });
-        }
-        if (string.IsNullOrWhiteSpace(dto.DeviceHash))
-        {
-            throw new ValidationException("device_hash is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["device_hash is required."]
-                });
-        }
-        Guid? accountId = null;
-        string sub = base.User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
-        if (Guid.TryParse(sub, out var parsed))
-        {
-            accountId = parsed;
-        }
-        Device device = ((!string.IsNullOrWhiteSpace(dto.DeviceHash)) ? (await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct)) : null);
-        Device device2 = device;
+            if (string.IsNullOrWhiteSpace(dto.IdempotencyKey))
+            {
+                outcome = SignalsMetrics.OutcomeValidationError;
+                throw new ValidationException("idempotency_key is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
+                    {
+                        ["idempotency_key"] = ["idempotency_key is required."]
+                    });
+            }
+            if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+            {
+                outcome = SignalsMetrics.OutcomeValidationError;
+                throw new ValidationException("device_hash is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new System.Collections.Generic.Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["device_hash is required."]
+                    });
+            }
+            Guid? accountId = null;
+            string sub = base.User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier");
+            if (Guid.TryParse(sub, out var parsed))
+            {
+                accountId = parsed;
+            }
+            Device device = ((!string.IsNullOrWhiteSpace(dto.DeviceHash)) ? (await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct)) : null);
+            Device device2 = device;
 
-        return Ok(await _ingestion.SubmitAsync(dto, accountId, device2?.Id, ct));
+            var response = await _ingestion.SubmitAsync(dto, accountId, device2?.Id, ct);
+            outcome = SignalsMetrics.OutcomeSuccess;
+            return Ok(response);
+        }
+        catch (OperationCanceledException)
+        {
+            emit = false;
+            throw;
+        }
+        catch (ValidationException)
+        {
+            outcome = SignalsMetrics.OutcomeValidationError;
+            throw;
+        }
+        catch (ConflictException)
+        {
+            // Duplicate idempotency key — a user-visible 409, not a server
+            // failure. Bucketed with other validation rejections.
+            outcome = SignalsMetrics.OutcomeValidationError;
+            throw;
+        }
+        catch (RateLimitException)
+        {
+            outcome = SignalsMetrics.OutcomeValidationError;
+            throw;
+        }
+        catch (DependencyException)
+        {
+            outcome = SignalsMetrics.OutcomeDependencyError;
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+        finally
+        {
+            if (emit)
+            {
+                _metrics?.SignalsSubmitRequestsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(SignalsMetrics.TagOutcome, outcome));
+            }
+        }
     }
 }

--- a/src/Hali.Api/Controllers/SignalsController.cs
+++ b/src/Hali.Api/Controllers/SignalsController.cs
@@ -41,13 +41,16 @@ public class SignalsController : ControllerBase
     public async Task<IActionResult> Preview([FromBody] SignalPreviewRequestDto dto, CancellationToken ct, [FromServices] IConnectionMultiplexer redis)
     {
         // The request-outcome counter is incremented exactly once per non-
-        // cancellation call. `emit` stays true on every normal code path and
-        // flips to false only when OperationCanceledException propagates —
-        // client disconnects are not an operational signal about the endpoint
-        // itself, so they do not bias any bucket. The outcome string defaults
-        // to dependency_error and is tightened by the catch clauses when the
-        // exception kind is known; on the success path it is set just before
-        // the happy-path return.
+        // cancellation call. `emit` flips to false only when the caller's
+        // CancellationToken was actually signaled — a true client-disconnect
+        // is not an operational signal about the endpoint itself, so it does
+        // not bias any bucket. An OperationCanceledException with an
+        // unsignaled token is a server-side timeout (e.g. HttpClient budget
+        // exhausted) and is bucketed as dependency_error so submit/preview
+        // throughput does not go silent during real upstream outages.
+        // The outcome string defaults to dependency_error and is tightened
+        // by the catch clauses when the exception kind is known; on the
+        // success path it is set just before the happy-path return.
         string outcome = SignalsMetrics.OutcomeDependencyError;
         bool emit = true;
         try
@@ -82,9 +85,20 @@ public class SignalsController : ControllerBase
             outcome = SignalsMetrics.OutcomeSuccess;
             return Ok(response);
         }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // True client cancellation — the caller's token is signaled.
+            // Skip the counter so disconnects do not skew outcome ratios.
+            emit = false;
+            throw;
+        }
         catch (OperationCanceledException)
         {
-            emit = false;
+            // Token not signaled — this is a server-side timeout dressed as
+            // OperationCanceledException (HttpClient / Polly / dependency
+            // budget). Bucket it as dependency_error so upstream failures
+            // stay visible to operators.
+            outcome = SignalsMetrics.OutcomeDependencyError;
             throw;
         }
         catch (ValidationException)
@@ -157,16 +171,25 @@ public class SignalsController : ControllerBase
             {
                 accountId = parsed;
             }
-            Device device = ((!string.IsNullOrWhiteSpace(dto.DeviceHash)) ? (await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct)) : null);
-            Device device2 = device;
+            // DeviceHash was validated non-empty above, so the lookup always
+            // runs and its result is the only source of truth for the
+            // device id.
+            Device? device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
 
-            var response = await _ingestion.SubmitAsync(dto, accountId, device2?.Id, ct);
+            var response = await _ingestion.SubmitAsync(dto, accountId, device?.Id, ct);
             outcome = SignalsMetrics.OutcomeSuccess;
             return Ok(response);
         }
-        catch (OperationCanceledException)
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
             emit = false;
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            // Server-side timeout (see Preview for the full rationale) —
+            // bucket as dependency_error instead of silently dropping.
+            outcome = SignalsMetrics.OutcomeDependencyError;
             throw;
         }
         catch (ValidationException)

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -46,6 +46,11 @@ builder.Services.AddSingleton<ApiMetrics>();
 // cache-hit/miss counters used by HomeController. Registered alongside
 // ApiMetrics so both meters export through the same OTel pipeline.
 builder.Services.AddSingleton<HomeMetrics>();
+// SignalsMetrics owns the Hali.Signals Meter + the signal ingestion counters,
+// NLP extraction latency histogram, and join-outcome counter emitted from
+// SignalsController / AnthropicNlpExtractionService / ClusteringService /
+// CivisEvaluationService. Same singleton lifetime as the other meters.
+builder.Services.AddSingleton<Hali.Application.Observability.SignalsMetrics>();
 
 string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
@@ -180,6 +185,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
             .AddAspNetCoreInstrumentation()
             .AddMeter(ApiMetrics.MeterName)
             .AddMeter(HomeMetrics.MeterName)
+            .AddMeter(Hali.Application.Observability.SignalsMetrics.MeterName)
             .AddOtlpExporter(o => o.Endpoint = new Uri(otelEndpoint)));
 }
 

--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -21,14 +22,18 @@ public class CivisEvaluationService : ICivisEvaluationService
 
     private readonly ILogger<CivisEvaluationService>? _logger;
 
+    private readonly SignalsMetrics? _metrics;
+
     public CivisEvaluationService(IClusterRepository repo, IOptions<CivisOptions> options,
         INotificationQueueService? notificationQueue = null,
-        ILogger<CivisEvaluationService>? logger = null)
+        ILogger<CivisEvaluationService>? logger = null,
+        SignalsMetrics? metrics = null)
     {
         _repo = repo;
         _options = options.Value;
         _notificationQueue = notificationQueue;
         _logger = logger;
+        _metrics = metrics;
     }
 
     public async Task EvaluateClusterAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
@@ -92,6 +97,18 @@ public class CivisEvaluationService : ICivisEvaluationService
                 _logger?.LogInformation(
                     "{EventName} clusterId={ClusterId} localityId={LocalityId} category={Category}",
                     ObservabilityEvents.ClusterActivated, clusterId, cluster.LocalityId, cluster.Category);
+
+                // Activation counter fires at the same decision point as the
+                // structured ClusterActivated log — once per unconfirmed →
+                // active transition. Operators can compute the activation
+                // rate directly (no need to derive it from log joins), and
+                // the bucket stays consistent with the join-outcome counter
+                // emitted earlier in ClusteringService.
+                _metrics?.SignalJoinOutcomeTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(
+                        SignalsMetrics.TagOutcome,
+                        SignalsMetrics.JoinOutcomeActivatedCluster));
 
                 if (_notificationQueue != null)
                 {

--- a/src/Hali.Application/Clusters/ClusteringService.cs
+++ b/src/Hali.Application/Clusters/ClusteringService.cs
@@ -25,13 +25,22 @@ public class ClusteringService : IClusteringService
 
     private readonly ILogger<ClusteringService>? _logger;
 
-    public ClusteringService(IClusterRepository repo, IH3CellService h3, ICivisEvaluationService civis, IOptions<CivisOptions> options, ILogger<ClusteringService>? logger = null)
+    private readonly SignalsMetrics? _metrics;
+
+    public ClusteringService(
+        IClusterRepository repo,
+        IH3CellService h3,
+        ICivisEvaluationService civis,
+        IOptions<CivisOptions> options,
+        ILogger<ClusteringService>? logger = null,
+        SignalsMetrics? metrics = null)
     {
         _repo = repo;
         _h3 = h3;
         _civis = civis;
         _options = options.Value;
         _logger = logger;
+        _metrics = metrics;
     }
 
     public async Task<ClusterRoutingResult> RouteSignalAsync(SignalEvent signal, CancellationToken ct = default(CancellationToken))
@@ -108,6 +117,17 @@ public class ClusteringService : IClusteringService
                 "{EventName} clusterId={ClusterId} outcome={Outcome} joinScore={JoinScore} candidateCount={CandidateCount}",
                 ObservabilityEvents.SignalRouted, bestCluster.Id, "joined", bestScore, candidates.Count);
 
+            // Join-outcome counter fires once here — at the true decision
+            // point — so the metric reflects what actually happened rather
+            // than inferring from downstream state. The activation bucket is
+            // incremented separately in CivisEvaluationService if and only if
+            // the submission flipped the cluster to Active.
+            _metrics?.SignalJoinOutcomeTotal.Add(
+                1,
+                new KeyValuePair<string, object?>(
+                    SignalsMetrics.TagOutcome,
+                    SignalsMetrics.JoinOutcomeJoinedExisting));
+
             return new ClusterRoutingResult(
                 bestCluster.Id,
                 WasCreated: false,
@@ -157,6 +177,12 @@ public class ClusteringService : IClusteringService
             _logger?.LogInformation(
                 "{EventName} clusterId={ClusterId} outcome={Outcome} candidateCount={CandidateCount}",
                 ObservabilityEvents.SignalRouted, newCluster.Id, "created", candidates.Count);
+
+            _metrics?.SignalJoinOutcomeTotal.Add(
+                1,
+                new KeyValuePair<string, object?>(
+                    SignalsMetrics.TagOutcome,
+                    SignalsMetrics.JoinOutcomeCreatedNew));
 
             return new ClusterRoutingResult(
                 newCluster.Id,

--- a/src/Hali.Application/Hali.Application.csproj
+++ b/src/Hali.Application/Hali.Application.csproj
@@ -7,6 +7,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Hali.Domain\Hali.Domain.csproj" />
     <ProjectReference Include="..\Hali.Contracts\Hali.Contracts.csproj" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.Abstractions" Version="10.0.5" />
     <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.5" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.17.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.17.0" />

--- a/src/Hali.Application/Observability/SignalsMetrics.cs
+++ b/src/Hali.Application/Observability/SignalsMetrics.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Diagnostics.Metrics;
+
+namespace Hali.Application.Observability;
+
+/// <summary>
+/// Hosts the <c>Hali.Signals</c> <see cref="Meter"/> and the instruments emitted
+/// across the signal intake pipeline (R3.b, issue #167). The pipeline —
+/// <c>SignalsController</c> → <c>SignalIngestionService</c> →
+/// <c>AnthropicNlpExtractionService</c> → <c>ClusteringService</c> →
+/// <c>CivisEvaluationService</c> — is the hottest write path in Phase 1. Before
+/// this meter it had structured logs but no queryable time series for the three
+/// operational questions the pilot must answer at a glance:
+/// <list type="bullet">
+///   <item><description><c>signals_preview_requests_total</c> /
+///     <c>signals_submit_requests_total</c> — ingestion throughput counters
+///     (tagged by request outcome only).</description></item>
+///   <item><description><c>nlp_extraction_duration_seconds</c> — latency
+///     histogram around the Anthropic HTTP call + parse span only, tagged by
+///     NLP outcome so regressions on either the happy path or the fallback
+///     path stay visible.</description></item>
+///   <item><description><c>signal_join_outcome_total</c> — clustering decision
+///     counter covering join-vs-create-new plus the downstream activation
+///     transition that turns an unconfirmed cluster active.</description></item>
+/// </list>
+///
+/// The meter is registered on the OpenTelemetry meter provider in
+/// <c>Program.cs</c> under the name <see cref="MeterName"/>. When
+/// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is unset the meter and its instruments
+/// still exist in-process (zero-cost, non-exported) and no behaviour regresses.
+///
+/// The class lives in <c>Hali.Application.Observability</c> (rather than
+/// <c>Hali.Api.Observability</c> where <c>HomeMetrics</c> lives) because the
+/// instruments are emitted from three layers — API (controller counters),
+/// Application (clustering + activation counter), and Infrastructure (NLP
+/// histogram). The application project is the lowest common reference point
+/// the other two already depend on.
+///
+/// Tag values are bounded by static catalogs — no request-derived string
+/// (free_text, locality name, category, subcategory, idempotency key,
+/// account id, device id, cluster id, spatial cell id, or NLP internals) is
+/// ever attached. At steady state this meter produces 4 × 3 = 12 time series
+/// at most, matching the cardinality envelope the observability backend can
+/// budget for pilot.
+/// </summary>
+public sealed class SignalsMetrics : IDisposable
+{
+    /// <summary>
+    /// Name of the signals <see cref="Meter"/>. Mirrored by
+    /// <c>AddMeter(SignalsMetrics.MeterName)</c> on the OpenTelemetry meter
+    /// provider so instruments export through the existing OTLP transport.
+    /// </summary>
+    public const string MeterName = "Hali.Signals";
+
+    /// <summary>Counter name — anonymous <c>POST /v1/signals/preview</c> requests.</summary>
+    public const string SignalsPreviewRequestsTotalName = "signals_preview_requests_total";
+
+    /// <summary>Counter name — authenticated <c>POST /v1/signals/submit</c> requests.</summary>
+    public const string SignalsSubmitRequestsTotalName = "signals_submit_requests_total";
+
+    /// <summary>Histogram name — NLP extraction call duration in seconds.</summary>
+    public const string NlpExtractionDurationName = "nlp_extraction_duration_seconds";
+
+    /// <summary>Counter name — clustering / activation outcomes for submitted signals.</summary>
+    public const string SignalJoinOutcomeTotalName = "signal_join_outcome_total";
+
+    /// <summary>
+    /// Tag key carrying the operational outcome for every instrument owned by
+    /// this meter. Values are drawn from the per-instrument catalogs defined
+    /// below (<see cref="OutcomeSuccess"/>, <see cref="OutcomeValidationError"/>,
+    /// <see cref="OutcomeDependencyError"/> for request counters;
+    /// <see cref="NlpOutcomeSuccess"/>, <see cref="NlpOutcomeFallback"/>,
+    /// <see cref="NlpOutcomeTimeout"/> for the NLP histogram;
+    /// <see cref="JoinOutcomeJoinedExisting"/>, <see cref="JoinOutcomeCreatedNew"/>,
+    /// <see cref="JoinOutcomeActivatedCluster"/> for the join counter). A single
+    /// shared tag key keeps dashboards uniform and simplifies correlation
+    /// queries across the four instruments.
+    /// </summary>
+    public const string TagOutcome = "outcome";
+
+    // ── Preview / submit request-counter outcomes ────────────────────────────
+    // These mirror the three-way wire-visible bucket the issue defined:
+    // success (the controller returned a 2xx body), validation_error (user
+    // input rejected — ValidationException / ConflictException /
+    // RateLimitException / NotFoundException mapped as 4xx), and
+    // dependency_error (system/dependency failure — DependencyException,
+    // InvariantViolationException, and any other unmapped exception that
+    // lands as a 5xx). OperationCanceledException is not counted as any
+    // outcome (see SignalsController).
+
+    /// <summary>Outcome tag value: request succeeded (2xx response).</summary>
+    public const string OutcomeSuccess = "success";
+
+    /// <summary>Outcome tag value: request rejected due to user input (4xx class).</summary>
+    public const string OutcomeValidationError = "validation_error";
+
+    /// <summary>Outcome tag value: request failed due to a dependency / server error (5xx class).</summary>
+    public const string OutcomeDependencyError = "dependency_error";
+
+    // ── NLP histogram outcomes ───────────────────────────────────────────────
+    // NLP outcomes are distinct from request outcomes because the NLP call
+    // can return null (fallback) while the outer request still returns a
+    // deterministic response (the ingestion service then throws a bounded
+    // DependencyException). The timeout bucket lets operators distinguish
+    // slow-upstream failures from hard-upstream failures without reaching
+    // for trace data.
+
+    /// <summary>NLP outcome tag value: extraction returned a structured result.</summary>
+    public const string NlpOutcomeSuccess = "success";
+
+    /// <summary>
+    /// NLP outcome tag value: extraction returned null (HTTP non-2xx,
+    /// malformed JSON, disallowed category, or any other error the parser
+    /// rejected). Does not indicate the caller request failed — the
+    /// ingestion layer maps this to <c>dependency.nlp_unavailable</c>.
+    /// </summary>
+    public const string NlpOutcomeFallback = "fallback";
+
+    /// <summary>
+    /// NLP outcome tag value: the Anthropic call itself did not complete
+    /// within the HttpClient timeout (<see cref="System.Threading.Tasks.TaskCanceledException"/>
+    /// not caused by the caller cancellation token). Distinguishes upstream
+    /// latency regressions from other fallback causes.
+    /// </summary>
+    public const string NlpOutcomeTimeout = "timeout";
+
+    // ── Join-outcome counter values ──────────────────────────────────────────
+    // joined_existing / created_new are emitted from ClusteringService at the
+    // decision point (WasCreated = false / true). activated_cluster is emitted
+    // from CivisEvaluationService when a cluster transitions from
+    // SignalState.Unconfirmed → SignalState.Active — the same event that
+    // already emits the ClusterActivated structured log. A single submission
+    // can therefore contribute at most one join/create increment plus one
+    // (optional) activation increment.
+
+    /// <summary>Join outcome tag value: submitted signal was attached to an existing cluster.</summary>
+    public const string JoinOutcomeJoinedExisting = "joined_existing";
+
+    /// <summary>Join outcome tag value: submitted signal created a new cluster.</summary>
+    public const string JoinOutcomeCreatedNew = "created_new";
+
+    /// <summary>
+    /// Join outcome tag value: cluster transitioned from
+    /// <c>unconfirmed</c> → <c>active</c> in the CIVIS evaluation triggered by
+    /// this submission. Counted in addition to the joined_existing or
+    /// created_new increment for the same signal when activation fires.
+    /// </summary>
+    public const string JoinOutcomeActivatedCluster = "activated_cluster";
+
+    private readonly Meter _meter;
+
+    /// <summary>
+    /// <c>signals_preview_requests_total</c> — incremented exactly once per
+    /// <c>POST /v1/signals/preview</c> request, with a single bounded
+    /// <see cref="TagOutcome"/> tag. Recorded in <c>SignalsController.Preview</c>
+    /// so the counter observes the wire-visible outcome, not internal NLP
+    /// behaviour (that is covered separately by
+    /// <see cref="NlpExtractionDuration"/>).
+    /// </summary>
+    public Counter<long> SignalsPreviewRequestsTotal { get; }
+
+    /// <summary>
+    /// <c>signals_submit_requests_total</c> — incremented exactly once per
+    /// <c>POST /v1/signals/submit</c> request, with a single bounded
+    /// <see cref="TagOutcome"/> tag. Recorded in <c>SignalsController.Submit</c>
+    /// so the counter observes the wire-visible outcome after idempotency,
+    /// rate limiting, validation, spatial derivation, clustering, and CIVIS
+    /// evaluation have all run.
+    /// </summary>
+    public Counter<long> SignalsSubmitRequestsTotal { get; }
+
+    /// <summary>
+    /// <c>nlp_extraction_duration_seconds</c> — latency histogram covering the
+    /// <c>AnthropicNlpExtractionService.ExtractAsync</c> call. The recorded
+    /// span starts immediately before the outbound HTTP send and ends after
+    /// the response body is parsed and validated (the only segment the
+    /// product actually exposes to users as "composer thinking time"). It
+    /// deliberately does not include idempotency / rate-limit / persistence
+    /// work from the outer ingestion path — those are covered by the
+    /// submit-request counter.
+    ///
+    /// Tag:
+    /// <list type="bullet">
+    ///   <item><description><see cref="TagOutcome"/> —
+    ///     <see cref="NlpOutcomeSuccess"/> |
+    ///     <see cref="NlpOutcomeFallback"/> |
+    ///     <see cref="NlpOutcomeTimeout"/>.</description></item>
+    /// </list>
+    /// </summary>
+    public Histogram<double> NlpExtractionDuration { get; }
+
+    /// <summary>
+    /// <c>signal_join_outcome_total</c> — counter covering the clustering
+    /// decision and the downstream activation transition, tagged only with
+    /// <see cref="TagOutcome"/>:
+    /// <list type="bullet">
+    ///   <item><description><see cref="JoinOutcomeJoinedExisting"/> — emitted
+    ///     in <c>ClusteringService.RouteSignalAsync</c> when the scored
+    ///     candidate beats the join threshold.</description></item>
+    ///   <item><description><see cref="JoinOutcomeCreatedNew"/> — emitted in
+    ///     <c>ClusteringService.RouteSignalAsync</c> when no candidate beats
+    ///     the threshold.</description></item>
+    ///   <item><description><see cref="JoinOutcomeActivatedCluster"/> —
+    ///     emitted in <c>CivisEvaluationService.EvaluateClusterAsync</c> when
+    ///     MACF + device-diversity gates trip and the cluster transitions to
+    ///     <c>Active</c>. Added on top of the join/create increment, so the
+    ///     activation rate is directly queryable as
+    ///     <c>rate(signal_join_outcome_total{outcome="activated_cluster"})</c>.</description></item>
+    /// </list>
+    /// No cluster id, locality id, category, or candidate score ever lands in
+    /// a tag — the counter is deliberately dimensionless beyond the outcome
+    /// bucket to keep dashboards correct at scale.
+    /// </summary>
+    public Counter<long> SignalJoinOutcomeTotal { get; }
+
+    public SignalsMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+        _meter = meterFactory.Create(MeterName);
+
+        SignalsPreviewRequestsTotal = _meter.CreateCounter<long>(
+            name: SignalsPreviewRequestsTotalName,
+            unit: "{request}",
+            description: "Number of POST /v1/signals/preview requests, tagged by wire-visible outcome.");
+
+        SignalsSubmitRequestsTotal = _meter.CreateCounter<long>(
+            name: SignalsSubmitRequestsTotalName,
+            unit: "{request}",
+            description: "Number of POST /v1/signals/submit requests, tagged by wire-visible outcome.");
+
+        NlpExtractionDuration = _meter.CreateHistogram<double>(
+            name: NlpExtractionDurationName,
+            unit: "s",
+            description: "Duration of the Anthropic NLP extraction call and response parse.");
+
+        SignalJoinOutcomeTotal = _meter.CreateCounter<long>(
+            name: SignalJoinOutcomeTotalName,
+            unit: "{signal}",
+            description: "Clustering and activation outcomes for submitted signals.");
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Hali.Application/Observability/SignalsMetrics.cs
+++ b/src/Hali.Application/Observability/SignalsMetrics.cs
@@ -82,11 +82,14 @@ public sealed class SignalsMetrics : IDisposable
     // These mirror the three-way wire-visible bucket the issue defined:
     // success (the controller returned a 2xx body), validation_error (user
     // input rejected — ValidationException / ConflictException /
-    // RateLimitException / NotFoundException mapped as 4xx), and
-    // dependency_error (system/dependency failure — DependencyException,
-    // InvariantViolationException, and any other unmapped exception that
-    // lands as a 5xx). OperationCanceledException is not counted as any
-    // outcome (see SignalsController).
+    // RateLimitException mapped as 4xx), and dependency_error
+    // (system/dependency failure — DependencyException, any unmapped
+    // AppException subclass, server-side timeouts surfaced as
+    // OperationCanceledException with an unsignaled caller token, and any
+    // other exception translated to a 5xx by ExceptionHandlingMiddleware).
+    // Only true caller-initiated cancellation (ct.IsCancellationRequested
+    // at catch time) is excluded from the taxonomy entirely — see
+    // SignalsController for the guard.
 
     /// <summary>Outcome tag value: request succeeded (2xx response).</summary>
     public const string OutcomeSuccess = "success";

--- a/src/Hali.Infrastructure/Signals/AnthropicNlpExtractionService.cs
+++ b/src/Hali.Infrastructure/Signals/AnthropicNlpExtractionService.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
@@ -7,6 +8,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Observability;
 using Hali.Application.Signals;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -23,20 +25,34 @@ public class AnthropicNlpExtractionService : INlpExtractionService
 
 	private readonly ILogger<AnthropicNlpExtractionService> _logger;
 
+	private readonly SignalsMetrics? _metrics;
+
 	private static readonly HashSet<string> AllowedCategories = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "roads", "transport", "electricity", "water", "environment", "safety", "governance", "infrastructure" };
 
 	private static readonly HashSet<string> AllowedTemporalTypes = new HashSet<string>(StringComparer.OrdinalIgnoreCase) { "temporary", "continuous", "recurring", "scheduled", "episodic_unknown" };
 
-	public AnthropicNlpExtractionService(HttpClient http, IConfiguration config, ILogger<AnthropicNlpExtractionService> logger)
+	public AnthropicNlpExtractionService(
+		HttpClient http,
+		IConfiguration config,
+		ILogger<AnthropicNlpExtractionService> logger,
+		SignalsMetrics? metrics = null)
 	{
 		_http = http;
 		_apiKey = config["Anthropic:ApiKey"] ?? throw new InvalidOperationException("Anthropic:ApiKey is required");
 		_model = config["Anthropic:Model"] ?? "claude-sonnet-4-6";
 		_logger = logger;
+		_metrics = metrics;
 	}
 
 	public async Task<NlpExtractionResultDto?> ExtractAsync(NlpExtractionRequest request, CancellationToken ct = default(CancellationToken))
 	{
+		// The histogram timer wraps the HTTP send + body-parse span only —
+		// prompt construction is deterministic and sub-millisecond so
+		// including it would muddy the "composer thinking time" signal the
+		// metric is supposed to represent. The outcome tag is set to a
+		// default of `fallback` and refined to `success` on a clean parse or
+		// `timeout` if HttpClient surfaces a TaskCanceledException that was
+		// not caused by the caller's cancellation token.
 		string prompt = BuildPrompt(request);
 		var body = new
 		{
@@ -56,23 +72,68 @@ public class AnthropicNlpExtractionService : INlpExtractionService
 		req.Headers.Add("x-api-key", _apiKey);
 		req.Headers.Add("anthropic-version", "2023-06-01");
 		req.Content = JsonContent.Create(body);
-		HttpResponseMessage response;
+
+		string outcome = SignalsMetrics.NlpOutcomeFallback;
+		bool record = true;
+		var sw = Stopwatch.StartNew();
 		try
 		{
-			response = await _http.SendAsync(req, ct);
+			HttpResponseMessage response;
+			try
+			{
+				response = await _http.SendAsync(req, ct);
+			}
+			catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+			{
+				// HttpClient surfaces its own timeout as TaskCanceledException;
+				// when the caller's CancellationToken was not signaled, the
+				// cancellation came from the HttpClient timeout budget and
+				// is operationally a timeout, not a generic fallback.
+				outcome = SignalsMetrics.NlpOutcomeTimeout;
+				_logger.LogError(ex, "Anthropic API request timed out");
+				return null;
+			}
+			catch (OperationCanceledException)
+			{
+				// Caller cancellation — leave the histogram unrecorded so
+				// dashboards do not conflate client disconnects with NLP
+				// latency. Matches the behaviour of the request counters in
+				// SignalsController.
+				record = false;
+				throw;
+			}
+			catch (Exception ex)
+			{
+				_logger.LogError(ex, "Anthropic API request failed");
+				return null;
+			}
+			if (!response.IsSuccessStatusCode)
+			{
+				_logger.LogError("Anthropic API returned {Status}", response.StatusCode);
+				return null;
+			}
+			var result = ParseAndValidate(await response.Content.ReadAsStringAsync(ct));
+			if (result is not null)
+			{
+				outcome = SignalsMetrics.NlpOutcomeSuccess;
+			}
+			return result;
 		}
-		catch (Exception ex)
+		catch (OperationCanceledException)
 		{
-			Exception ex2 = ex;
-			_logger.LogError(ex2, "Anthropic API request failed");
-			return null;
+			record = false;
+			throw;
 		}
-		if (!response.IsSuccessStatusCode)
+		finally
 		{
-			_logger.LogError("Anthropic API returned {Status}", response.StatusCode);
-			return null;
+			sw.Stop();
+			if (record)
+			{
+				_metrics?.NlpExtractionDuration.Record(
+					sw.Elapsed.TotalSeconds,
+					new KeyValuePair<string, object?>(SignalsMetrics.TagOutcome, outcome));
+			}
 		}
-		return ParseAndValidate(await response.Content.ReadAsStringAsync(ct));
 	}
 
 	private NlpExtractionResultDto? ParseAndValidate(string rawBody)

--- a/src/Hali.Infrastructure/Signals/AnthropicNlpExtractionService.cs
+++ b/src/Hali.Infrastructure/Signals/AnthropicNlpExtractionService.cs
@@ -73,40 +73,23 @@ public class AnthropicNlpExtractionService : INlpExtractionService
 		req.Headers.Add("anthropic-version", "2023-06-01");
 		req.Content = JsonContent.Create(body);
 
+		// Outcome ladder for the histogram:
+		//   - success  : ParseAndValidate returned a non-null result.
+		//   - timeout  : OperationCanceledException (includes TaskCanceledException,
+		//                which HttpClient raises on its own timeout budget) with
+		//                an UNSIGNALED caller token — regardless of whether it
+		//                fires from SendAsync, ReadAsStringAsync, or later.
+		//   - fallback : any other failure path (non-2xx, network error, parse
+		//                error, unknown category).
+		// A true caller-initiated cancellation (ct.IsCancellationRequested is
+		// true) is propagated without recording so dashboards don't conflate
+		// client disconnects with NLP latency. Matches SignalsController.
 		string outcome = SignalsMetrics.NlpOutcomeFallback;
 		bool record = true;
 		var sw = Stopwatch.StartNew();
 		try
 		{
-			HttpResponseMessage response;
-			try
-			{
-				response = await _http.SendAsync(req, ct);
-			}
-			catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
-			{
-				// HttpClient surfaces its own timeout as TaskCanceledException;
-				// when the caller's CancellationToken was not signaled, the
-				// cancellation came from the HttpClient timeout budget and
-				// is operationally a timeout, not a generic fallback.
-				outcome = SignalsMetrics.NlpOutcomeTimeout;
-				_logger.LogError(ex, "Anthropic API request timed out");
-				return null;
-			}
-			catch (OperationCanceledException)
-			{
-				// Caller cancellation — leave the histogram unrecorded so
-				// dashboards do not conflate client disconnects with NLP
-				// latency. Matches the behaviour of the request counters in
-				// SignalsController.
-				record = false;
-				throw;
-			}
-			catch (Exception ex)
-			{
-				_logger.LogError(ex, "Anthropic API request failed");
-				return null;
-			}
+			HttpResponseMessage response = await _http.SendAsync(req, ct);
 			if (!response.IsSuccessStatusCode)
 			{
 				_logger.LogError("Anthropic API returned {Status}", response.StatusCode);
@@ -119,10 +102,21 @@ public class AnthropicNlpExtractionService : INlpExtractionService
 			}
 			return result;
 		}
-		catch (OperationCanceledException)
+		catch (OperationCanceledException) when (ct.IsCancellationRequested)
 		{
 			record = false;
 			throw;
+		}
+		catch (OperationCanceledException ex)
+		{
+			outcome = SignalsMetrics.NlpOutcomeTimeout;
+			_logger.LogError(ex, "Anthropic API request timed out");
+			return null;
+		}
+		catch (Exception ex)
+		{
+			_logger.LogError(ex, "Anthropic API request failed");
+			return null;
 		}
 		finally
 		{

--- a/tests/Hali.Tests.Unit/Observability/SignalsMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/SignalsMetricsTests.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.Metrics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Api.Controllers;
@@ -232,10 +231,38 @@ public class SignalsMetricsTests
     [Fact]
     public async Task Preview_ClientCancelled_DoesNotIncrementPreviewCounter()
     {
-        // OperationCanceledException is explicitly excluded from the outcome
-        // taxonomy — disconnects should not bias any of the three buckets.
+        // True caller cancellation (token signaled) is excluded from the
+        // outcome taxonomy — disconnects should not bias any of the three
+        // buckets. A canceled CTS mirrors the real request-abort scenario
+        // and distinguishes it from server-side timeouts, which surface as
+        // OperationCanceledException with an unsignaled caller token and
+        // are bucketed as dependency_error.
         using var scope = TestSignalsMetrics.Create();
         using var capture = new MetricCapture(scope.Metrics);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.PreviewAsync(Arg.Any<SignalPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            controller.Preview(PreviewRequest(), cts.Token, BuildAllowAllRedis()));
+
+        Assert.Empty(capture.PreviewMeasurements);
+    }
+
+    [Fact]
+    public async Task Preview_ServerSideTimeout_IncrementsPreviewCounter_DependencyError()
+    {
+        // OperationCanceledException with an unsignaled caller token is a
+        // server-side timeout (HttpClient / dependency budget), not a
+        // client disconnect — the counter must still emit so upstream
+        // outages stay visible to operators.
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
         var ingestion = Substitute.For<ISignalIngestionService>();
         ingestion.PreviewAsync(Arg.Any<SignalPreviewRequestDto>(), Arg.Any<CancellationToken>())
             .ThrowsAsync(new OperationCanceledException());
@@ -244,7 +271,8 @@ public class SignalsMetricsTests
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
             controller.Preview(PreviewRequest(), CancellationToken.None, BuildAllowAllRedis()));
 
-        Assert.Empty(capture.PreviewMeasurements);
+        var m = Assert.Single(capture.PreviewMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeDependencyError, m.Tags[SignalsMetrics.TagOutcome]);
     }
 
     // ── SignalsController.Submit — submit counter ────────────────────────────
@@ -305,6 +333,26 @@ public class SignalsMetricsTests
 
         var m = Assert.Single(capture.SubmitMeasurements);
         Assert.Equal(SignalsMetrics.OutcomeValidationError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Submit_ServerSideTimeout_IncrementsSubmitCounter_DependencyError()
+    {
+        // Mirror of Preview_ServerSideTimeout: an unsignaled caller token
+        // means the OperationCanceledException is a server-side budget
+        // exhaustion, not a client disconnect.
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.SubmitAsync(Arg.Any<SignalSubmitRequestDto>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            controller.Submit(SubmitRequest(), CancellationToken.None));
+
+        var m = Assert.Single(capture.SubmitMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeDependencyError, m.Tags[SignalsMetrics.TagOutcome]);
     }
 
     [Fact]

--- a/tests/Hali.Tests.Unit/Observability/SignalsMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/SignalsMetricsTests.cs
@@ -1,0 +1,702 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Auth;
+using Hali.Application.Clusters;
+using Hali.Application.Errors;
+using Hali.Application.Observability;
+using Hali.Application.Signals;
+using Hali.Contracts.Signals;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Entities.Signals;
+using Hali.Domain.Enums;
+using Hali.Infrastructure.Signals;
+using Hali.Tests.Unit.Clusters;
+using Hali.Tests.Unit.Signals;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+/// <summary>
+/// Verifies that the signals pipeline emits the four instruments owned by
+/// <see cref="SignalsMetrics"/>:
+/// <list type="bullet">
+///   <item><description><c>signals_preview_requests_total</c> /
+///     <c>signals_submit_requests_total</c> — increment exactly once per
+///     controller call with a bounded outcome tag and no request-derived
+///     dimensions;</description></item>
+///   <item><description><c>nlp_extraction_duration_seconds</c> — records
+///     once per completed NLP call on the success, fallback, and timeout
+///     paths (and stays silent on caller-cancellation);</description></item>
+///   <item><description><c>signal_join_outcome_total</c> — emits
+///     <c>joined_existing</c> or <c>created_new</c> at the clustering
+///     decision point, plus <c>activated_cluster</c> when CIVIS flips the
+///     cluster to Active.</description></item>
+/// </list>
+///
+/// Each test owns an isolated <see cref="SignalsMetrics"/> via
+/// <see cref="TestSignalsMetrics"/> so the <see cref="MeterListener"/> only
+/// observes measurements from that test's meter — keeping the suite
+/// parallel-safe.
+/// </summary>
+public class SignalsMetricsTests
+{
+    private sealed record DoubleMeasurement(double Value, Dictionary<string, object?> Tags);
+    private sealed record LongMeasurement(long Value, Dictionary<string, object?> Tags);
+
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<DoubleMeasurement> NlpDurationMeasurements { get; } = new();
+        public List<LongMeasurement> PreviewMeasurements { get; } = new();
+        public List<LongMeasurement> SubmitMeasurements { get; } = new();
+        public List<LongMeasurement> JoinOutcomeMeasurements { get; } = new();
+
+        public MetricCapture(SignalsMetrics metrics)
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(instrument, metrics.NlpExtractionDuration)
+                    || ReferenceEquals(instrument, metrics.SignalsPreviewRequestsTotal)
+                    || ReferenceEquals(instrument, metrics.SignalsSubmitRequestsTotal)
+                    || ReferenceEquals(instrument, metrics.SignalJoinOutcomeTotal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+            {
+                if (ReferenceEquals(instrument, metrics.NlpExtractionDuration))
+                {
+                    NlpDurationMeasurements.Add(new DoubleMeasurement(measurement, ToDict(tags)));
+                }
+            });
+
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                var dict = ToDict(tags);
+                if (ReferenceEquals(instrument, metrics.SignalsPreviewRequestsTotal))
+                {
+                    PreviewMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+                else if (ReferenceEquals(instrument, metrics.SignalsSubmitRequestsTotal))
+                {
+                    SubmitMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+                else if (ReferenceEquals(instrument, metrics.SignalJoinOutcomeTotal))
+                {
+                    JoinOutcomeMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+            });
+
+            _listener.Start();
+        }
+
+        private static Dictionary<string, object?> ToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            foreach (var tag in tags)
+            {
+                dict[tag.Key] = tag.Value;
+            }
+            return dict;
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    // ── SignalsController.Preview — preview counter ──────────────────────────
+
+    private static SignalsController CreateController(
+        SignalsMetrics metrics,
+        ISignalIngestionService ingestion,
+        IAuthRepository? auth = null)
+    {
+        var controller = new SignalsController(
+            ingestion,
+            auth ?? Substitute.For<IAuthRepository>(),
+            metrics);
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        return controller;
+    }
+
+    private static IConnectionMultiplexer BuildAllowAllRedis()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var db = Substitute.For<IDatabase>();
+        mux.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(db);
+        // StringIncrement returns 1 so the rate-limit gate never trips.
+        db.StringIncrementAsync(Arg.Any<RedisKey>(), Arg.Any<long>(), Arg.Any<CommandFlags>())
+            .Returns(1L);
+        db.KeyExpireAsync(Arg.Any<RedisKey>(), Arg.Any<TimeSpan?>(), Arg.Any<ExpireWhen>(), Arg.Any<CommandFlags>())
+            .Returns(true);
+        return mux;
+    }
+
+    private static IConnectionMultiplexer BuildRateLimitedRedis()
+    {
+        var mux = Substitute.For<IConnectionMultiplexer>();
+        var db = Substitute.For<IDatabase>();
+        mux.GetDatabase(Arg.Any<int>(), Arg.Any<object?>()).Returns(db);
+        db.StringIncrementAsync(Arg.Any<RedisKey>(), Arg.Any<long>(), Arg.Any<CommandFlags>())
+            .Returns(100L);
+        return mux;
+    }
+
+    private static SignalPreviewRequestDto PreviewRequest(string freeText = "Pothole on Lusaka Road") =>
+        new(freeText, null, null, null, null, null, null);
+
+    [Fact]
+    public async Task Preview_Success_IncrementsPreviewCounter_OutcomeSuccess()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.PreviewAsync(Arg.Any<SignalPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .Returns(new SignalPreviewResponseDto("roads", "potholes", "difficult", 0.8,
+                new SignalLocationDto(null, null, null, null, null, null, "road", 0.9, "nlp"),
+                "temporary", "summary", ShouldSuggestJoin: false, RequiresLocationFallback: false));
+
+        var controller = CreateController(scope.Metrics, ingestion);
+        await controller.Preview(PreviewRequest(), CancellationToken.None, BuildAllowAllRedis());
+
+        var m = Assert.Single(capture.PreviewMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(SignalsMetrics.OutcomeSuccess, m.Tags[SignalsMetrics.TagOutcome]);
+        Assert.Empty(capture.SubmitMeasurements);
+    }
+
+    [Fact]
+    public async Task Preview_ValidationMissingFreeText_IncrementsPreviewCounter_ValidationError()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.Preview(PreviewRequest(""), CancellationToken.None, BuildAllowAllRedis()));
+
+        var m = Assert.Single(capture.PreviewMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeValidationError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Preview_RateLimited_IncrementsPreviewCounter_ValidationError()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<RateLimitException>(() =>
+            controller.Preview(PreviewRequest(), CancellationToken.None, BuildRateLimitedRedis()));
+
+        var m = Assert.Single(capture.PreviewMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeValidationError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Preview_IngestionDependencyFails_IncrementsPreviewCounter_DependencyError()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.PreviewAsync(Arg.Any<SignalPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DependencyException(ErrorCodes.DependencyNlpUnavailable, "NLP down"));
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<DependencyException>(() =>
+            controller.Preview(PreviewRequest(), CancellationToken.None, BuildAllowAllRedis()));
+
+        var m = Assert.Single(capture.PreviewMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeDependencyError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Preview_ClientCancelled_DoesNotIncrementPreviewCounter()
+    {
+        // OperationCanceledException is explicitly excluded from the outcome
+        // taxonomy — disconnects should not bias any of the three buckets.
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.PreviewAsync(Arg.Any<SignalPreviewRequestDto>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            controller.Preview(PreviewRequest(), CancellationToken.None, BuildAllowAllRedis()));
+
+        Assert.Empty(capture.PreviewMeasurements);
+    }
+
+    // ── SignalsController.Submit — submit counter ────────────────────────────
+
+    private static SignalSubmitRequestDto SubmitRequest(string idem = "idem-1", string deviceHash = "dev-1") =>
+        new(idem, deviceHash, "Pothole", "roads", "potholes", "difficult",
+            0.9, -1.3, 36.8, "Lusaka Rd", "road", 0.9, "nlp", "temporary", "summary", "en");
+
+    [Fact]
+    public async Task Submit_Success_IncrementsSubmitCounter_OutcomeSuccess()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.SubmitAsync(Arg.Any<SignalSubmitRequestDto>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(new SignalSubmitResponseDto(
+                Guid.NewGuid(), Guid.NewGuid(), true, "unconfirmed",
+                Guid.NewGuid(), DateTime.UtcNow));
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await controller.Submit(SubmitRequest(), CancellationToken.None);
+
+        var m = Assert.Single(capture.SubmitMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(SignalsMetrics.OutcomeSuccess, m.Tags[SignalsMetrics.TagOutcome]);
+        Assert.Empty(capture.PreviewMeasurements);
+    }
+
+    [Fact]
+    public async Task Submit_MissingIdempotencyKey_IncrementsSubmitCounter_ValidationError()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.Submit(SubmitRequest(idem: ""), CancellationToken.None));
+
+        var m = Assert.Single(capture.SubmitMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeValidationError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Submit_DuplicateIdempotency_IncrementsSubmitCounter_ValidationError()
+    {
+        // ConflictException on duplicate idempotency bucketizes as
+        // validation_error per the controller's catch policy.
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.SubmitAsync(Arg.Any<SignalSubmitRequestDto>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ConflictException(ErrorCodes.SignalDuplicate, "dup"));
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            controller.Submit(SubmitRequest(), CancellationToken.None));
+
+        var m = Assert.Single(capture.SubmitMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeValidationError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Submit_SpatialDerivationFails_IncrementsSubmitCounter_DependencyError()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var ingestion = Substitute.For<ISignalIngestionService>();
+        ingestion.SubmitAsync(Arg.Any<SignalSubmitRequestDto>(), Arg.Any<Guid?>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DependencyException(ErrorCodes.DependencySpatialDerivationFailed, "h3 failed"));
+        var controller = CreateController(scope.Metrics, ingestion);
+
+        await Assert.ThrowsAsync<DependencyException>(() =>
+            controller.Submit(SubmitRequest(), CancellationToken.None));
+
+        var m = Assert.Single(capture.SubmitMeasurements);
+        Assert.Equal(SignalsMetrics.OutcomeDependencyError, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    // ── NLP histogram — AnthropicNlpExtractionService ────────────────────────
+
+    private static IConfiguration MinimalNlpConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Anthropic:ApiKey"] = "test-key",
+                ["Anthropic:Model"] = "claude-sonnet-4-6"
+            })
+            .Build();
+
+    private static string ValidNlpResponseBody() =>
+        """
+        {
+          "content": [
+            { "text": "{\"category\":\"roads\",\"subcategory\":\"potholes\",\"condition_level\":\"difficult\",\"condition_confidence\":0.9,\"location\":{\"area_name\":\"Nairobi West\",\"location_confidence\":0.8,\"location_precision_type\":\"road\",\"location_source\":\"nlp\"},\"temporal_hint\":{\"type\":\"temporary\",\"confidence\":0.7},\"summary\":\"x\",\"should_suggest_join\":false}" }
+          ]
+        }
+        """;
+
+    [Fact]
+    public async Task Nlp_Success_RecordsHistogramOnce_OutcomeSuccess()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, ValidNlpResponseBody());
+        using var http = new HttpClient(handler);
+        var svc = new AnthropicNlpExtractionService(
+            http,
+            MinimalNlpConfig(),
+            NullLogger<AnthropicNlpExtractionService>.Instance,
+            scope.Metrics);
+
+        var result = await svc.ExtractAsync(MakeNlpRequest());
+
+        Assert.NotNull(result);
+        var m = Assert.Single(capture.NlpDurationMeasurements);
+        Assert.True(m.Value >= 0);
+        Assert.Equal(SignalsMetrics.NlpOutcomeSuccess, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Nlp_Http500_RecordsHistogramOnce_OutcomeFallback()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.InternalServerError, "{}");
+        using var http = new HttpClient(handler);
+        var svc = new AnthropicNlpExtractionService(
+            http,
+            MinimalNlpConfig(),
+            NullLogger<AnthropicNlpExtractionService>.Instance,
+            scope.Metrics);
+
+        var result = await svc.ExtractAsync(MakeNlpRequest());
+
+        Assert.Null(result);
+        var m = Assert.Single(capture.NlpDurationMeasurements);
+        Assert.Equal(SignalsMetrics.NlpOutcomeFallback, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Nlp_ParseError_RecordsHistogramOnce_OutcomeFallback()
+    {
+        // A 2xx with malformed content is the other fallback flavour — the
+        // histogram still fires, tagged fallback (never silently success).
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var handler = new FakeHttpMessageHandler(HttpStatusCode.OK, "not-json");
+        using var http = new HttpClient(handler);
+        var svc = new AnthropicNlpExtractionService(
+            http,
+            MinimalNlpConfig(),
+            NullLogger<AnthropicNlpExtractionService>.Instance,
+            scope.Metrics);
+
+        var result = await svc.ExtractAsync(MakeNlpRequest());
+
+        Assert.Null(result);
+        var m = Assert.Single(capture.NlpDurationMeasurements);
+        Assert.Equal(SignalsMetrics.NlpOutcomeFallback, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Nlp_HttpClientTimeout_RecordsHistogramOnce_OutcomeTimeout()
+    {
+        // TaskCanceledException with an unsignaled caller CT is the HttpClient
+        // timeout signal — the metric must distinguish it from other fallbacks
+        // so operators can tell "upstream slow" from "upstream broken".
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var handler = new ThrowingHttpMessageHandler(new TaskCanceledException("timeout"));
+        using var http = new HttpClient(handler);
+        var svc = new AnthropicNlpExtractionService(
+            http,
+            MinimalNlpConfig(),
+            NullLogger<AnthropicNlpExtractionService>.Instance,
+            scope.Metrics);
+
+        var result = await svc.ExtractAsync(MakeNlpRequest(), CancellationToken.None);
+
+        Assert.Null(result);
+        var m = Assert.Single(capture.NlpDurationMeasurements);
+        Assert.Equal(SignalsMetrics.NlpOutcomeTimeout, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Nlp_CallerCancellation_DoesNotRecordHistogram()
+    {
+        // When the caller's CT is signaled before the call completes, the
+        // cancellation is not a latency outcome — record nothing.
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var handler = new ThrowingHttpMessageHandler(new OperationCanceledException(cts.Token));
+        using var http = new HttpClient(handler);
+        var svc = new AnthropicNlpExtractionService(
+            http,
+            MinimalNlpConfig(),
+            NullLogger<AnthropicNlpExtractionService>.Instance,
+            scope.Metrics);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            svc.ExtractAsync(MakeNlpRequest(), cts.Token));
+
+        Assert.Empty(capture.NlpDurationMeasurements);
+    }
+
+    private static NlpExtractionRequest MakeNlpRequest() =>
+        new(FreeText: "Pothole on Lusaka Road",
+            UserLatitude: null,
+            UserLongitude: null,
+            SelectedWard: null,
+            Locale: null,
+            KnownCity: null,
+            CountryCode: null,
+            CurrentTimeUtc: DateTime.UtcNow.ToString("o"),
+            TaxonomyBlock: "roads: potholes");
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _ex;
+        public ThrowingHttpMessageHandler(Exception ex) { _ex = ex; }
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromException<HttpResponseMessage>(_ex);
+    }
+
+    // ── Join-outcome counter — ClusteringService ─────────────────────────────
+
+    [Fact]
+    public async Task Clustering_WhenCandidateJoined_EmitsJoinOutcome_JoinedExisting()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var (svc, repo, h3, civis) = BuildClustering(scope.Metrics);
+        var signal = MakeSignal();
+        var existingCluster = MakeCluster();
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster> { existingCluster });
+
+        await svc.RouteSignalAsync(signal);
+
+        var m = Assert.Single(capture.JoinOutcomeMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(SignalsMetrics.JoinOutcomeJoinedExisting, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Clustering_WhenNoCandidate_EmitsJoinOutcome_CreatedNew()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var (svc, repo, h3, civis) = BuildClustering(scope.Metrics);
+        var signal = MakeSignal();
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster>());
+        repo.CreateClusterAsync(Arg.Any<SignalCluster>(), Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<SignalCluster>()));
+
+        await svc.RouteSignalAsync(signal);
+
+        var m = Assert.Single(capture.JoinOutcomeMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(SignalsMetrics.JoinOutcomeCreatedNew, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Clustering_WhenCandidateBelowThreshold_EmitsJoinOutcome_CreatedNew()
+    {
+        // Candidate exists but scores below 0.65 → falls through to the
+        // create-new branch. The counter must reflect the decision
+        // outcome, not the candidate-count intermediate signal.
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var (svc, repo, h3, civis) = BuildClustering(scope.Metrics);
+        var signal = MakeSignal();
+        // Different cell + stale + no matching condition → score well below 0.65
+        var weakCandidate = MakeCluster(
+            spatialCellId: "8928308281fffff", // different cell
+            conditionSlug: null,
+            lastSeenAgoHours: 100);
+        h3.GetKRingCells(signal.SpatialCellId!, 1).Returns(new[] { signal.SpatialCellId! });
+        repo.FindCandidateClustersAsync(Arg.Any<IEnumerable<string>>(), Arg.Any<CivicCategory>(), Arg.Any<CancellationToken>())
+            .Returns(new List<SignalCluster> { weakCandidate });
+        repo.CreateClusterAsync(Arg.Any<SignalCluster>(), Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<CancellationToken>())
+            .Returns(ci => Task.FromResult(ci.Arg<SignalCluster>()));
+
+        await svc.RouteSignalAsync(signal);
+
+        var m = Assert.Single(capture.JoinOutcomeMeasurements);
+        Assert.Equal(SignalsMetrics.JoinOutcomeCreatedNew, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    // ── Activation counter — CivisEvaluationService ──────────────────────────
+
+    [Fact]
+    public async Task Civis_WhenClusterActivates_EmitsJoinOutcome_ActivatedCluster()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var cluster = new SignalCluster
+        {
+            Id = Guid.NewGuid(),
+            Category = CivicCategory.Roads,
+            State = SignalState.Unconfirmed,
+            RawConfirmationCount = 3,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow
+        };
+        var repo = new FakeClusterRepo(cluster) { WrabCount = 3, ActiveMass = 3, UniqueDevices = 2 };
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(new CivisOptions
+            {
+                WrabRollingWindowDays = 30,
+                JoinThreshold = 0.65,
+                MinUniqueDevices = 2,
+                DeactivationThreshold = 0.5,
+                ActiveMassHorizonHours = 48,
+                TimeScoreMaxAgeHours = 24.0,
+                Roads = new CivisCategoryOptions
+                {
+                    BaseFloor = 2,
+                    HalfLifeHours = 18.0,
+                    MacfMin = 2,
+                    MacfMax = 6
+                }
+            }),
+            notificationQueue: null,
+            logger: null,
+            metrics: scope.Metrics);
+
+        await svc.EvaluateClusterAsync(cluster.Id);
+
+        Assert.Equal(SignalState.Active, cluster.State);
+        var m = Assert.Single(capture.JoinOutcomeMeasurements);
+        Assert.Equal(SignalsMetrics.JoinOutcomeActivatedCluster, m.Tags[SignalsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Civis_WhenClusterStaysUnconfirmed_NoActivationCounter()
+    {
+        using var scope = TestSignalsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var cluster = new SignalCluster
+        {
+            Id = Guid.NewGuid(),
+            Category = CivicCategory.Roads,
+            State = SignalState.Unconfirmed,
+            // Insufficient raw count to trip MACF.
+            RawConfirmationCount = 1,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow
+        };
+        var repo = new FakeClusterRepo(cluster) { WrabCount = 3, ActiveMass = 1, UniqueDevices = 2 };
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(new CivisOptions
+            {
+                WrabRollingWindowDays = 30,
+                JoinThreshold = 0.65,
+                MinUniqueDevices = 2,
+                DeactivationThreshold = 0.5,
+                ActiveMassHorizonHours = 48,
+                TimeScoreMaxAgeHours = 24.0,
+                Roads = new CivisCategoryOptions
+                {
+                    BaseFloor = 2,
+                    HalfLifeHours = 18.0,
+                    MacfMin = 2,
+                    MacfMax = 6
+                }
+            }),
+            notificationQueue: null,
+            logger: null,
+            metrics: scope.Metrics);
+
+        await svc.EvaluateClusterAsync(cluster.Id);
+
+        Assert.Equal(SignalState.Unconfirmed, cluster.State);
+        Assert.Empty(capture.JoinOutcomeMeasurements);
+    }
+
+    // ── Clustering test helpers (mirrors ClusteringServiceTests) ─────────────
+
+    private static (ClusteringService svc, IClusterRepository repo, IH3CellService h3, ICivisEvaluationService civis)
+        BuildClustering(SignalsMetrics metrics)
+    {
+        var repo = Substitute.For<IClusterRepository>();
+        var h3 = Substitute.For<IH3CellService>();
+        var civis = Substitute.For<ICivisEvaluationService>();
+        var options = Options.Create(new CivisOptions
+        {
+            JoinThreshold = 0.65,
+            TimeScoreMaxAgeHours = 24.0
+        });
+        var svc = new ClusteringService(repo, h3, civis, options, logger: null, metrics: metrics);
+        return (svc, repo, h3, civis);
+    }
+
+    private static SignalEvent MakeSignal(string? spatialCellId = "8928308280fffff", CivicCategory category = CivicCategory.Water)
+    {
+        return new SignalEvent
+        {
+            Id = Guid.NewGuid(),
+            DeviceId = Guid.NewGuid(),
+            Category = category,
+            SubcategorySlug = "low-pressure",
+            ConditionSlug = "no-water",
+            NeutralSummary = "No water in the area.",
+            TemporalType = "episodic",
+            SpatialCellId = spatialCellId,
+            OccurredAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow
+        };
+    }
+
+    private static SignalCluster MakeCluster(
+        string spatialCellId = "8928308280fffff",
+        CivicCategory category = CivicCategory.Water,
+        string? conditionSlug = "no-water",
+        double lastSeenAgoHours = 0.5)
+    {
+        return new SignalCluster
+        {
+            Id = Guid.NewGuid(),
+            Category = category,
+            State = SignalState.Unconfirmed,
+            SpatialCellId = spatialCellId,
+            DominantConditionSlug = conditionSlug,
+            RawConfirmationCount = 1,
+            CreatedAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours),
+            UpdatedAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours),
+            FirstSeenAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours),
+            LastSeenAt = DateTime.UtcNow.AddHours(-lastSeenAgoHours)
+        };
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
+++ b/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics.Metrics;
 using Hali.Api.Observability;
+using Hali.Application.Observability;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Hali.Tests.Unit.Observability;
@@ -90,5 +91,47 @@ internal static class TestHomeMetrics
         var provider = services.BuildServiceProvider();
         var factory = provider.GetRequiredService<IMeterFactory>();
         return new TestHomeMetricsScope(provider, new HomeMetrics(factory));
+    }
+}
+
+/// <summary>
+/// Disposable wrapper around a test-owned <see cref="SignalsMetrics"/> and the
+/// <see cref="ServiceProvider"/> that hosts its <see cref="IMeterFactory"/>.
+/// Mirrors <see cref="TestHomeMetricsScope"/> for the signals meter so each
+/// test gets an isolated <see cref="System.Diagnostics.Metrics.Meter"/>
+/// instance and <see cref="System.Diagnostics.Metrics.MeterListener"/>
+/// observations stay scoped to that test.
+/// </summary>
+internal sealed class TestSignalsMetricsScope : IDisposable
+{
+    private readonly ServiceProvider _provider;
+    public SignalsMetrics Metrics { get; }
+
+    internal TestSignalsMetricsScope(ServiceProvider provider, SignalsMetrics metrics)
+    {
+        _provider = provider;
+        Metrics = metrics;
+    }
+
+    public void Dispose()
+    {
+        Metrics.Dispose();
+        _provider.Dispose();
+    }
+}
+
+/// <summary>
+/// Factory for <see cref="TestSignalsMetricsScope"/>. Callers own the returned
+/// scope and must dispose it (via <c>using</c> or a fixture).
+/// </summary>
+internal static class TestSignalsMetrics
+{
+    public static TestSignalsMetricsScope Create()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IMeterFactory>();
+        return new TestSignalsMetricsScope(provider, new SignalsMetrics(factory));
     }
 }


### PR DESCRIPTION
## Problem
The signal intake pipeline — `SignalsController` → `SignalIngestionService` → `AnthropicNlpExtractionService` → `ClusteringService` → `CivisEvaluationService` — is the hottest write path in Phase 1 and has no queryable time series. Structured logs exist (`ObservabilityEvents.cs`) but ingestion throughput, NLP call latency, and cluster-join rate are not graphable or alertable today.

## Root cause
No custom metrics were wired into the signals pipeline. The audit (`docs/audits/post_run_rebaseline_audit.md` step R3.b) called this out as the next PR after R3.a (home feed, #166) to clear the pilot-readiness observability gate.

## What changed
New `Hali.Signals` meter (`src/Hali.Application/Observability/SignalsMetrics.cs`) owning four instruments emitted from the four natural layers of the intake path. Follows the exact style established by `ApiMetrics` (#171, R2) and `HomeMetrics` (#173, R3.a): explicit metrics owner class, named meter, tag-name constants, low-cardinality bounded dimensions, tests that assert semantics.

- `SignalsController.Preview` / `.Submit` emit request counters once per call with a single `outcome` tag; `OperationCanceledException` is explicitly excluded from the tag taxonomy so client disconnects do not bias any bucket.
- `AnthropicNlpExtractionService.ExtractAsync` records the histogram around the HTTP send + response parse only (not idempotency/rate-limit/persistence work from the outer ingestion path). `HttpClient`'s own timeout surfaces as `TaskCanceledException` with an unsignaled caller CT and is tagged `timeout`; caller-initiated cancellation does not record.
- `ClusteringService.RouteSignalAsync` emits the join/create counter at the true decision point (matching the existing `SignalRouted` structured log).
- `CivisEvaluationService.EvaluateClusterAsync` emits the activation counter at the same point that already logs `ClusterActivated`, so activation rate is queryable without log joins.

Added `Microsoft.Extensions.Diagnostics.Abstractions 10.0.5` to `Hali.Application.csproj` for `IMeterFactory` (the meter owner lives in Application because its instruments are emitted from API, Application, and Infrastructure).

## Metric names and tags
All four instruments share a single `outcome` tag key. No request-derived value (free_text, locality, category, subcategory, cluster/account/device/spatial ids, correlation id) is ever attached.

| Instrument | Type | Unit | Tag values |
|---|---|---|---|
| `signals_preview_requests_total` | Counter&lt;long&gt; | `{request}` | `outcome` = `success` \| `validation_error` \| `dependency_error` |
| `signals_submit_requests_total` | Counter&lt;long&gt; | `{request}` | `outcome` = `success` \| `validation_error` \| `dependency_error` |
| `nlp_extraction_duration_seconds` | Histogram&lt;double&gt; | `s` | `outcome` = `success` \| `fallback` \| `timeout` |
| `signal_join_outcome_total` | Counter&lt;long&gt; | `{signal}` | `outcome` = `joined_existing` \| `created_new` \| `activated_cluster` |

Total series at steady state: 4 × 3 = **12**.

## Where each metric is measured
| Metric | File | Layer | Span |
|---|---|---|---|
| `signals_preview_requests_total` | `src/Hali.Api/Controllers/SignalsController.cs` | API | Controller entry to response (one emit per non-cancelled call) |
| `signals_submit_requests_total` | `src/Hali.Api/Controllers/SignalsController.cs` | API | Same pattern, submit endpoint |
| `nlp_extraction_duration_seconds` | `src/Hali.Infrastructure/Signals/AnthropicNlpExtractionService.cs` | Infrastructure | Immediately before `HttpClient.SendAsync` through response parse/validate |
| `signal_join_outcome_total` (joined / created) | `src/Hali.Application/Clusters/ClusteringService.cs` | Application | At the clustering decision branch |
| `signal_join_outcome_total` (activated) | `src/Hali.Application/Clusters/CivisEvaluationService.cs` | Application | At the `Unconfirmed → Active` transition |

## How join-rate is represented
A single counter (`signal_join_outcome_total`) with three bounded outcome values:
- `joined_existing` — emitted once from `ClusteringService` when the scored candidate beats the join threshold.
- `created_new` — emitted once from `ClusteringService` when no candidate beats the threshold (including the below-threshold fall-through case).
- `activated_cluster` — emitted once from `CivisEvaluationService` when MACF + device-diversity gates trip. This is **additive** — a single submission contributes one join/create increment plus at most one activation increment — so the activation rate is directly queryable as `rate(signal_join_outcome_total{outcome="activated_cluster"})` and the join-rate as `rate(signal_join_outcome_total{outcome="joined_existing"}) / rate(signal_join_outcome_total{outcome=~"joined_existing|created_new"})`.

## Why the chosen tags are safe
Only one tag key (`outcome`) across all four instruments, drawn from three static catalogs totalling nine values. No free text, no cluster/locality/account/device ids, no category/subcategory slugs, no HTTP path/method, no correlation/trace ids, no CIVIS internals (`civis_score`, `wrab`, `sds`, `macf`, `raw_confirmation_count`) — matching the explicit "CIVIS internals never leave trusted surfaces, including metric tags" rule from the issue.

## Tests added/updated
- `tests/Hali.Tests.Unit/Observability/SignalsMetricsTests.cs` — 19 focused tests covering:
  - Preview counter: success, validation (missing free_text), rate-limit (validation bucket), dependency (NLP down), cancellation (no emit).
  - Submit counter: success, validation (missing idempotency key), conflict (duplicate idempotency → validation bucket), dependency (H3 failure).
  - NLP histogram: success (HTTP 200 + valid body), fallback (HTTP 500), fallback (HTTP 200 + unparseable body), timeout (`TaskCanceledException` with unsignaled CT), caller-cancellation (no emit).
  - Join counter: joined_existing, created_new (no candidate), created_new (below-threshold candidate), activated_cluster (CIVIS flips Unconfirmed → Active), no-activation when cluster stays Unconfirmed.
- `tests/Hali.Tests.Unit/Observability/TestMetrics.cs` — extended with `TestSignalsMetrics` / `TestSignalsMetricsScope` helper mirroring the existing home-metrics pattern for parallel-safe meter isolation per test.

All 401 unit tests + 60 integration tests pass.

## Out of scope
- Spatial (H3) metrics.
- Per-category / per-subcategory / per-locality dimensions (cardinality risk).
- Participation + cluster metrics (#168, R3.c).
- Feedback hardening (#169, R4).
- Notifications metrics (#170, R3.d).
- Dashboard / alert definitions, runbook work.
- Modifying signal submission contract, NLP output semantics, clustering behaviour, join/create decision logic, error behaviour, or notification behaviour — this PR is observability only.

## Risk assessment
**Low.**
- No behaviour changes to the signals pipeline. Every touched service accepts the metrics instance as an optional constructor parameter (`SignalsMetrics? metrics = null`) identical to the existing optional `ILogger<T>?` pattern — existing unit tests that build the services without DI continue to work unchanged.
- When `OTEL_EXPORTER_OTLP_ENDPOINT` is unset the meter exists in-process but exports nothing, matching the `ApiMetrics` / `HomeMetrics` behaviour already in production.
- Cardinality capped at 12 series — well within the observability backend's budget.
- `dotnet format --verify-no-changes` clean on all touched files.
- `dotnet build` produces zero new warnings vs baseline.
- Full unit suite (401) and integration suite (60) green locally.

Closes #167