### PR TITLE
[Issue #168] Add participation and cluster observability metrics

### DIFF
--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -165,14 +165,14 @@ public class ClustersController : ControllerBase
                         ["type"] = ["type is required."]
                     });
             }
-            bool flag = !Enum.TryParse<ParticipationType>(dto.Type, ignoreCase: true, out var type);
-            bool flag2 = flag;
-            if (!flag2)
-            {
-                bool flag3 = (uint)type <= 2u;
-                flag2 = !flag3;
-            }
-            if (flag2)
+            // Reject when the string is not a valid ParticipationType name
+            // OR when the parsed value falls outside the three endpoint-
+            // visible types (0–2). Values 3–5 (RestorationYes / RestorationNo
+            // / RestorationUnsure) are persisted via /restoration-response,
+            // not /participation, so accepting them here would let clients
+            // bypass the server-side "requires affected" gate in
+            // ParticipationService.
+            if (!Enum.TryParse<ParticipationType>(dto.Type, ignoreCase: true, out var type) || (uint)type > 2u)
             {
                 outcome = ClustersMetrics.OutcomeRejectedValidation;
                 throw new ValidationException("Invalid participation type.",
@@ -386,8 +386,13 @@ public class ClustersController : ControllerBase
                         ["device_hash"] = ["device_hash is required."]
                     });
             }
-            HashSet<string> validResponses = new HashSet<string> { "still_affected", "restored", "not_sure" };
-            if (string.IsNullOrWhiteSpace(dto.Response) || !validResponses.Contains(dto.Response))
+            // Pattern-match avoids allocating a HashSet per request. The
+            // three valid values are stable and part of the wire contract;
+            // ParticipationService.RecordRestorationResponseAsync re-maps
+            // the same strings to the RestorationYes / RestorationNo /
+            // RestorationUnsure enum values.
+            bool isValidResponse = dto.Response is "still_affected" or "restored" or "not_sure";
+            if (string.IsNullOrWhiteSpace(dto.Response) || !isValidResponse)
             {
                 outcome = ClustersMetrics.OutcomeRejectedValidation;
                 throw new ValidationException("Invalid response value.",

--- a/src/Hali.Api/Controllers/ClustersController.cs
+++ b/src/Hali.Api/Controllers/ClustersController.cs
@@ -8,6 +8,7 @@ using Hali.Application.Advisories;
 using Hali.Application.Auth;
 using Hali.Application.Clusters;
 using Hali.Application.Errors;
+using Hali.Application.Observability;
 using Hali.Application.Participation;
 using Hali.Contracts.Clusters;
 using Hali.Domain.Entities.Auth;
@@ -29,6 +30,7 @@ public class ClustersController : ControllerBase
     private readonly IAuthRepository _auth;
     private readonly IOfficialPostsService _officialPosts;
     private readonly CivisOptions _civisOptions;
+    private readonly ClustersMetrics? _metrics;
 
     public ClustersController(
         IParticipationService participation,
@@ -36,7 +38,8 @@ public class ClustersController : ControllerBase
         IClusterRepository clusters,
         IAuthRepository auth,
         IOfficialPostsService officialPosts,
-        IOptions<CivisOptions> civisOptions)
+        IOptions<CivisOptions> civisOptions,
+        ClustersMetrics? metrics = null)
     {
         _participation = participation;
         _participationRepo = participationRepo;
@@ -44,6 +47,7 @@ public class ClustersController : ControllerBase
         _auth = auth;
         _officialPosts = officialPosts;
         _civisOptions = civisOptions.Value;
+        _metrics = metrics;
     }
 
     [HttpGet("{id:guid}")]
@@ -127,135 +131,330 @@ public class ClustersController : ControllerBase
     [Authorize]
     public async Task<IActionResult> RecordParticipation(Guid id, [FromBody] ParticipationRequestDto dto, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+        // action_type is "unknown" until the `type` field is successfully
+        // parsed — validation errors before that point still emit, bucketed
+        // as unknown/rejected_validation so operators see the full slice of
+        // rejected traffic. outcome defaults to dependency_error and is
+        // tightened by catch clauses on known exception kinds; the happy
+        // path sets it to accepted just before the NoContent return. True
+        // caller cancellation (ct.IsCancellationRequested at catch time)
+        // flips `emit` to false so client disconnects do not skew the
+        // taxonomy — mirrors the SignalsController pattern from #167.
+        string actionType = ClustersMetrics.ActionTypeUnknown;
+        string outcome = ClustersMetrics.OutcomeDependencyError;
+        bool emit = true;
+        try
         {
-            throw new ValidationException("device_hash is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["device_hash is required."]
-                });
+            if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("device_hash is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["device_hash is required."]
+                    });
+            }
+            if (string.IsNullOrWhiteSpace(dto.Type))
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("type is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["type"] = ["type is required."]
+                    });
+            }
+            bool flag = !Enum.TryParse<ParticipationType>(dto.Type, ignoreCase: true, out var type);
+            bool flag2 = flag;
+            if (!flag2)
+            {
+                bool flag3 = (uint)type <= 2u;
+                flag2 = !flag3;
+            }
+            if (flag2)
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("Invalid participation type.",
+                    code: ErrorCodes.ValidationInvalidParticipationType,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["type"] = ["Invalid participation type."]
+                    });
+            }
+            // Type parsed and in range — tag with the normalised value.
+            actionType = ActionTypeFor(type);
+            Device device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
+            if (device == null)
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("Device not recognised.",
+                    code: ErrorCodes.ValidationDeviceNotFound,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["Device not recognised."]
+                    });
+            }
+            Guid? accountId = null;
+            if (Guid.TryParse(User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"), out var parsed))
+            {
+                accountId = parsed;
+            }
+            await _participation.RecordParticipationAsync(id, device.Id, accountId, type, dto.IdempotencyKey, ct);
+            outcome = ClustersMetrics.OutcomeAccepted;
+            return NoContent();
         }
-        if (string.IsNullOrWhiteSpace(dto.Type))
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            throw new ValidationException("type is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["type"] = ["type is required."]
-                });
+            emit = false;
+            throw;
         }
-        bool flag = !Enum.TryParse<ParticipationType>(dto.Type, ignoreCase: true, out var type);
-        bool flag2 = flag;
-        if (!flag2)
+        catch (OperationCanceledException)
         {
-            bool flag3 = (uint)type <= 2u;
-            flag2 = !flag3;
+            outcome = ClustersMetrics.OutcomeDependencyError;
+            throw;
         }
-        if (flag2)
+        catch (ValidationException)
         {
-            throw new ValidationException("Invalid participation type.",
-                code: ErrorCodes.ValidationInvalidParticipationType,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["type"] = ["Invalid participation type."]
-                });
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
         }
-        Device device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
-        if (device == null)
+        catch (ConflictException)
         {
-            throw new ValidationException("Device not recognised.",
-                code: ErrorCodes.ValidationDeviceNotFound,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["Device not recognised."]
-                });
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
         }
-        Guid? accountId = null;
-        if (Guid.TryParse(User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"), out var parsed))
+        catch (RateLimitException)
         {
-            accountId = parsed;
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
         }
-        await _participation.RecordParticipationAsync(id, device.Id, accountId, type, dto.IdempotencyKey, ct);
-        return NoContent();
+        catch (DependencyException)
+        {
+            outcome = ClustersMetrics.OutcomeDependencyError;
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+        finally
+        {
+            if (emit)
+            {
+                _metrics?.ParticipationActionsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(ClustersMetrics.TagActionType, actionType),
+                    new KeyValuePair<string, object?>(ClustersMetrics.TagOutcome, outcome));
+            }
+        }
     }
+
+    /// <summary>
+    /// Maps the parsed <see cref="ParticipationType"/> to the
+    /// <c>action_type</c> tag value used by
+    /// <see cref="ClustersMetrics.ParticipationActionsTotal"/>. Only the
+    /// three endpoint-visible participation types (0–2) are mapped — the
+    /// restoration_* types (3–5) are persisted via
+    /// <see cref="RecordRestorationResponse"/> and therefore never reach
+    /// this endpoint, so their action_type is <c>restoration_response</c>
+    /// (set at that endpoint's call site).
+    /// </summary>
+    private static string ActionTypeFor(ParticipationType type) => type switch
+    {
+        ParticipationType.Affected => ClustersMetrics.ActionTypeAffected,
+        ParticipationType.Observing => ClustersMetrics.ActionTypeObserving,
+        ParticipationType.NoLongerAffected => ClustersMetrics.ActionTypeNoLongerAffected,
+        _ => ClustersMetrics.ActionTypeUnknown,
+    };
 
     [HttpPost("{id:guid}/context")]
     [Authorize]
     public async Task<IActionResult> AddContext(Guid id, [FromBody] ContextRequestDto dto, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+        // action_type is fixed by the route — this endpoint is only ever a
+        // "context" action. ConflictException (context_requires_affected,
+        // context_window_expired) is bucketed with other user-input
+        // rejections; see ClustersMetrics.OutcomeRejectedValidation for the
+        // full taxonomy.
+        const string actionType = ClustersMetrics.ActionTypeContext;
+        string outcome = ClustersMetrics.OutcomeDependencyError;
+        bool emit = true;
+        try
         {
-            throw new ValidationException("device_hash is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["device_hash is required."]
-                });
-        }
-        if (string.IsNullOrWhiteSpace(dto.Text))
-        {
-            throw new ValidationException("text is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["text"] = ["text is required."]
-                });
-        }
-        Device device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
-        if (device == null)
-        {
-            throw new ValidationException("Device not recognised.",
-                code: ErrorCodes.ValidationDeviceNotFound,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["Device not recognised."]
-                });
-        }
+            if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("device_hash is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["device_hash is required."]
+                    });
+            }
+            if (string.IsNullOrWhiteSpace(dto.Text))
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("text is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["text"] = ["text is required."]
+                    });
+            }
+            Device device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
+            if (device == null)
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("Device not recognised.",
+                    code: ErrorCodes.ValidationDeviceNotFound,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["Device not recognised."]
+                    });
+            }
 
