### PR TITLE
[Issue #169] Add feedback endpoint rate limiting and 429 contract

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -436,6 +436,11 @@ paths:
         No auth required. Returns 202 immediately — fire and forget from client.
         account_id captured server-side if request is authenticated, otherwise null.
         Text capped at 300 chars server-side regardless of client input.
+
+        Rate-limited via the canonical Redis limiter (#169 / R4). Authenticated
+        callers are throttled per-account; anonymous callers fall back to a
+        per-IP bucket. Over-cap submissions return 429 with
+        `error.code = rate_limit.exceeded` on the canonical error envelope.
       security: []
       requestBody:
         required: true
@@ -445,6 +450,11 @@ paths:
               $ref: '#/components/schemas/FeedbackRequest'
       responses:
         '202': { description: Feedback received }
+        '429':
+          description: Rate limit exceeded (per-account for authenticated callers, per-IP for anonymous)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Signals ─────────────────────────────────────────────────────────
   /v1/signals/preview:

--- a/src/Hali.Api/Controllers/FeedbackController.cs
+++ b/src/Hali.Api/Controllers/FeedbackController.cs
@@ -2,6 +2,8 @@ using System;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Auth;
+using Hali.Application.Errors;
 using Hali.Application.Feedback;
 using Hali.Contracts.Requests;
 using Microsoft.AspNetCore.Authorization;
@@ -15,8 +17,14 @@ namespace Hali.Api.Controllers;
 /// No auth required. Persistence is synchronous via
 /// <see cref="IFeedbackService"/>; the response is <c>202 Accepted</c> to
 /// signal "recorded for later processing" semantics to the client, not
-/// asynchronous storage. Rate limiting is intentionally deferred (see PR
-/// for #156 — not re-added to OpenAPI until a limiter is wired in).
+/// asynchronous storage.
+///
+/// The endpoint is rate-limited with the repo's canonical Redis limiter
+/// (see <see cref="IRateLimiter"/>) to bound abuse of a public write path
+/// (#169 / R4). Authenticated callers are throttled per-account; anonymous
+/// callers fall back to a per-IP bucket so a single account cannot be
+/// silenced by an anonymous neighbour and vice versa. Over-cap requests
+/// surface as the canonical 429 via <see cref="RateLimitException"/>.
 /// </summary>
 [ApiController]
 [Route("v1/feedback")]
@@ -24,19 +32,41 @@ namespace Hali.Api.Controllers;
 public class FeedbackController : ControllerBase
 {
     private readonly IFeedbackService _feedback;
+    private readonly IRateLimiter _rateLimiter;
 
-    public FeedbackController(IFeedbackService feedback)
+    // Conservative per-identity cap. Real human feedback submission is
+    // sub-minute pace at worst; 10/min leaves genuine users untouched while
+    // bounding the blast radius of a scripted flood against an anonymous
+    // write path. Aligns with the order-of-magnitude of the existing
+    // places/localities search limits (30/min — those are read fan-outs to
+    // an upstream geocoder, which is why they can be more permissive).
+    private const int RateLimitMaxRequests = 10;
+    private static readonly TimeSpan RateLimitWindow = TimeSpan.FromMinutes(1);
+
+    public FeedbackController(IFeedbackService feedback, IRateLimiter rateLimiter)
     {
         _feedback = feedback;
+        _rateLimiter = rateLimiter;
     }
 
     [HttpPost]
     [ProducesResponseType(StatusCodes.Status202Accepted)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
     public async Task<IActionResult> Submit(
         [FromBody] SubmitFeedbackRequest request,
         CancellationToken ct)
     {
-        await _feedback.SubmitAsync(request, GetAccountId(), ct);
+        var accountId = GetAccountId();
+        var rateKey = BuildRateLimitKey(accountId);
+        var allowed = await _rateLimiter.IsAllowedAsync(rateKey, RateLimitMaxRequests, RateLimitWindow, ct);
+        if (!allowed)
+        {
+            throw new RateLimitException(
+                code: ErrorCodes.RateLimitExceeded,
+                message: "Too many feedback submissions. Please try again later.");
+        }
+
+        await _feedback.SubmitAsync(request, accountId, ct);
         return Accepted();
     }
 
@@ -49,5 +79,25 @@ public class FeedbackController : ControllerBase
     {
         var raw = User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
         return Guid.TryParse(raw, out var id) ? id : null;
+    }
+
+    /// <summary>
+    /// Derives a rate-limit key from the caller's identity.
+    /// Authenticated callers are keyed per-account so a flood from one
+    /// account does not throttle unrelated callers sharing a NAT/proxy
+    /// egress IP. Anonymous callers fall back to the remote IP — mirroring
+    /// <c>PlacesController</c> and <c>LocalitiesController</c> — with the
+    /// same <c>"unknown"</c> sentinel used by those sites when the remote
+    /// address is absent (e.g. test server).
+    /// </summary>
+    private string BuildRateLimitKey(Guid? accountId)
+    {
+        if (accountId.HasValue)
+        {
+            return $"ratelimit:feedback_submit:acct:{accountId.Value}";
+        }
+
+        var clientIp = HttpContext.Connection.RemoteIpAddress?.ToString() ?? "unknown";
+        return $"ratelimit:feedback_submit:ip:{clientIp}";
     }
 }

--- a/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
@@ -1,24 +1,49 @@
 using System;
 using System.Net;
+using System.Net.Http;
 using System.Net.Http.Json;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Hali.Tests.Integration.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
 using Npgsql;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Hali.Tests.Integration.Feedback;
 
 /// <summary>
-/// End-to-end coverage for <c>POST /v1/feedback</c> (issue #156).
-/// Proves that valid submissions persist an <c>app_feedback</c> row with the
-/// expected field mapping, that invalid bodies are rejected at the controller
-/// boundary, and that the endpoint remains anonymous.
+/// End-to-end coverage for <c>POST /v1/feedback</c> (issue #156 persistence +
+/// issue #169 rate limiting). Proves that valid submissions persist an
+/// <c>app_feedback</c> row with the expected field mapping, that invalid
+/// bodies are rejected at the controller boundary, that the endpoint remains
+/// anonymous, and that over-cap submissions surface the canonical 429
+/// envelope without persisting the throttled row.
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
 public sealed class FeedbackIntegrationTests : IntegrationTestBase
 {
+    private static readonly JsonSerializerOptions _json = new(JsonSerializerDefaults.Web);
+
     public FeedbackIntegrationTests(HaliWebApplicationFactory factory) : base(factory) { }
+
+    public override async Task InitializeAsync()
+    {
+        await base.InitializeAsync();
+        // Redis state persists across tests in the Integration collection.
+        // Clear any residual feedback-submit rate-limit counters both BEFORE
+        // and AFTER each test so (a) each test begins with a fresh bucket and
+        // (b) a 429-producing test does not bleed its counter into a
+        // success-path test that runs immediately after.
+        await ClearFeedbackRateLimitKeysAsync();
+    }
+
+    public override async Task DisposeAsync()
+    {
+        await ClearFeedbackRateLimitKeysAsync();
+        await base.DisposeAsync();
+    }
 
     [Fact]
     public async Task Submit_AnonymousValidRequest_PersistsAppFeedbackRow()
@@ -137,6 +162,154 @@ public sealed class FeedbackIntegrationTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
         Assert.Equal(0, await CountFeedbackAsync());
+    }
+
+    // ----------------------------------------------------------------------
+    // Rate limiting (#169 / R4)
+    //
+    // FeedbackController caps each identity (account or IP) at
+    // RateLimitMaxRequests per RateLimitWindow. The tests below assert (1)
+    // under-cap traffic still persists, (2) the (cap+1)th call trips the
+    // canonical 429 envelope with rate_limit.exceeded, and (3) authenticated
+    // and anonymous callers are keyed into independent buckets so one cannot
+    // silence the other.
+    // ----------------------------------------------------------------------
+
+    private const int RateLimitMaxRequests = 10;
+
+    [Fact]
+    public async Task Submit_AnonymousUnderCap_AllPersist()
+    {
+        // Under-cap traffic must continue to 202 and persist every row.
+        for (var i = 0; i < RateLimitMaxRequests; i++)
+        {
+            var response = await Client.PostAsJsonAsync("/v1/feedback", new
+            {
+                rating = "neutral",
+                text = $"under-cap-{i}",
+            });
+            Assert.Equal(HttpStatusCode.Accepted, response.StatusCode);
+        }
+
+        Assert.Equal(RateLimitMaxRequests, await CountFeedbackAsync());
+    }
+
+    [Fact]
+    public async Task Submit_AnonymousExceedsCap_Returns429CanonicalEnvelopeAndDoesNotPersist()
+    {
+        HttpResponseMessage? last = null;
+        for (var i = 0; i <= RateLimitMaxRequests; i++)
+        {
+            last = await Client.PostAsJsonAsync("/v1/feedback", new
+            {
+                rating = "positive",
+                text = $"probe-{i}",
+            });
+        }
+
+        Assert.NotNull(last);
+        Assert.Equal(HttpStatusCode.TooManyRequests, last!.StatusCode);
+        AssertCanonicalRateLimitEnvelope(await last.Content.ReadFromJsonAsync<JsonElement>(_json));
+
+        // The throttled (cap+1)th call must not have persisted. Only the
+        // allowed RateLimitMaxRequests rows should be present.
+        Assert.Equal(RateLimitMaxRequests, await CountFeedbackAsync());
+    }
+
+    [Fact]
+    public async Task Submit_AuthenticatedExceedsCap_Returns429()
+    {
+        // Authenticated callers are keyed per-account. Proves the limiter
+        // engages on the account-id key path, not only the IP fallback.
+        var (_, _, jwt) = await SeedVerifiedAccountAsync();
+        using var authed = CreateAuthenticatedClient(jwt);
+
+        HttpResponseMessage? last = null;
+        for (var i = 0; i <= RateLimitMaxRequests; i++)
+        {
+            last = await authed.PostAsJsonAsync("/v1/feedback", new
+            {
+                rating = "negative",
+                text = $"authed-probe-{i}",
+            });
+        }
+
+        Assert.NotNull(last);
+        Assert.Equal(HttpStatusCode.TooManyRequests, last!.StatusCode);
+        AssertCanonicalRateLimitEnvelope(await last.Content.ReadFromJsonAsync<JsonElement>(_json));
+    }
+
+    [Fact]
+    public async Task Submit_AuthenticatedAndAnonymousKeyedIndependently()
+    {
+        // Saturate the authenticated bucket to 429.
+        var (_, _, jwt) = await SeedVerifiedAccountAsync();
+        using var authed = CreateAuthenticatedClient(jwt);
+
+        HttpResponseMessage? authedLast = null;
+        for (var i = 0; i <= RateLimitMaxRequests; i++)
+        {
+            authedLast = await authed.PostAsJsonAsync("/v1/feedback", new
+            {
+                rating = "neutral",
+                text = $"authed-{i}",
+            });
+        }
+        Assert.NotNull(authedLast);
+        Assert.Equal(HttpStatusCode.TooManyRequests, authedLast!.StatusCode);
+
+        // The anonymous bucket must remain untouched — a flood on one account
+        // cannot silence unrelated callers sharing a NAT/proxy egress IP.
+        var anonResponse = await Client.PostAsJsonAsync("/v1/feedback", new
+        {
+            rating = "positive",
+            text = "anon-after-authed-flood",
+        });
+        Assert.Equal(HttpStatusCode.Accepted, anonResponse.StatusCode);
+    }
+
+    private static void AssertCanonicalRateLimitEnvelope(JsonElement body)
+    {
+        // Mirrors the canonical envelope assertion in
+        // StandardizedErrorEnvelopeTests. Kept local here so a regression in
+        // the feedback throttle surfaces in the feedback test class directly
+        // rather than only in the cross-cutting envelope suite.
+        Assert.Equal(JsonValueKind.Object, body.ValueKind);
+
+        Assert.True(body.TryGetProperty("error", out var error),
+            "response body must carry a top-level `error` object");
+        Assert.Equal(JsonValueKind.Object, error.ValueKind);
+
+        Assert.True(error.TryGetProperty("code", out var code));
+        Assert.Equal("rate_limit.exceeded", code.GetString());
+
+        Assert.True(error.TryGetProperty("message", out var message));
+        Assert.False(string.IsNullOrWhiteSpace(message.GetString()));
+
+        Assert.True(error.TryGetProperty("traceId", out _),
+            "error envelope must include a traceId for support/log correlation");
+    }
+
+    private async Task ClearFeedbackRateLimitKeysAsync()
+    {
+        // The controller keys anonymous callers by remote IP. Under the
+        // WebApplicationFactory TestServer the remote IP is unset, so every
+        // anonymous request hits `ratelimit:feedback_submit:ip:unknown`.
+        // The authenticated test paths key by account id; those account ids
+        // are freshly generated each test, so we only need to wipe the
+        // anonymous key plus the keys for any accounts this test touched.
+        //
+        // We pattern-match on :acct:* keys by walking the server's key space
+        // via SCAN — cheap at test-db scale and avoids requiring
+        // `allowAdmin` (KEYS pattern would, SCAN via IServer does not if we
+        // stream it). For simplicity and because the account-id key is
+        // always fresh per test, a single DEL of the anonymous sentinel is
+        // sufficient for the anonymous suite; the per-account keys naturally
+        // expire after RateLimitWindow and carry no cross-test leakage.
+        using var scope = Factory.Services.CreateScope();
+        var mux = scope.ServiceProvider.GetRequiredService<IConnectionMultiplexer>();
+        var db = mux.GetDatabase();
+        await db.KeyDeleteAsync("ratelimit:feedback_submit:ip:unknown");
     }
 
     // ----------------------------------------------------------------------

--- a/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs
@@ -295,17 +295,17 @@ public sealed class FeedbackIntegrationTests : IntegrationTestBase
         // The controller keys anonymous callers by remote IP. Under the
         // WebApplicationFactory TestServer the remote IP is unset, so every
         // anonymous request hits `ratelimit:feedback_submit:ip:unknown`.
-        // The authenticated test paths key by account id; those account ids
-        // are freshly generated each test, so we only need to wipe the
-        // anonymous key plus the keys for any accounts this test touched.
+        // Deleting that single sentinel key is all the anonymous suite needs
+        // to be order-independent — mirrors the preview-limiter cleanup in
+        // StandardizedErrorEnvelopeTests.ClearPreviewRateLimitKeysAsync.
         //
-        // We pattern-match on :acct:* keys by walking the server's key space
-        // via SCAN — cheap at test-db scale and avoids requiring
-        // `allowAdmin` (KEYS pattern would, SCAN via IServer does not if we
-        // stream it). For simplicity and because the account-id key is
-        // always fresh per test, a single DEL of the anonymous sentinel is
-        // sufficient for the anonymous suite; the per-account keys naturally
-        // expire after RateLimitWindow and carry no cross-test leakage.
+        // The authenticated test paths key by account id (`:acct:{guid}`);
+        // those account ids are freshly generated each test via
+        // SeedVerifiedAccountAsync, so the per-account keys carry no
+        // cross-test leakage and are not explicitly cleared here. They
+        // naturally expire after RateLimitWindow. Using SCAN to wipe
+        // `ratelimit:feedback_submit:acct:*` would require a second Redis
+        // round-trip per test for no test-integrity gain.
         using var scope = Factory.Services.CreateScope();
         var mux = scope.ServiceProvider.GetRequiredService<IConnectionMultiplexer>();
         var db = mux.GetDatabase();


### PR DESCRIPTION
Closes #169

## Problem

`POST /v1/feedback` persists unbounded rows after #156 / PR #163: no rate limit protects the endpoint and OpenAPI does not advertise a 429 (correctly — the contract was honest). With the mobile client now distinguishing `rate_limit.exceeded` after #154, the endpoint can be safely hardened without a client update.

## Root cause

Phase 1 shipped feedback persistence without the operational guardrail it needs before the mobile app goes to pilot. Unrate-limited public writes are a standard abuse vector; the repo already has a proven Redis-backed limiter used on OTP, localities search, places search/reverse, and signal preview.

## What changed

- `FeedbackController` injects `IRateLimiter` and runs a per-identity throttle check before calling `IFeedbackService.SubmitAsync`.
- Over-cap requests throw `RateLimitException(ErrorCodes.RateLimitExceeded)` — no ad-hoc feedback-specific error shape introduced. `ExceptionToApiErrorMapper` maps it to HTTP 429 + the canonical `ApiErrorResponse` envelope.
- Controller carries `[ProducesResponseType(StatusCodes.Status429TooManyRequests)]` matching the pattern used by `PlacesController`.
- OpenAPI `/v1/feedback` documents the 429 response against the shared `ErrorResponse` schema. `rate_limit.exceeded` was already published in the `ErrorCode` enum (H3 / #153).

## Rate-limit strategy

- **Cap:** 10 submissions per minute per identity. Conservative relative to places/localities (30/min) because feedback is a manual user action, not a geocoder fan-out — genuine users will never hit the ceiling, and the cap bounds the blast radius of a scripted flood against an anonymous write path.
- **Key derivation:**
  - Authenticated callers → `ratelimit:feedback_submit:acct:{accountId}`. Keeps one account's flood from silencing unrelated callers sharing a NAT/proxy egress IP.
  - Anonymous callers → `ratelimit:feedback_submit:ip:{remoteIp}` (falling back to `"unknown"` when `HttpContext.Connection.RemoteIpAddress` is null, matching the existing `PlacesController` / `LocalitiesController` sentinel).
- **Independence:** authenticated and anonymous buckets never collide — a saturated account cannot block an anonymous submission, and vice versa. Proven by `Submit_AuthenticatedAndAnonymousKeyedIndependently`.
- **Fairness tradeoff:** a single public IP shared by many anonymous users (coffee-shop WiFi, carrier CGNAT) absorbs the 10/min limit collectively. This is the same tradeoff already accepted by `/v1/signals/preview`, `/v1/places/search`, and `/v1/localities/search`, and is the right call here — the alternative (unkeyed / device-keyed anonymous throttling) would require high-cardinality telemetry or fingerprint plumbing that this issue explicitly rules out-of-scope.

## 429 behavior and error code

- HTTP status: `429 Too Many Requests`.
- Error code: `rate_limit.exceeded` (canonical `ErrorCodes.RateLimitExceeded`, already in the wire catalog).
- Envelope: standard `{ error: { code, message, traceId } }` emitted by `ExceptionHandlingMiddleware` — identical to the 429 path on OTP, places, localities, and signal preview.

## OpenAPI / contract changes

- `02_openapi.yaml` `/v1/feedback` gains a `'429'` response referencing `#/components/schemas/ErrorResponse`, with a description that names the per-account / per-IP keying explicitly so integrators know which bucket they are hitting.
- Endpoint description updated to note the Redis-backed limiter and the `rate_limit.exceeded` wire code.
- No new codes added to the `ErrorCode` enum — `rate_limit.exceeded` is already present.
- No new schemas; the canonical `ErrorResponse` is reused verbatim.

## Tests added/updated

Four new integration tests in `tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs`:

1. `Submit_AnonymousUnderCap_AllPersist` — the first N (= cap) anonymous calls all return 202 and persist.
2. `Submit_AnonymousExceedsCap_Returns429CanonicalEnvelopeAndDoesNotPersist` — the (cap+1)th call returns 429 with the canonical envelope and `rate_limit.exceeded`; the throttled call does not write a row.
3. `Submit_AuthenticatedExceedsCap_Returns429` — proves the limiter fires on the per-account key, not only the IP fallback.
4. `Submit_AuthenticatedAndAnonymousKeyedIndependently` — saturates the authenticated bucket, then proves an anonymous submission still 202s.

Test isolation: the fixture now clears the anonymous rate-limit key (`ratelimit:feedback_submit:ip:unknown`) in `InitializeAsync` / `DisposeAsync`, mirroring the pattern used by `StandardizedErrorEnvelopeTests.ClearPreviewRateLimitKeysAsync`. Per-account keys use freshly-generated account IDs each test so they carry no cross-test leakage.

Results:
- `dotnet test` — 428 unit + 64 integration passing, 0 failures.
- `dotnet build` — 0 errors (37 pre-existing CS8600 warnings, none introduced here).
- `dotnet format --verify-no-changes` — clean on all touched files (`src/Hali.Api/Controllers/FeedbackController.cs`, `tests/Hali.Tests.Integration/Feedback/FeedbackIntegrationTests.cs`).

## Out of scope

- Feedback moderation / admin review tooling.
- Feedback analytics or aggregation surfaces.
- Changes to the `app_feedback` schema.
- Redesigning the shared rate-limit infrastructure.
- General abuse-prevention architecture for other endpoints.
- Notifications observability (#170).

## Risk assessment

**Low.**

- Persistence semantics are preserved for all non-throttled valid submissions — the rate-limit check short-circuits before `IFeedbackService.SubmitAsync` but never modifies the success path.
- Validation semantics, auth model, and storage schema are unchanged.
- The limiter pattern is the exact same one already running on four other endpoints in production-equivalent code paths; no new primitives introduced.
- The 10/min cap is well above any plausible human-driven usage rate.
- Cross-test state in Redis is explicitly cleaned up; no risk of flaky ordering.
- Rollback is a trivial controller revert — no schema migration, no contract break for clients that already handle `rate_limit.exceeded` (the mobile union already covers it post-#154).

## PR Quality Gates

- G1 Build clean: `dotnet build` 0 errors.
- G2 API contract integrity: OpenAPI documents the new 429 response against the canonical `ErrorResponse`; no new response codes added to the controller without a code path.
- G3 Test integrity: no tests removed; 4 new integration tests cover the new behaviour end-to-end.
- G4 Security surface: no request-derived values in log templates; the rate-limit key uses only the authenticated account id (GUID) or a direct `RemoteIpAddress.ToString()` — no secrets, no credentials.
- G6 Documentation alignment: PR body, inline controller summary, and the OpenAPI description all describe the same strategy and wire code.