-        await _participation.AddContextAsync(id, device.Id, dto.Text, ct);
-        return NoContent();
+            await _participation.AddContextAsync(id, device.Id, dto.Text, ct);
+            outcome = ClustersMetrics.OutcomeAccepted;
+            return NoContent();
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            emit = false;
+            throw;
+        }
+        catch (OperationCanceledException)
+        {
+            outcome = ClustersMetrics.OutcomeDependencyError;
+            throw;
+        }
+        catch (ValidationException)
+        {
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
+        }
+        catch (ConflictException)
+        {
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
+        }
+        catch (DependencyException)
+        {
+            outcome = ClustersMetrics.OutcomeDependencyError;
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+        finally
+        {
+            if (emit)
+            {
+                _metrics?.ParticipationActionsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(ClustersMetrics.TagActionType, actionType),
+                    new KeyValuePair<string, object?>(ClustersMetrics.TagOutcome, outcome));
+            }
+        }
     }
 
     [HttpPost("{id:guid}/restoration-response")]
     [Authorize]
     public async Task<IActionResult> RecordRestorationResponse(Guid id, [FromBody] RestorationResponseRequestDto dto, CancellationToken ct)
     {
-        if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+        // action_type is fixed by the route — every call to this endpoint
+        // attempts a restoration_response regardless of the specific vote
+        // value (restored / still_affected / not_sure). The vote value
+        // deliberately does not become a tag: it's already one of three
+        // bounded values, but making it a dimension would double this
+        // instrument's series count with no operational lift (the
+        // restoration-transition signal is better answered by
+        // cluster_lifecycle_transitions_total).
+        const string actionType = ClustersMetrics.ActionTypeRestorationResponse;
+        string outcome = ClustersMetrics.OutcomeDependencyError;
+        bool emit = true;
+        try
         {
-            throw new ValidationException("device_hash is required.",
-                code: ErrorCodes.ValidationMissingField,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["device_hash is required."]
-                });
+            if (string.IsNullOrWhiteSpace(dto.DeviceHash))
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("device_hash is required.",
+                    code: ErrorCodes.ValidationMissingField,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["device_hash is required."]
+                    });
+            }
+            HashSet<string> validResponses = new HashSet<string> { "still_affected", "restored", "not_sure" };
+            if (string.IsNullOrWhiteSpace(dto.Response) || !validResponses.Contains(dto.Response))
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("Invalid response value.",
+                    code: ErrorCodes.ValidationInvalidRestorationResponse,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["response"] = ["Invalid response value. Must be one of: still_affected, restored, not_sure."]
+                    });
+            }
+            Device device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
+            if (device == null)
+            {
+                outcome = ClustersMetrics.OutcomeRejectedValidation;
+                throw new ValidationException("Device not recognised.",
+                    code: ErrorCodes.ValidationDeviceNotFound,
+                    fieldErrors: new Dictionary<string, string[]>
+                    {
+                        ["device_hash"] = ["Device not recognised."]
+                    });
+            }
+            Guid? accountId = null;
+            if (Guid.TryParse(User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"), out var parsed))
+            {
+                accountId = parsed;
+            }
+            await _participation.RecordRestorationResponseAsync(id, device.Id, accountId, dto.Response, ct);
+            outcome = ClustersMetrics.OutcomeAccepted;
+            return NoContent();
         }
-        HashSet<string> validResponses = new HashSet<string> { "still_affected", "restored", "not_sure" };
-        if (string.IsNullOrWhiteSpace(dto.Response) || !validResponses.Contains(dto.Response))
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
-            throw new ValidationException("Invalid response value.",
-                code: ErrorCodes.ValidationInvalidRestorationResponse,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["response"] = ["Invalid response value. Must be one of: still_affected, restored, not_sure."]
-                });
+            emit = false;
+            throw;
         }
-        Device device = await _auth.FindDeviceByFingerprintAsync(dto.DeviceHash, ct);
-        if (device == null)
+        catch (OperationCanceledException)
         {
-            throw new ValidationException("Device not recognised.",
-                code: ErrorCodes.ValidationDeviceNotFound,
-                fieldErrors: new Dictionary<string, string[]>
-                {
-                    ["device_hash"] = ["Device not recognised."]
-                });
+            outcome = ClustersMetrics.OutcomeDependencyError;
+            throw;
         }
-        Guid? accountId = null;
-        if (Guid.TryParse(User.FindFirstValue("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier"), out var parsed))
+        catch (ValidationException)
         {
-            accountId = parsed;
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
         }
-        await _participation.RecordRestorationResponseAsync(id, device.Id, accountId, dto.Response, ct);
-        return NoContent();
+        catch (ConflictException)
+        {
+            outcome = ClustersMetrics.OutcomeRejectedValidation;
+            throw;
+        }
+        catch (DependencyException)
+        {
+            outcome = ClustersMetrics.OutcomeDependencyError;
+            throw;
+        }
+        catch
+        {
+            throw;
+        }
+        finally
+        {
+            if (emit)
+            {
+                _metrics?.ParticipationActionsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(ClustersMetrics.TagActionType, actionType),
+                    new KeyValuePair<string, object?>(ClustersMetrics.TagOutcome, outcome));
+            }
+        }
     }
 }

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -51,6 +51,10 @@ builder.Services.AddSingleton<HomeMetrics>();
 // SignalsController / AnthropicNlpExtractionService / ClusteringService /
 // CivisEvaluationService. Same singleton lifetime as the other meters.
 builder.Services.AddSingleton<Hali.Application.Observability.SignalsMetrics>();
+// ClustersMetrics owns the Hali.Clusters Meter + the participation actions
+// counter and cluster lifecycle transitions counter emitted from
+// ClustersController / ParticipationService / CivisEvaluationService.
+builder.Services.AddSingleton<Hali.Application.Observability.ClustersMetrics>();
 
 string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
@@ -186,6 +190,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
             .AddMeter(ApiMetrics.MeterName)
             .AddMeter(HomeMetrics.MeterName)
             .AddMeter(Hali.Application.Observability.SignalsMetrics.MeterName)
+            .AddMeter(Hali.Application.Observability.ClustersMetrics.MeterName)
             .AddOtlpExporter(o => o.Endpoint = new Uri(otelEndpoint)));
 }
 

--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -24,16 +24,20 @@ public class CivisEvaluationService : ICivisEvaluationService
 
     private readonly SignalsMetrics? _metrics;
 
+    private readonly ClustersMetrics? _clustersMetrics;
+
     public CivisEvaluationService(IClusterRepository repo, IOptions<CivisOptions> options,
         INotificationQueueService? notificationQueue = null,
         ILogger<CivisEvaluationService>? logger = null,
-        SignalsMetrics? metrics = null)
+        SignalsMetrics? metrics = null,
+        ClustersMetrics? clustersMetrics = null)
     {
         _repo = repo;
         _options = options.Value;
         _notificationQueue = notificationQueue;
         _logger = logger;
         _metrics = metrics;
+        _clustersMetrics = clustersMetrics;
     }
 
     public async Task EvaluateClusterAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
@@ -110,6 +114,23 @@ public class CivisEvaluationService : ICivisEvaluationService
                         SignalsMetrics.TagOutcome,
                         SignalsMetrics.JoinOutcomeActivatedCluster));
 
+                // Lifecycle counter (R3.c / #168) — cluster-scoped companion
+                // to the signal-scoped activated_cluster outcome above. Both
+                // agree on cardinality for this transition (one increment
+                // per unconfirmed→active flip) but the lifecycle counter is
+                // the canonical source across all three state transitions
+                // (active→possible_restoration and
+                // possible_restoration→resolved are covered in ApplyDecay
+                // and ParticipationService.EvaluateRestorationAsync).
+                _clustersMetrics?.ClusterLifecycleTransitionsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(
+                        ClustersMetrics.TagFromState,
+                        ClustersMetrics.StateUnconfirmed),
+                    new KeyValuePair<string, object?>(
+                        ClustersMetrics.TagToState,
+                        ClustersMetrics.StateActive));
+
                 if (_notificationQueue != null)
                 {
                     try
@@ -132,6 +153,21 @@ public class CivisEvaluationService : ICivisEvaluationService
             }
         }
     }
+
+    /// <summary>
+    /// Maps a <see cref="SignalState"/> to the canonical snake_case tag
+    /// value used by <see cref="ClustersMetrics.ClusterLifecycleTransitionsTotal"/>.
+    /// Only the three lifecycle states that participate in transitions
+    /// emitted by this service are mapped.
+    /// </summary>
+    private static string ToStateTag(SignalState state) => state switch
+    {
+        SignalState.Active => ClustersMetrics.StateActive,
+        SignalState.PossibleRestoration => ClustersMetrics.StatePossibleRestoration,
+        SignalState.Resolved => ClustersMetrics.StateResolved,
+        SignalState.Unconfirmed => ClustersMetrics.StateUnconfirmed,
+        _ => state.ToString().ToLowerInvariant(),
+    };
 
     public async Task ApplyDecayAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
     {
@@ -193,6 +229,24 @@ public class CivisEvaluationService : ICivisEvaluationService
                 }),
                 OccurredAt = now
             }, ct);
+
+            // Lifecycle counter (R3.c / #168) — fires at the same
+            // transition point as the outbox event and the
+            // ClusterPossibleRestoration / ClusterResolvedByDecay log
+            // events below. Tag values come from the ClustersMetrics
+            // state catalog (canonical snake_case) rather than the raw
+            // enum ToString, because `SignalState.PossibleRestoration`
+            // lowercases to "possiblerestoration" without an underscore —
+            // using the catalog keeps metric tags uniform and alertable
+            // (`to_state="possible_restoration"`).
+            _clustersMetrics?.ClusterLifecycleTransitionsTotal.Add(
+                1,
+                new KeyValuePair<string, object?>(
+                    ClustersMetrics.TagFromState,
+                    ToStateTag(fromState)),
+                new KeyValuePair<string, object?>(
+                    ClustersMetrics.TagToState,
+                    ToStateTag(toState)));
 
             if (_notificationQueue != null)
             {

--- a/src/Hali.Application/Observability/ClustersMetrics.cs
+++ b/src/Hali.Application/Observability/ClustersMetrics.cs
@@ -1,0 +1,285 @@
+using System;
+using System.Diagnostics.Metrics;
+
+namespace Hali.Application.Observability;
+
+/// <summary>
+/// Hosts the <c>Hali.Clusters</c> <see cref="Meter"/> and the instruments
+/// covering participation activity and cluster lifecycle transitions (R3.c,
+/// issue #168). These two concerns share a meter because participation
+/// directly drives lifecycle: an <c>affected</c> / <c>restoration_response</c>
+/// submission is what trips the state machine from <c>active</c> to
+/// <c>possible_restoration</c>, and operators correlate the two signals on the
+/// same dashboard.
+///
+/// Before this meter, participation counts and lifecycle transitions were
+/// only visible through the structured log stream (<c>ClusterActivated</c>,
+/// <c>ClusterPossibleRestoration</c>, <c>ClusterResolvedByDecay</c>) and
+/// through the <c>outbox_events</c> table — neither is a queryable
+/// time-series surface for pilot alerting.
+///
+/// <list type="bullet">
+///   <item><description><c>participation_actions_total</c> — wire-visible
+///     counter over the three participation endpoints
+///     (<c>/participation</c>, <c>/context</c>,
+///     <c>/restoration-response</c>), tagged by the action attempted and the
+///     outcome. Emitted once per non-cancelled call from
+///     <c>ClustersController</c>.</description></item>
+///   <item><description><c>cluster_lifecycle_transitions_total</c> — counter
+///     over the Phase 1 lifecycle state machine
+///     (<c>unconfirmed → active → possible_restoration → resolved</c>),
+///     tagged with <c>from_state</c> / <c>to_state</c>. Emitted at each of
+///     the three code paths that mutate <c>SignalCluster.State</c>: CIVIS
+///     activation, CIVIS decay, and the restoration-ratio evaluation in
+///     <c>ParticipationService</c>.</description></item>
+/// </list>
+///
+/// The meter is registered on the OpenTelemetry meter provider in
+/// <c>Program.cs</c> under the name <see cref="MeterName"/>. When
+/// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is unset the meter and its instruments
+/// still exist in-process (zero-cost, non-exported) and no behaviour
+/// regresses.
+///
+/// The class lives in <c>Hali.Application.Observability</c> (same home as
+/// <see cref="SignalsMetrics"/>) because the instruments are emitted from
+/// both the API tier (<c>ClustersController</c>) and the Application tier
+/// (<c>CivisEvaluationService</c>, <c>ParticipationService</c>). The
+/// Application project is the lowest common reference point.
+///
+/// Tag values are bounded by static catalogs — no cluster id, locality id,
+/// locality name, ward name, account id, device id, correlation id,
+/// category, subcategory, restoration vote count, or any CIVIS internal
+/// (civis_score, wrab, sds, macf, raw_confirmation_count) is ever attached.
+/// At steady state the two counters produce at most
+/// 6 × 3 + 3 × 3 = <b>27</b> time series (and in practice the lifecycle
+/// counter only populates three <c>from_state/to_state</c> pairs:
+/// <c>unconfirmed→active</c>, <c>active→possible_restoration</c>,
+/// <c>possible_restoration→resolved</c>).
+///
+/// <para>
+/// <b>Overlap with <see cref="SignalsMetrics.SignalJoinOutcomeTotal"/>.</b>
+/// The signals meter already counts <c>activated_cluster</c> as one of the
+/// three <c>signal_join_outcome_total</c> outcomes (emitted from
+/// <c>CivisEvaluationService</c> on the same line the activation log fires).
+/// That counter is signal-scoped — "what did the submitted signal do?". The
+/// lifecycle counter here is cluster-scoped — "which transition did the
+/// cluster just make?". They are deliberately additive: for the
+/// <c>unconfirmed→active</c> transition both increment by one, and the two
+/// counts will agree. The lifecycle counter is the canonical source for the
+/// other two transitions (<c>active→possible_restoration</c>,
+/// <c>possible_restoration→resolved</c>), which the signals meter does not
+/// cover.
+/// </para>
+/// </summary>
+public sealed class ClustersMetrics : IDisposable
+{
+    /// <summary>
+    /// Name of the clusters <see cref="Meter"/>. Mirrored by
+    /// <c>AddMeter(ClustersMetrics.MeterName)</c> on the OpenTelemetry meter
+    /// provider so instruments export through the existing OTLP transport.
+    /// </summary>
+    public const string MeterName = "Hali.Clusters";
+
+    /// <summary>Counter name — participation actions attempted against a cluster.</summary>
+    public const string ParticipationActionsTotalName = "participation_actions_total";
+
+    /// <summary>Counter name — cluster lifecycle state transitions.</summary>
+    public const string ClusterLifecycleTransitionsTotalName = "cluster_lifecycle_transitions_total";
+
+    // ── Tag keys ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Tag key on <see cref="ParticipationActionsTotal"/> identifying the
+    /// action the caller attempted. Values are drawn from
+    /// <see cref="ActionTypeAffected"/>, <see cref="ActionTypeObserving"/>,
+    /// <see cref="ActionTypeNoLongerAffected"/>,
+    /// <see cref="ActionTypeContext"/>,
+    /// <see cref="ActionTypeRestorationResponse"/>, and
+    /// <see cref="ActionTypeUnknown"/> (for <c>/participation</c> calls that
+    /// fail validation before the action type can be parsed).
+    /// </summary>
+    public const string TagActionType = "action_type";
+
+    /// <summary>
+    /// Tag key on <see cref="ParticipationActionsTotal"/> identifying the
+    /// wire-visible outcome. Values: <see cref="OutcomeAccepted"/> (2xx),
+    /// <see cref="OutcomeRejectedValidation"/> (4xx — missing fields,
+    /// invalid type, unknown device, context window expired, restoration
+    /// requires affected), or <see cref="OutcomeDependencyError"/> (5xx —
+    /// unmapped application exceptions, server-side timeouts).
+    /// </summary>
+    public const string TagOutcome = "outcome";
+
+    /// <summary>
+    /// Tag key on <see cref="ClusterLifecycleTransitionsTotal"/> identifying
+    /// the prior <c>SignalState</c>. Values are drawn from
+    /// <see cref="StateUnconfirmed"/>, <see cref="StateActive"/>,
+    /// <see cref="StatePossibleRestoration"/>.
+    /// </summary>
+    public const string TagFromState = "from_state";
+
+    /// <summary>
+    /// Tag key on <see cref="ClusterLifecycleTransitionsTotal"/> identifying
+    /// the new <c>SignalState</c>. Values are drawn from
+    /// <see cref="StateActive"/>, <see cref="StatePossibleRestoration"/>,
+    /// <see cref="StateResolved"/>.
+    /// </summary>
+    public const string TagToState = "to_state";
+
+    // ── Action-type tag values ──────────────────────────────────────────────
+    // The three participation endpoints map to action_type as follows:
+    //   POST /v1/clusters/{id}/participation         → affected | observing | no_longer_affected | unknown
+    //   POST /v1/clusters/{id}/context               → context
+    //   POST /v1/clusters/{id}/restoration-response  → restoration_response
+    // "unknown" is only used on the /participation endpoint when the request
+    // fails validation (missing/invalid `type`) before the type is parsed.
+    // Keeping that bucket makes validation-error counts truthful even when
+    // the payload is unusable.
+
+    /// <summary>Action type: citizen marked themselves affected.</summary>
+    public const string ActionTypeAffected = "affected";
+
+    /// <summary>Action type: citizen marked themselves observing.</summary>
+    public const string ActionTypeObserving = "observing";
+
+    /// <summary>Action type: citizen cleared a prior affected participation.</summary>
+    public const string ActionTypeNoLongerAffected = "no_longer_affected";
+
+    /// <summary>Action type: citizen added free-text context to an affected participation.</summary>
+    public const string ActionTypeContext = "context";
+
+    /// <summary>Action type: citizen replied to a restoration prompt (restored / still_affected / not_sure).</summary>
+    public const string ActionTypeRestorationResponse = "restoration_response";
+
+    /// <summary>
+    /// Action type: a <c>/participation</c> request that failed validation
+    /// before the <c>type</c> field could be parsed (missing/unknown value).
+    /// Only ever emitted with <see cref="OutcomeRejectedValidation"/>.
+    /// </summary>
+    public const string ActionTypeUnknown = "unknown";
+
+    // ── Outcome tag values ──────────────────────────────────────────────────
+    // The issue (#168) defined two buckets — accepted / rejected_validation —
+    // which cover the two dominant dispositions: a successful 2xx and a
+    // user-visible 4xx. A third bucket (dependency_error) is added to stay
+    // consistent with the SignalsMetrics / ApiMetrics outcome taxonomy and
+    // to keep 5xx failures from vanishing into the accepted bucket on
+    // error paths the controller does not explicitly classify. This matches
+    // the three-way taxonomy already established by R3.b (#167).
+
+    /// <summary>Outcome: request succeeded (controller returned 2xx).</summary>
+    public const string OutcomeAccepted = "accepted";
+
+    /// <summary>
+    /// Outcome: request rejected due to user input or pre-conditions —
+    /// covers ValidationException (missing / invalid fields, unknown device),
+    /// ConflictException (context requires affected, context window expired,
+    /// restoration requires affected), and RateLimitException.
+    /// </summary>
+    public const string OutcomeRejectedValidation = "rejected_validation";
+
+    /// <summary>
+    /// Outcome: request failed due to a dependency or server error —
+    /// DependencyException, unmapped AppException subclasses, server-side
+    /// timeouts (<c>OperationCanceledException</c> with an unsignaled caller
+    /// token), and any other exception translated to 5xx by
+    /// <c>ExceptionHandlingMiddleware</c>. True caller cancellation
+    /// (<c>ct.IsCancellationRequested</c> at catch time) is excluded from
+    /// the taxonomy entirely — see <c>ClustersController</c> for the guard.
+    /// </summary>
+    public const string OutcomeDependencyError = "dependency_error";
+
+    // ── State tag values ────────────────────────────────────────────────────
+    // Kept in lockstep with the `from_state` / `to_state` strings that the
+    // outbox event payload already uses for cluster_state_changed events.
+    // Only the three states that participate in lifecycle transitions are
+    // listed here — Expired and Suppressed are not produced by any of the
+    // instrumented code paths and are omitted from the tag catalog to keep
+    // cardinality honest.
+
+    /// <summary>State: cluster created but not yet confirmed.</summary>
+    public const string StateUnconfirmed = "unconfirmed";
+
+    /// <summary>State: cluster active (MACF + device diversity met).</summary>
+    public const string StateActive = "active";
+
+    /// <summary>State: restoration being evaluated (decay or restoration vote).</summary>
+    public const string StatePossibleRestoration = "possible_restoration";
+
+    /// <summary>State: cluster resolved.</summary>
+    public const string StateResolved = "resolved";
+
+    private readonly Meter _meter;
+
+    /// <summary>
+    /// <c>participation_actions_total</c> — incremented exactly once per
+    /// non-cancelled call to any of the three participation endpoints on
+    /// <c>ClustersController</c>. The controller is the truthful point of
+    /// observation because it is the only layer that knows both the
+    /// attempted action (from the route and, for <c>/participation</c>,
+    /// the parsed <c>type</c>) and the wire-visible outcome (from its
+    /// try/catch taxonomy).
+    ///
+    /// Tags (bounded — 6 × 3 = 18 combinations max):
+    /// <list type="bullet">
+    ///   <item><description><see cref="TagActionType"/> —
+    ///     <c>affected | observing | no_longer_affected | context |
+    ///     restoration_response | unknown</c>.</description></item>
+    ///   <item><description><see cref="TagOutcome"/> —
+    ///     <c>accepted | rejected_validation | dependency_error</c>.</description></item>
+    /// </list>
+    /// No cluster id, account id, device id, device hash, correlation id,
+    /// idempotency key, restoration response value, or context text is ever
+    /// attached.
+    /// </summary>
+    public Counter<long> ParticipationActionsTotal { get; }
+
+    /// <summary>
+    /// <c>cluster_lifecycle_transitions_total</c> — incremented exactly once
+    /// per persisted cluster state transition, at the same lines that emit
+    /// the <c>cluster_state_changed</c> outbox event and the corresponding
+    /// structured log (<c>ClusterActivated</c>,
+    /// <c>ClusterPossibleRestoration</c>, <c>ClusterResolvedByDecay</c>).
+    ///
+    /// Tags (bounded — 3 actual pairs at steady state):
+    /// <list type="bullet">
+    ///   <item><description><see cref="TagFromState"/> —
+    ///     <c>unconfirmed | active | possible_restoration</c>.</description></item>
+    ///   <item><description><see cref="TagToState"/> —
+    ///     <c>active | possible_restoration | resolved</c>.</description></item>
+    /// </list>
+    /// Emitted from exactly three places:
+    /// <list type="bullet">
+    ///   <item><description><c>CivisEvaluationService.EvaluateClusterAsync</c>
+    ///     — <c>unconfirmed → active</c> (MACF + device diversity met).</description></item>
+    ///   <item><description><c>CivisEvaluationService.ApplyDecayAsync</c> —
+    ///     <c>active → possible_restoration</c> (decay below threshold) and
+    ///     <c>possible_restoration → resolved</c> (decay again below
+    ///     threshold).</description></item>
+    ///   <item><description><c>ParticipationService.EvaluateRestorationAsync</c>
+    ///     — <c>active → possible_restoration</c> (restoration ratio met
+    ///     from citizen votes).</description></item>
+    /// </list>
+    /// No cluster id, locality id, category, reason code, CIVIS metric, or
+    /// restoration vote count is ever attached.
+    /// </summary>
+    public Counter<long> ClusterLifecycleTransitionsTotal { get; }
+
+    public ClustersMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+        _meter = meterFactory.Create(MeterName);
+
+        ParticipationActionsTotal = _meter.CreateCounter<long>(
+            name: ParticipationActionsTotalName,
+            unit: "{action}",
+            description: "Number of participation-endpoint calls, tagged by action type and wire-visible outcome.");
+
+        ClusterLifecycleTransitionsTotal = _meter.CreateCounter<long>(
+            name: ClusterLifecycleTransitionsTotalName,
+            unit: "{transition}",
+            description: "Number of persisted cluster state transitions, tagged by from_state and to_state.");
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Hali.Application/Observability/ClustersMetrics.cs
+++ b/src/Hali.Application/Observability/ClustersMetrics.cs
@@ -190,9 +190,15 @@ public sealed class ClustersMetrics : IDisposable
     public const string OutcomeDependencyError = "dependency_error";
 
     // ── State tag values ────────────────────────────────────────────────────
-    // Kept in lockstep with the `from_state` / `to_state` strings that the
-    // outbox event payload already uses for cluster_state_changed events.
-    // Only the three states that participate in lifecycle transitions are
+    // Canonical snake_case values used by the cluster_lifecycle_transitions
+    // counter. These are deliberately NOT derived from SignalState.ToString()
+    // because `SignalState.PossibleRestoration.ToString().ToLowerInvariant()`
+    // yields "possiblerestoration" (no underscore) — the existing outbox
+    // event payload for cluster_state_changed currently uses that form, but
+    // the metric tag stays snake_case so dashboards and alerts remain
+    // readable and human-friendly. Normalizing the outbox payload is a
+    // separate, out-of-scope change.
+    // Only the four states that participate in lifecycle transitions are
     // listed here — Expired and Suppressed are not produced by any of the
     // instrumented code paths and are omitted from the tag catalog to keep
     // cardinality honest.

--- a/src/Hali.Application/Participation/ParticipationService.cs
+++ b/src/Hali.Application/Participation/ParticipationService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -23,12 +24,15 @@ public class ParticipationService : IParticipationService
 
     private readonly ILogger<ParticipationService>? _logger;
 
-    public ParticipationService(IParticipationRepository participationRepo, IClusterRepository clusterRepo, IOptions<CivisOptions> options, ILogger<ParticipationService>? logger = null)
+    private readonly ClustersMetrics? _metrics;
+
+    public ParticipationService(IParticipationRepository participationRepo, IClusterRepository clusterRepo, IOptions<CivisOptions> options, ILogger<ParticipationService>? logger = null, ClustersMetrics? metrics = null)
     {
         _participationRepo = participationRepo;
         _clusterRepo = clusterRepo;
         _options = options.Value;
         _logger = logger;
+        _metrics = metrics;
     }
 
     public async Task RecordParticipationAsync(Guid clusterId, Guid deviceId, Guid? accountId, ParticipationType type, string? idempotencyKey, CancellationToken ct)
@@ -145,6 +149,25 @@ public class ParticipationService : IParticipationService
                 _logger?.LogInformation(
                     "{EventName} clusterId={ClusterId} restorationYes={RestorationYes} totalResponses={TotalResponses}",
                     ObservabilityEvents.ClusterPossibleRestoration, clusterId, restorationYes, totalResponses);
+
+                // Lifecycle counter (R3.c / #168) — fires at the same
+                // transition point as the outbox event above. This is the
+                // active→possible_restoration transition driven by citizen
+                // restoration votes; the decay-driven counterpart in
+                // CivisEvaluationService.ApplyDecay emits the same
+                // (from=active,to=possible_restoration) pair when the
+                // transition is driven by inactivity instead. Operators
+                // correlate the two sources via the already-existing
+                // CivisDecision.ReasonCodes field (restoration_ratio_met
+                // vs decay_below_threshold) when the split matters.
+                _metrics?.ClusterLifecycleTransitionsTotal.Add(
+                    1,
+                    new KeyValuePair<string, object?>(
+                        ClustersMetrics.TagFromState,
+                        ClustersMetrics.StateActive),
+                    new KeyValuePair<string, object?>(
+                        ClustersMetrics.TagToState,
+                        ClustersMetrics.StatePossibleRestoration));
             }
         }
     }

--- a/tests/Hali.Tests.Unit/Observability/ClustersMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/ClustersMetricsTests.cs
@@ -1,0 +1,782 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Advisories;
+using Hali.Application.Auth;
+using Hali.Application.Clusters;
+using Hali.Application.Errors;
+using Hali.Application.Observability;
+using Hali.Application.Participation;
+using Hali.Contracts.Clusters;
+using Hali.Domain.Entities.Auth;
+using Hali.Domain.Entities.Clusters;
+using Hali.Domain.Enums;
+using Hali.Tests.Unit.Clusters;
+using Hali.Tests.Unit.Participation;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+/// <summary>
+/// Verifies that the participation surface and the cluster lifecycle
+/// transitions emit the two instruments owned by <see cref="ClustersMetrics"/>:
+/// <list type="bullet">
+///   <item><description><c>participation_actions_total</c> — increments once
+///     per non-cancelled call to <c>ClustersController</c> with bounded
+///     <c>action_type</c> + <c>outcome</c> tags;</description></item>
+///   <item><description><c>cluster_lifecycle_transitions_total</c> — fires
+///     at the three transition points
+///     (<c>CivisEvaluationService.EvaluateClusterAsync</c>,
+///     <c>CivisEvaluationService.ApplyDecayAsync</c>,
+///     <c>ParticipationService.EvaluateRestorationAsync</c>) with
+///     <c>from_state</c> / <c>to_state</c> drawn from the bounded
+///     <see cref="SignalState"/> catalog.</description></item>
+/// </list>
+///
+/// Each test owns an isolated <see cref="ClustersMetrics"/> via
+/// <see cref="TestClustersMetrics"/> so the <see cref="MeterListener"/> only
+/// observes measurements from that test's meter — keeping the suite
+/// parallel-safe.
+/// </summary>
+public class ClustersMetricsTests
+{
+    private sealed record LongMeasurement(long Value, Dictionary<string, object?> Tags);
+
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<LongMeasurement> ParticipationMeasurements { get; } = new();
+        public List<LongMeasurement> LifecycleMeasurements { get; } = new();
+
+        public MetricCapture(ClustersMetrics metrics)
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(instrument, metrics.ParticipationActionsTotal)
+                    || ReferenceEquals(instrument, metrics.ClusterLifecycleTransitionsTotal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                var dict = ToDict(tags);
+                if (ReferenceEquals(instrument, metrics.ParticipationActionsTotal))
+                {
+                    ParticipationMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+                else if (ReferenceEquals(instrument, metrics.ClusterLifecycleTransitionsTotal))
+                {
+                    LifecycleMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+            });
+
+            _listener.Start();
+        }
+
+        private static Dictionary<string, object?> ToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            foreach (var tag in tags)
+            {
+                dict[tag.Key] = tag.Value;
+            }
+            return dict;
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    // ── ClustersController — participation counter ───────────────────────────
+
+    private static readonly Guid ClusterId = Guid.NewGuid();
+    private static readonly Guid DeviceId = Guid.NewGuid();
+    private const string DeviceHash = "dev-hash-1";
+
+    private static CivisOptions DefaultOptions() => new CivisOptions
+    {
+        ContextEditWindowMinutes = 2,
+        RestorationRatio = 0.6,
+        MinRestorationAffectedVotes = 2
+    };
+
+    private static ClustersController CreateController(
+        ClustersMetrics metrics,
+        IParticipationService? participation = null,
+        IParticipationRepository? participationRepo = null,
+        IClusterRepository? clusters = null,
+        IAuthRepository? auth = null,
+        bool authenticated = true)
+    {
+        auth ??= Substitute.For<IAuthRepository>();
+        var controller = new ClustersController(
+            participation ?? Substitute.For<IParticipationService>(),
+            participationRepo ?? Substitute.For<IParticipationRepository>(),
+            clusters ?? Substitute.For<IClusterRepository>(),
+            auth,
+            Substitute.For<IOfficialPostsService>(),
+            Options.Create(DefaultOptions()),
+            metrics);
+        var httpCtx = new DefaultHttpContext();
+        if (authenticated)
+        {
+            httpCtx.User = new ClaimsPrincipal(new ClaimsIdentity(new[]
+            {
+                new Claim("http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier", Guid.NewGuid().ToString())
+            }, authenticationType: "test"));
+        }
+        controller.ControllerContext = new ControllerContext { HttpContext = httpCtx };
+        return controller;
+    }
+
+    private static IAuthRepository AuthRepoWithDevice()
+    {
+        var auth = Substitute.For<IAuthRepository>();
+        auth.FindDeviceByFingerprintAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns(new Device { Id = DeviceId, DeviceFingerprintHash = DeviceHash });
+        return auth;
+    }
+
+    [Fact]
+    public async Task RecordParticipation_Affected_Success_Emits_Accepted()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics, auth: AuthRepoWithDevice());
+
+        var result = await controller.RecordParticipation(
+            ClusterId,
+            new ParticipationRequestDto("affected", DeviceHash, null),
+            CancellationToken.None);
+
+        Assert.IsType<NoContentResult>(result);
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(ClustersMetrics.ActionTypeAffected, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeAccepted, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_Observing_Success_Emits_Accepted()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics, auth: AuthRepoWithDevice());
+
+        await controller.RecordParticipation(
+            ClusterId,
+            new ParticipationRequestDto("observing", DeviceHash, null),
+            CancellationToken.None);
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeObserving, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeAccepted, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_NoLongerAffected_Success_Emits_Accepted()
+    {
+        // The controller parses `dto.Type` via Enum.TryParse with
+        // ignoreCase=true, so "NoLongerAffected" / "nolongeraffected" are
+        // accepted — not the snake_case "no_longer_affected" wire form.
+        // The metric tag on the other hand is the canonical snake_case
+        // value (via ActionTypeFor); that split is deliberate and
+        // documented in ClustersMetrics.
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics, auth: AuthRepoWithDevice());
+
+        await controller.RecordParticipation(
+            ClusterId,
+            new ParticipationRequestDto("NoLongerAffected", DeviceHash, null),
+            CancellationToken.None);
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeNoLongerAffected, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeAccepted, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_MissingDeviceHash_Emits_Unknown_RejectedValidation()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("affected", "", null),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        // action_type bucket is "unknown" because the device_hash validation
+        // runs before the type field is parsed. This keeps the bucket honest
+        // about what the controller actually knew at the moment of rejection.
+        Assert.Equal(ClustersMetrics.ActionTypeUnknown, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_MissingType_Emits_Unknown_RejectedValidation()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("", DeviceHash, null),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeUnknown, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_InvalidType_Emits_Unknown_RejectedValidation()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("bogus", DeviceHash, null),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        // "bogus" is not a valid ParticipationType. Even though the
+        // controller technically parsed the string, the action_type stays
+        // "unknown" because the validation failure happens before the
+        // parsed value is assigned to the action-type tag.
+        Assert.Equal(ClustersMetrics.ActionTypeUnknown, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_RestorationType_Rejected_Emits_Unknown_RejectedValidation()
+    {
+        // Raw restoration types (values 3–5) can be parsed from the enum but
+        // the controller explicitly rejects them because they are persisted
+        // via /restoration-response, not /participation. The tag stays
+        // "unknown" so operators don't see a phantom "restoration_yes"
+        // action_type that the endpoint never accepts.
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("RestorationYes", DeviceHash, null),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeUnknown, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_DeviceNotFound_Emits_KnownType_RejectedValidation()
+    {
+        // Device lookup runs AFTER the type field is successfully parsed, so
+        // the action_type tag has already been refined from "unknown" to the
+        // real value. The rejection bucket is still rejected_validation.
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var auth = Substitute.For<IAuthRepository>();
+        auth.FindDeviceByFingerprintAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .Returns((Device?)null);
+        var controller = CreateController(scope.Metrics, auth: auth);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("affected", "unknown-hash", null),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeAffected, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_ServiceThrowsDependency_Emits_KnownType_DependencyError()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var participation = Substitute.For<IParticipationService>();
+        participation.RecordParticipationAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid?>(),
+            Arg.Any<ParticipationType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new DependencyException("dependency.db_unavailable", "DB down"));
+        var controller = CreateController(scope.Metrics, participation: participation, auth: AuthRepoWithDevice());
+
+        await Assert.ThrowsAsync<DependencyException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("affected", DeviceHash, null),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeAffected, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeDependencyError, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordParticipation_ClientCancelled_DoesNotEmit()
+    {
+        // Caller cancellation (token signaled) is excluded from the outcome
+        // taxonomy — client disconnects should not bias any bucket. Mirrors
+        // the guard used by SignalsController.
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        var participation = Substitute.For<IParticipationService>();
+        participation.RecordParticipationAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid?>(),
+            Arg.Any<ParticipationType>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+        var controller = CreateController(scope.Metrics, participation: participation, auth: AuthRepoWithDevice());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            controller.RecordParticipation(
+                ClusterId,
+                new ParticipationRequestDto("affected", DeviceHash, null),
+                cts.Token));
+
+        Assert.Empty(capture.ParticipationMeasurements);
+    }
+
+    [Fact]
+    public async Task AddContext_Success_Emits_Context_Accepted()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics, auth: AuthRepoWithDevice());
+
+        await controller.AddContext(
+            ClusterId,
+            new ContextRequestDto(DeviceHash, "Big pothole on Lusaka Road"),
+            CancellationToken.None);
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeContext, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeAccepted, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task AddContext_MissingText_Emits_Context_RejectedValidation()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.AddContext(ClusterId, new ContextRequestDto(DeviceHash, ""), CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeContext, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task AddContext_ConflictFromService_Emits_Context_RejectedValidation()
+    {
+        // ConflictException (context_requires_affected, context_window_expired)
+        // is bucketed as rejected_validation because, like a 4xx, it means
+        // the request was rejected on user-visible preconditions — not a
+        // server/dependency failure.
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var participation = Substitute.For<IParticipationService>();
+        participation.AddContextAsync(Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ConflictException(ErrorCodes.ParticipationContextRequiresAffected, "Requires affected."));
+        var controller = CreateController(scope.Metrics, participation: participation, auth: AuthRepoWithDevice());
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            controller.AddContext(ClusterId, new ContextRequestDto(DeviceHash, "Late"), CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeContext, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordRestorationResponse_Success_Emits_RestorationResponse_Accepted()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics, auth: AuthRepoWithDevice());
+
+        await controller.RecordRestorationResponse(
+            ClusterId,
+            new RestorationResponseRequestDto("restored", DeviceHash),
+            CancellationToken.None);
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeRestorationResponse, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeAccepted, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordRestorationResponse_InvalidResponse_Emits_RestorationResponse_RejectedValidation()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics);
+
+        await Assert.ThrowsAsync<ValidationException>(() =>
+            controller.RecordRestorationResponse(
+                ClusterId,
+                new RestorationResponseRequestDto("bogus", DeviceHash),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeRestorationResponse, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task RecordRestorationResponse_ConflictFromService_Emits_RestorationResponse_RejectedValidation()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var participation = Substitute.For<IParticipationService>();
+        participation.RecordRestorationResponseAsync(
+            Arg.Any<Guid>(), Arg.Any<Guid>(), Arg.Any<Guid?>(), Arg.Any<string>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ConflictException(ErrorCodes.ParticipationRestorationRequiresAffected, "Requires affected."));
+        var controller = CreateController(scope.Metrics, participation: participation, auth: AuthRepoWithDevice());
+
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            controller.RecordRestorationResponse(
+                ClusterId,
+                new RestorationResponseRequestDto("restored", DeviceHash),
+                CancellationToken.None));
+
+        var m = Assert.Single(capture.ParticipationMeasurements);
+        Assert.Equal(ClustersMetrics.ActionTypeRestorationResponse, m.Tags[ClustersMetrics.TagActionType]);
+        Assert.Equal(ClustersMetrics.OutcomeRejectedValidation, m.Tags[ClustersMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task AllThreeParticipationEndpoints_NoLifecycleTransitionEmitted()
+    {
+        // Sanity guard: the controller layer never touches the lifecycle
+        // counter — that instrument belongs to the Application layer.
+        // Participation counter is allowed to fire on all three endpoints.
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var controller = CreateController(scope.Metrics, auth: AuthRepoWithDevice());
+
+        await controller.RecordParticipation(
+            ClusterId, new ParticipationRequestDto("affected", DeviceHash, null), CancellationToken.None);
+        await controller.AddContext(
+            ClusterId, new ContextRequestDto(DeviceHash, "ctx"), CancellationToken.None);
+        await controller.RecordRestorationResponse(
+            ClusterId, new RestorationResponseRequestDto("restored", DeviceHash), CancellationToken.None);
+
+        Assert.Equal(3, capture.ParticipationMeasurements.Count);
+        Assert.Empty(capture.LifecycleMeasurements);
+    }
+
+    // ── CivisEvaluationService — lifecycle counter ───────────────────────────
+
+    private static SignalCluster UnconfirmedRoadsCluster(int rawCount = 3) => new SignalCluster
+    {
+        Id = Guid.NewGuid(),
+        Category = CivicCategory.Roads,
+        State = SignalState.Unconfirmed,
+        RawConfirmationCount = rawCount,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+        FirstSeenAt = DateTime.UtcNow,
+        LastSeenAt = DateTime.UtcNow
+    };
+
+    private static SignalCluster ActiveRoadsCluster(int rawCount = 4) => new SignalCluster
+    {
+        Id = Guid.NewGuid(),
+        Category = CivicCategory.Roads,
+        State = SignalState.Active,
+        RawConfirmationCount = rawCount,
+        Wrab = 2m,
+        CreatedAt = DateTime.UtcNow.AddHours(-100.0),
+        UpdatedAt = DateTime.UtcNow.AddHours(-100.0),
+        FirstSeenAt = DateTime.UtcNow.AddHours(-100.0),
+        LastSeenAt = DateTime.UtcNow.AddHours(-100.0),
+        ActivatedAt = DateTime.UtcNow.AddHours(-100.0)
+    };
+
+    private static CivisOptions CivisDefaults() => new CivisOptions
+    {
+        WrabRollingWindowDays = 30,
+        JoinThreshold = 0.65,
+        MinUniqueDevices = 2,
+        DeactivationThreshold = 0.5,
+        ActiveMassHorizonHours = 48,
+        TimeScoreMaxAgeHours = 24.0,
+        Roads = new CivisCategoryOptions
+        {
+            BaseFloor = 2,
+            HalfLifeHours = 18.0,
+            MacfMin = 2,
+            MacfMax = 6
+        }
+    };
+
+    [Fact]
+    public async Task EvaluateCluster_UnconfirmedToActive_EmitsLifecycleTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = UnconfirmedRoadsCluster(3);
+        var repo = new FakeClusterRepo(cluster)
+        {
+            WrabCount = 3,
+            ActiveMass = 3,
+            UniqueDevices = 2,
+        };
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(CivisDefaults()),
+            notificationQueue: null,
+            logger: null,
+            metrics: null,
+            clustersMetrics: scope.Metrics);
+
+        await svc.EvaluateClusterAsync(cluster.Id);
+
+        Assert.Equal(SignalState.Active, cluster.State);
+        var m = Assert.Single(capture.LifecycleMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(ClustersMetrics.StateUnconfirmed, m.Tags[ClustersMetrics.TagFromState]);
+        Assert.Equal(ClustersMetrics.StateActive, m.Tags[ClustersMetrics.TagToState]);
+    }
+
+    [Fact]
+    public async Task EvaluateCluster_WhenMacfNotMet_EmitsNoLifecycleTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = UnconfirmedRoadsCluster(rawCount: 1);
+        var repo = new FakeClusterRepo(cluster)
+        {
+            WrabCount = 3,
+            ActiveMass = 3,
+            UniqueDevices = 2,
+        };
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(CivisDefaults()),
+            notificationQueue: null,
+            logger: null,
+            metrics: null,
+            clustersMetrics: scope.Metrics);
+
+        await svc.EvaluateClusterAsync(cluster.Id);
+
+        Assert.Equal(SignalState.Unconfirmed, cluster.State);
+        Assert.Empty(capture.LifecycleMeasurements);
+    }
+
+    [Fact]
+    public async Task ApplyDecay_ActiveToPossibleRestoration_EmitsLifecycleTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = ActiveRoadsCluster();
+        var repo = new FakeClusterRepo(cluster);
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(CivisDefaults()),
+            notificationQueue: null,
+            logger: null,
+            metrics: null,
+            clustersMetrics: scope.Metrics);
+
+        await svc.ApplyDecayAsync(cluster.Id);
+
+        Assert.Equal(SignalState.PossibleRestoration, cluster.State);
+        var m = Assert.Single(capture.LifecycleMeasurements);
+        Assert.Equal(ClustersMetrics.StateActive, m.Tags[ClustersMetrics.TagFromState]);
+        Assert.Equal(ClustersMetrics.StatePossibleRestoration, m.Tags[ClustersMetrics.TagToState]);
+    }
+
+    [Fact]
+    public async Task ApplyDecay_PossibleRestorationToResolved_EmitsLifecycleTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = ActiveRoadsCluster();
+        cluster.State = SignalState.PossibleRestoration;
+        cluster.PossibleRestorationAt = DateTime.UtcNow.AddHours(-100.0);
+        var repo = new FakeClusterRepo(cluster);
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(CivisDefaults()),
+            notificationQueue: null,
+            logger: null,
+            metrics: null,
+            clustersMetrics: scope.Metrics);
+
+        await svc.ApplyDecayAsync(cluster.Id);
+
+        Assert.Equal(SignalState.Resolved, cluster.State);
+        var m = Assert.Single(capture.LifecycleMeasurements);
+        Assert.Equal(ClustersMetrics.StatePossibleRestoration, m.Tags[ClustersMetrics.TagFromState]);
+        Assert.Equal(ClustersMetrics.StateResolved, m.Tags[ClustersMetrics.TagToState]);
+    }
+
+    [Fact]
+    public async Task ApplyDecay_WhenLiveMassAboveThreshold_EmitsNoLifecycleTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = new SignalCluster
+        {
+            Id = Guid.NewGuid(),
+            Category = CivicCategory.Roads,
+            State = SignalState.Active,
+            RawConfirmationCount = 100,
+            Wrab = 2m,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            FirstSeenAt = DateTime.UtcNow,
+            LastSeenAt = DateTime.UtcNow,
+            ActivatedAt = DateTime.UtcNow
+        };
+        var repo = new FakeClusterRepo(cluster);
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(CivisDefaults()),
+            notificationQueue: null,
+            logger: null,
+            metrics: null,
+            clustersMetrics: scope.Metrics);
+
+        await svc.ApplyDecayAsync(cluster.Id);
+
+        Assert.Equal(SignalState.Active, cluster.State);
+        Assert.Empty(capture.LifecycleMeasurements);
+    }
+
+    // ── ParticipationService — lifecycle counter ─────────────────────────────
+
+    private static SignalCluster RestorationActiveCluster() => new SignalCluster
+    {
+        Id = ClusterId,
+        Category = CivicCategory.Roads,
+        State = SignalState.Active,
+        RawConfirmationCount = 3,
+        CreatedAt = DateTime.UtcNow,
+        UpdatedAt = DateTime.UtcNow,
+        FirstSeenAt = DateTime.UtcNow,
+        LastSeenAt = DateTime.UtcNow,
+        ActivatedAt = DateTime.UtcNow,
+    };
+
+    [Fact]
+    public async Task EvaluateRestoration_RatioMet_EmitsActiveToPossibleRestorationTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = RestorationActiveCluster();
+        var pRepo = new FakeParticipationRepo();
+        var cRepo = new FakeClusterRepoForParticipation(cluster);
+        var svc = new ParticipationService(
+            pRepo,
+            cRepo,
+            Options.Create(DefaultOptions()),
+            logger: null,
+            metrics: scope.Metrics);
+
+        var deviceA = Guid.NewGuid();
+        var deviceB = Guid.NewGuid();
+
+        // Seed both devices as affected first (server-side gating requires it)
+        await svc.RecordParticipationAsync(cluster.Id, deviceA, null, ParticipationType.Affected, null, default);
+        await svc.RecordParticipationAsync(cluster.Id, deviceB, null, ParticipationType.Affected, null, default);
+        await svc.RecordRestorationResponseAsync(cluster.Id, deviceA, null, "restored", default);
+        await svc.RecordRestorationResponseAsync(cluster.Id, deviceB, null, "restored", default);
+
+        Assert.Equal(SignalState.PossibleRestoration, cluster.State);
+        var m = Assert.Single(capture.LifecycleMeasurements);
+        Assert.Equal(ClustersMetrics.StateActive, m.Tags[ClustersMetrics.TagFromState]);
+        Assert.Equal(ClustersMetrics.StatePossibleRestoration, m.Tags[ClustersMetrics.TagToState]);
+    }
+
+    [Fact]
+    public async Task EvaluateRestoration_RatioNotMet_EmitsNoLifecycleTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = RestorationActiveCluster();
+        var pRepo = new FakeParticipationRepo();
+        var cRepo = new FakeClusterRepoForParticipation(cluster);
+        var svc = new ParticipationService(
+            pRepo,
+            cRepo,
+            Options.Create(DefaultOptions()),
+            logger: null,
+            metrics: scope.Metrics);
+
+        var deviceA = Guid.NewGuid();
+        var deviceB = Guid.NewGuid();
+
+        // 1 yes + 1 still_affected → ratio 0.5, below 0.6 threshold
+        await svc.RecordParticipationAsync(cluster.Id, deviceA, null, ParticipationType.Affected, null, default);
+        await svc.RecordParticipationAsync(cluster.Id, deviceB, null, ParticipationType.Affected, null, default);
+        await svc.RecordRestorationResponseAsync(cluster.Id, deviceA, null, "restored", default);
+        await svc.RecordRestorationResponseAsync(cluster.Id, deviceB, null, "still_affected", default);
+
+        Assert.Equal(SignalState.Active, cluster.State);
+        Assert.Empty(capture.LifecycleMeasurements);
+    }
+
+    // ── Cross-instrument sanity — no double-counting at the instrument level ─
+
+    [Fact]
+    public async Task LifecycleCounter_FiresExactlyOncePerPersistedTransition()
+    {
+        using var scope = TestClustersMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var cluster = UnconfirmedRoadsCluster(3);
+        var repo = new FakeClusterRepo(cluster)
+        {
+            WrabCount = 3,
+            ActiveMass = 3,
+            UniqueDevices = 2,
+        };
+        var svc = new CivisEvaluationService(
+            repo,
+            Options.Create(CivisDefaults()),
+            notificationQueue: null,
+            logger: null,
+            metrics: null,
+            clustersMetrics: scope.Metrics);
+
+        await svc.EvaluateClusterAsync(cluster.Id);
+        // Second call: the guard `cluster.State == SignalState.Unconfirmed`
+        // rejects the re-evaluation — we must not emit a second time.
+        await svc.EvaluateClusterAsync(cluster.Id);
+
+        Assert.Single(capture.LifecycleMeasurements);
+        Assert.Single(repo.OutboxEvents);
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
+++ b/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
@@ -135,3 +135,45 @@ internal static class TestSignalsMetrics
         return new TestSignalsMetricsScope(provider, new SignalsMetrics(factory));
     }
 }
+
+/// <summary>
+/// Disposable wrapper around a test-owned <see cref="ClustersMetrics"/> and the
+/// <see cref="ServiceProvider"/> that hosts its <see cref="IMeterFactory"/>.
+/// Mirrors <see cref="TestSignalsMetricsScope"/> for the clusters meter so each
+/// test gets an isolated <see cref="System.Diagnostics.Metrics.Meter"/>
+/// instance and <see cref="System.Diagnostics.Metrics.MeterListener"/>
+/// observations stay scoped to that test.
+/// </summary>
+internal sealed class TestClustersMetricsScope : IDisposable
+{
+    private readonly ServiceProvider _provider;
+    public ClustersMetrics Metrics { get; }
+
+    internal TestClustersMetricsScope(ServiceProvider provider, ClustersMetrics metrics)
+    {
+        _provider = provider;
+        Metrics = metrics;
+    }
+
+    public void Dispose()
+    {
+        Metrics.Dispose();
+        _provider.Dispose();
+    }
+}
+
+/// <summary>
+/// Factory for <see cref="TestClustersMetricsScope"/>. Callers own the returned
+/// scope and must dispose it (via <c>using</c> or a fixture).
+/// </summary>
+internal static class TestClustersMetrics
+{
+    public static TestClustersMetricsScope Create()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IMeterFactory>();
+        return new TestClustersMetricsScope(provider, new ClustersMetrics(factory));
+    }
+}


### PR DESCRIPTION
Closes #168

## Problem
Participation actions (`I'm Affected` / `I'm Observing` / `No Longer Affected` / `Add Further Context` / restoration responses) and cluster lifecycle transitions (`Unconfirmed → Active → Possible Restoration → Resolved`) have no custom time-series signal. Structured logs exist (`ClusterActivated`, `ClusterPossibleRestoration`, `ClusterResolvedByDecay`) and every transition writes a `cluster_state_changed` outbox event — but neither surface is alertable. Pilot readiness needs a time-series counter for engagement volume and for lifecycle health.

## Root cause
No `Meter` was registered for the clusters / participation module. R3.a (#166) introduced the FooMetrics module-tier convention; R3.b (#175) applied it to signals. This PR is the third module-tier consumer.

## What changed
New `Hali.Clusters` meter (`src/Hali.Application/Observability/ClustersMetrics.cs`) owning two instruments:

- **`participation_actions_total`** — emitted from `ClustersController` at the three participation endpoints (`POST /v1/clusters/{id}/participation`, `POST /v1/clusters/{id}/context`, `POST /v1/clusters/{id}/restoration-response`). Recorded once per non-cancelled call in a `finally` block so success, validation-error, conflict, dependency-error, and server-side-timeout paths all emit one observation. Caller cancellation (signaled `ct`) is excluded from the taxonomy — mirrors the SignalsController pattern.
- **`cluster_lifecycle_transitions_total`** — emitted at the three truthful transition points in `CivisEvaluationService` (unconfirmed→active, active→possible_restoration via decay, possible_restoration→resolved via decay) and `ParticipationService.EvaluateRestorationAsync` (active→possible_restoration via citizen votes). Recorded on the same lines that already emit the `cluster_state_changed` outbox event and the ClusterActivated / ClusterPossibleRestoration / ClusterResolvedByDecay structured logs, so log joins are unnecessary.

Follows the FooMetrics discipline established by `ApiMetrics` (#171), `HomeMetrics` (#173), and `SignalsMetrics` (#175): explicit metrics owner class, named meter, tag-key + tag-value constants exposed for callers + tests, low-cardinality bounded dimensions, parallel-safe `TestClustersMetrics` helper, and tests that assert semantics (not implementation).

## Metric names and tags
No request-derived value (cluster id, account id, device id, device hash, correlation id, idempotency key, locality id, locality name, ward name, category, subcategory, restoration vote count, context text) is ever attached. No CIVIS internal (`civis_score`, `wrab`, `sds`, `macf`, `raw_confirmation_count`) is ever attached.

| Instrument | Type | Unit | Tag keys | Tag values |
|---|---|---|---|---|
| `participation_actions_total` | `Counter<long>` | `{action}` | `action_type`, `outcome` | `action_type` ∈ `{affected, observing, no_longer_affected, context, restoration_response, unknown}` (6 values); `outcome` ∈ `{accepted, rejected_validation, dependency_error}` (3 values) |
| `cluster_lifecycle_transitions_total` | `Counter<long>` | `{transition}` | `from_state`, `to_state` | Three actual pairs at steady state: `(unconfirmed, active)`, `(active, possible_restoration)`, `(possible_restoration, resolved)` |

**Worst-case cardinality**: 6 × 3 + 3 × 3 = **27 series**. Practical cardinality is ~18 (validation buckets for `action_type=unknown` are real; `rejected_validation` × `no_longer_affected` is rare but allowed) plus 3 transition pairs = **21 series**.

## Where each metric is measured
| Metric / tag-pair | File | Layer | Span |
|---|---|---|---|
| `participation_actions_total{action_type=affected\|observing\|no_longer_affected\|unknown, outcome=…}` | `src/Hali.Api/Controllers/ClustersController.cs` → `RecordParticipation` | API | Controller entry → response (try / finally) |
| `participation_actions_total{action_type=context, outcome=…}` | `ClustersController.AddContext` | API | Same pattern |
| `participation_actions_total{action_type=restoration_response, outcome=…}` | `ClustersController.RecordRestorationResponse` | API | Same pattern |
| `cluster_lifecycle_transitions_total{from=unconfirmed, to=active}` | `src/Hali.Application/Clusters/CivisEvaluationService.cs` → `EvaluateClusterAsync` | Application | MACF + device diversity gate trips |
| `cluster_lifecycle_transitions_total{from=active, to=possible_restoration}` and `{from=possible_restoration, to=resolved}` | `CivisEvaluationService.ApplyDecayAsync` | Application | Decay ratio drops below threshold |
| `cluster_lifecycle_transitions_total{from=active, to=possible_restoration}` | `src/Hali.Application/Participation/ParticipationService.cs` → `EvaluateRestorationAsync` | Application | Restoration ratio met from citizen votes |

## How participation outcomes are represented
`participation_actions_total` carries two orthogonal tags. `action_type` identifies **what** the caller attempted; `outcome` identifies **what happened**:
- `accepted` — 2xx response. The controller successfully called the participation service.
- `rejected_validation` — 4xx class. Covers `ValidationException` (missing / invalid fields, unknown device, invalid participation type, invalid restoration response) and `ConflictException` (context requires affected, context window expired, restoration requires affected). These are user-visible pre-condition failures, not server failures.
- `dependency_error` — 5xx class. Covers `DependencyException`, any unmapped `AppException` subclass, server-side timeouts (`OperationCanceledException` with an unsignaled caller token), and any other exception that `ExceptionHandlingMiddleware` translates to 500.

`action_type=unknown` is used when a `/participation` request fails validation before the `type` field can be parsed (missing / unknown value, or one of the restoration_* enum values which this endpoint rejects). Keeping this bucket keeps validation-error counts truthful without inventing phantom action types.

Issue #168 defined the outcome taxonomy as `{accepted, rejected_validation}`. A third `dependency_error` bucket is added to stay consistent with the `SignalsMetrics` / `ApiMetrics` taxonomy (R2 #164, R3.b #175) and to keep genuine 5xx failures from vanishing into the accepted bucket.

## How cluster lifecycle outcomes are represented
`cluster_lifecycle_transitions_total` is the canonical cluster-scoped counter for all three Phase 1 state transitions. It is deliberately **additive** to the existing signal-scoped counter `signal_join_outcome_total{outcome="activated_cluster"}` from `SignalsMetrics` (#175): both increment by exactly one on the `unconfirmed→active` transition and their counts must agree. The lifecycle counter is the only source for the other two transitions (`active→possible_restoration`, `possible_restoration→resolved`).

Tag values come from the canonical snake_case `ClustersMetrics.State*` catalog. The raw outbox payload uses `fromState.ToString().ToLowerInvariant()` which produces `"possiblerestoration"` (no underscore) — a latent format quirk in the outbox layer that is explicitly **out of scope** here. The metric tag uses the canonical `"possible_restoration"` form so dashboards and alerts stay readable.

## Why the chosen tags are safe
- All tag values are drawn from static catalogs exposed as `public const string` on `ClustersMetrics`. No request-derived value is ever a tag.
- `participation_actions_total` theoretical cardinality: 6 × 3 = 18. `cluster_lifecycle_transitions_total` actual pairs at steady state: 3.
- No CIVIS internals (`civis_score`, `wrab`, `sds`, `macf`, `raw_confirmation_count`) appear in any tag — matching the issue's explicit forbid list.
- No cluster id, account id, device id, locality id, locality name, category, subcategory, or idempotency key appears in any tag.
- The restoration response value (`restored` / `still_affected` / `not_sure`) is deliberately not a tag on the restoration_response action_type — that dimension is better answered by the lifecycle counter's `(active, possible_restoration)` pair, which is what operators actually alert on.

## Tests added/updated
**New**: `tests/Hali.Tests.Unit/Observability/ClustersMetricsTests.cs` — 25 focused tests using a reference-equality `MeterListener` on the test-owned instruments:
- Participation counter:
  - Affected / Observing / NoLongerAffected success paths → accepted with the correct action_type.
  - Validation errors (missing device_hash, missing type, invalid type, restoration enum value rejected by /participation endpoint) → unknown / rejected_validation.
  - Device lookup failure after type parsed → known action_type / rejected_validation (regression guard: the tag must refine when the controller knows more, not silently stay unknown).
  - Service `DependencyException` → known action_type / dependency_error.
  - Client cancellation → **no emit**.
  - AddContext: success, missing text, ConflictException from service (context window expired equivalent) → context / rejected_validation.
  - RecordRestorationResponse: success, invalid response, ConflictException from service (requires affected) → restoration_response / rejected_validation.
  - Cross-endpoint sanity: all three endpoints emit the participation counter and **never** emit the lifecycle counter.
- Lifecycle counter:
  - `EvaluateCluster` unconfirmed→active → lifecycle emit with canonical tags.
  - `EvaluateCluster` when MACF not met → **no emit**.
  - `ApplyDecay` active→possible_restoration → lifecycle emit.
  - `ApplyDecay` possible_restoration→resolved → lifecycle emit.
  - `ApplyDecay` when ratio above threshold → **no emit**.
  - `ParticipationService` restoration ratio met → active→possible_restoration emit.
  - `ParticipationService` restoration ratio **not** met → **no emit**.
  - Re-evaluating an already-Active cluster does not fire a second emission (guard preserves the one-observation-per-persisted-transition invariant, and matches the outbox-event assertion in the existing Civis tests).

**Updated**: `tests/Hali.Tests.Unit/Observability/TestMetrics.cs` — extended with `TestClustersMetrics` / `TestClustersMetricsScope` helper mirroring the existing signals-metrics pattern for parallel-safe meter isolation per test.

### Validation
- `dotnet build` — 0 errors.
- `dotnet test tests/Hali.Tests.Unit` — **428 passed, 0 failed, 0 skipped** (403 prior + 25 new — 25 `[Fact]` methods added in `ClustersMetricsTests.cs`).
- `dotnet test tests/Hali.Tests.Integration` — **60 passed, 0 failed, 0 skipped**.
- `dotnet format --verify-no-changes` on touched files — clean.

## Out of scope
- OpenAPI changes (no endpoint contract change).
- Mobile changes.
- Dashboard / alert / Grafana definitions.
- Tracing overhaul.
- Clustering algorithm changes.
- Signals metrics redesign (#167 is merged).
- Feedback endpoint hardening (#169).
- Notifications metrics (#170).
- The latent outbox payload quirk (`possiblerestoration` vs `possible_restoration`) in `CivisEvaluationService.ApplyDecayAsync` is **not** fixed here — the metric uses a canonical catalog so it is not affected. Tracked as the follow-up in irvinesunday/Hali#178.
- The `ParticipationRequestDto.Type` case-insensitive enum-name parse behaviour (which accepts `"Affected"` / `"affected"` / `"nolongeraffected"` but not `"no_longer_affected"`) is **not** changed here — this is a pre-existing controller behaviour. The metric tag values are the canonical snake_case regardless of the wire format accepted by the controller.

## Risk assessment
**Low.**
- No behaviour changes to any participation or cluster code path. Every touched service accepts the new metrics instance as an optional constructor parameter (`ClustersMetrics? metrics = null` / `ClustersMetrics? clustersMetrics = null`) identical to the existing optional `ILogger<T>?` and `SignalsMetrics?` pattern — existing unit tests that build the services without DI continue to work unchanged.
- When `OTEL_EXPORTER_OTLP_ENDPOINT` is unset the meter exists in-process but exports nothing, matching the `ApiMetrics` / `HomeMetrics` / `SignalsMetrics` behaviour already in production.
- Cardinality capped at 27 theoretical / ~21 practical series — well within the observability backend's budget.
- `dotnet format --verify-no-changes` clean on all touched files.
- `dotnet build` produces zero new warnings vs baseline.
- Full unit suite (428) and integration suite (60) green locally.
- Instruments are emitted at the same line as the already-existing outbox event and structured log for each transition, so an existing log or outbox consumer's semantics are preserved byte-for-byte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
