### PR TITLE
[Issue #170] Add notifications observability metrics

### DIFF
--- a/src/Hali.Api/Controllers/DevicesController.cs
+++ b/src/Hali.Api/Controllers/DevicesController.cs
@@ -5,6 +5,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Auth;
 using Hali.Application.Errors;
+using Hali.Application.Observability;
 using Hali.Contracts.Notifications;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -18,11 +19,16 @@ public class DevicesController : ControllerBase
 {
     private readonly IAuthRepository _auth;
     private readonly ILogger<DevicesController> _logger;
+    private readonly PushNotificationsMetrics _metrics;
 
-    public DevicesController(IAuthRepository auth, ILogger<DevicesController> logger)
+    public DevicesController(
+        IAuthRepository auth,
+        ILogger<DevicesController> logger,
+        PushNotificationsMetrics metrics)
     {
         _auth = auth;
         _logger = logger;
+        _metrics = metrics;
     }
 
     [HttpPost("push-token")]
@@ -53,9 +59,26 @@ public class DevicesController : ControllerBase
                 message: "Device not recognised.");
         }
 
+        // Snapshot the pre-write token so the registration result tag
+        // reflects the real state change (new / updated / unchanged) rather
+        // than the post-write state. The comparison is ordinal because
+        // Expo tokens are case-sensitive opaque strings.
+        var previousToken = device.ExpoPushToken;
+        var result = previousToken switch
+        {
+            null => PushNotificationsMetrics.ResultNew,
+            _ when string.Equals(previousToken, dto.ExpoPushToken, StringComparison.Ordinal)
+                => PushNotificationsMetrics.ResultUnchanged,
+            _ => PushNotificationsMetrics.ResultUpdated,
+        };
+
         var start = DateTime.UtcNow;
         await _auth.UpdateExpoPushTokenAsync(device.Id, dto.ExpoPushToken, ct);
         var durationMs = (DateTime.UtcNow - start).TotalMilliseconds;
+
+        _metrics.PushTokenRegistrationsTotal.Add(
+            1,
+            new KeyValuePair<string, object?>(PushNotificationsMetrics.TagResult, result));
 
         var correlationId = HttpContext.Items["CorrelationId"] as string;
         _logger.LogInformation(

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -55,6 +55,10 @@ builder.Services.AddSingleton<Hali.Application.Observability.SignalsMetrics>();
 // counter and cluster lifecycle transitions counter emitted from
 // ClustersController / ParticipationService / CivisEvaluationService.
 builder.Services.AddSingleton<Hali.Application.Observability.ClustersMetrics>();
+// PushNotificationsMetrics owns the Hali.Notifications Meter + the push-send
+// attempt counter, push-send latency histogram, and push-token registration
+// counter emitted from ExpoPushNotificationService / DevicesController.
+builder.Services.AddSingleton<Hali.Application.Observability.PushNotificationsMetrics>();
 
 string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
@@ -191,6 +195,7 @@ if (!string.IsNullOrWhiteSpace(otelEndpoint))
             .AddMeter(HomeMetrics.MeterName)
             .AddMeter(Hali.Application.Observability.SignalsMetrics.MeterName)
             .AddMeter(Hali.Application.Observability.ClustersMetrics.MeterName)
+            .AddMeter(Hali.Application.Observability.PushNotificationsMetrics.MeterName)
             .AddOtlpExporter(o => o.Endpoint = new Uri(otelEndpoint)));
 }
 

--- a/src/Hali.Application/Observability/PushNotificationsMetrics.cs
+++ b/src/Hali.Application/Observability/PushNotificationsMetrics.cs
@@ -23,9 +23,12 @@ namespace Hali.Application.Observability;
 ///   <item><description><c>push_send_duration_seconds</c> — latency histogram
 ///     covering exactly the outbound HTTP call to
 ///     <c>https://exp.host/--/api/v2/push/send</c> (request send +
-///     response header read + body parse). Tagged with a batch-level outcome
-///     bucket so the "upstream slow" vs "upstream broken" distinction stays
-///     visible without reaching for trace data.</description></item>
+///     response header read + response body read). Tagged with a
+///     batch-level outcome bucket so the "upstream slow" vs "upstream
+///     broken" distinction stays visible without reaching for trace data.
+///     JSON parse / per-ticket classification is deliberately excluded —
+///     it is local CPU work measured in microseconds and conflating it
+///     with upstream latency would muddy the SLO.</description></item>
 ///   <item><description><c>push_token_registrations_total</c> — one increment
 ///     per successful <c>POST /v1/devices/push-token</c> call, tagged with
 ///     the registration <c>result</c> (<c>new</c>, <c>updated</c>, or
@@ -192,12 +195,13 @@ public sealed class PushNotificationsMetrics : IDisposable
     /// <summary>
     /// <c>push_send_duration_seconds</c> — latency histogram covering the
     /// outbound Expo send call. The recorded span starts immediately before
-    /// <c>PostAsJsonAsync</c> and ends after the response body has been read
-    /// and parsed (the only portion of the worker pass whose latency
-    /// depends on upstream health). It deliberately does not include queue
-    /// fetch, payload parse, or database mark-as-sent work — those are
-    /// owned by the caller path and measured separately by the worker's
-    /// own structured logs.
+    /// <c>PostAsJsonAsync</c> and ends after the response body has been
+    /// read (<c>ReadAsStringAsync</c>) — i.e. the full HTTP round trip
+    /// whose latency depends on upstream health. It deliberately does not
+    /// include JSON parse / per-ticket classification (local CPU work,
+    /// microseconds), queue fetch, payload parse, or database
+    /// mark-as-sent work — those are owned by the caller path and
+    /// measured separately by the worker's own structured logs.
     ///
     /// Tag:
     /// <list type="bullet">

--- a/src/Hali.Application/Observability/PushNotificationsMetrics.cs
+++ b/src/Hali.Application/Observability/PushNotificationsMetrics.cs
@@ -1,0 +1,251 @@
+using System;
+using System.Diagnostics.Metrics;
+
+namespace Hali.Application.Observability;
+
+/// <summary>
+/// Hosts the <c>Hali.Notifications</c> <see cref="Meter"/> and the instruments
+/// covering the Phase 1 push-notification path (R3.d, issue #170). Restoration
+/// prompts and new-cluster-in-followed-ward pushes are the only user-visible
+/// asynchronous output the citizen mobile app produces, and before this meter
+/// the <see cref="Hali.Application.Notifications.IPushNotificationService"/>
+/// pipeline was visible only through the structured log stream — which is fine
+/// for incident forensics but not queryable as a time series for pilot alerting.
+///
+/// <list type="bullet">
+///   <item><description><c>push_send_attempts_total</c> — one increment per
+///     <see cref="Hali.Application.Notifications.PushMessage"/> submitted to
+///     Expo, tagged by the per-message outcome derived from the Expo response
+///     (<c>status</c> + <c>details.error</c>) or, when the batch fails as a
+///     whole, from the HTTP status / transport exception. Emitted from
+///     <c>ExpoPushNotificationService.SendBatchAsync</c> — the only layer
+///     that sees the real per-message disposition.</description></item>
+///   <item><description><c>push_send_duration_seconds</c> — latency histogram
+///     covering exactly the outbound HTTP call to
+///     <c>https://exp.host/--/api/v2/push/send</c> (request send +
+///     response header read + body parse). Tagged with a batch-level outcome
+///     bucket so the "upstream slow" vs "upstream broken" distinction stays
+///     visible without reaching for trace data.</description></item>
+///   <item><description><c>push_token_registrations_total</c> — one increment
+///     per successful <c>POST /v1/devices/push-token</c> call, tagged with
+///     the registration <c>result</c> (<c>new</c>, <c>updated</c>, or
+///     <c>unchanged</c>). Emitted from <c>DevicesController</c> because that
+///     is the only layer with both the previously-persisted token (on the
+///     resolved <c>Device</c> entity) and the new token from the request
+///     body.</description></item>
+/// </list>
+///
+/// The meter is registered on the OpenTelemetry meter provider in
+/// <c>Program.cs</c> under the name <see cref="MeterName"/>. When
+/// <c>OTEL_EXPORTER_OTLP_ENDPOINT</c> is unset the meter and its instruments
+/// still exist in-process (zero-cost, non-exported) and no behaviour regresses.
+///
+/// The class lives in <c>Hali.Application.Observability</c> (parallel to
+/// <see cref="SignalsMetrics"/> / <see cref="ClustersMetrics"/>) because the
+/// instruments are emitted from both the API tier (<c>DevicesController</c>)
+/// and the Infrastructure tier (<c>ExpoPushNotificationService</c>). The
+/// Application project is the lowest common reference point.
+///
+/// Tag values are bounded by static catalogs — no push token, device id,
+/// account id, locality id, notification title/body, correlation id,
+/// idempotency key, or Expo message id is ever attached. At steady state the
+/// three instruments produce at most 4 + 3 + 3 = <b>10</b> time series.
+/// </summary>
+public sealed class PushNotificationsMetrics : IDisposable
+{
+    /// <summary>
+    /// Name of the push-notifications <see cref="Meter"/>. Mirrored by
+    /// <c>AddMeter(PushNotificationsMetrics.MeterName)</c> on the
+    /// OpenTelemetry meter provider so instruments export through the existing
+    /// OTLP transport.
+    /// </summary>
+    public const string MeterName = "Hali.Notifications";
+
+    /// <summary>Counter name — per-message push send attempts.</summary>
+    public const string PushSendAttemptsTotalName = "push_send_attempts_total";
+
+    /// <summary>Histogram name — Expo push HTTP call duration in seconds.</summary>
+    public const string PushSendDurationName = "push_send_duration_seconds";
+
+    /// <summary>Counter name — successful push-token registrations.</summary>
+    public const string PushTokenRegistrationsTotalName = "push_token_registrations_total";
+
+    // ── Tag keys ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Tag key on <see cref="PushSendAttemptsTotal"/> and
+    /// <see cref="PushSendDuration"/> identifying the operational outcome of
+    /// the send. Values for the counter are drawn from
+    /// <see cref="OutcomeSuccess"/>, <see cref="OutcomeDeviceInvalid"/>,
+    /// <see cref="OutcomeTransientError"/>, <see cref="OutcomePermanentError"/>.
+    /// The histogram uses the same key but only the three batch-visible
+    /// dispositions (<c>success</c>, <c>transient_error</c>,
+    /// <c>permanent_error</c>) — <c>device_invalid</c> is per-message and
+    /// never appears on the histogram because the HTTP call succeeded.
+    /// </summary>
+    public const string TagOutcome = "outcome";
+
+    /// <summary>
+    /// Tag key on <see cref="PushTokenRegistrationsTotal"/> identifying
+    /// whether the request registered a new token, updated a different
+    /// existing token, or replayed the same token already on file. Values:
+    /// <see cref="ResultNew"/>, <see cref="ResultUpdated"/>,
+    /// <see cref="ResultUnchanged"/>.
+    /// </summary>
+    public const string TagResult = "result";
+
+    // ── Send outcome tag values ─────────────────────────────────────────────
+    // Bounded four-way classification derived from Expo's documented response
+    // shape (https://docs.expo.dev/push-notifications/sending-notifications).
+    // Each per-message disposition maps to exactly one bucket:
+    //
+    //   status == "ok"                                               → success
+    //   status == "error", details.error == "DeviceNotRegistered"    → device_invalid
+    //   status == "error", details.error == "InvalidCredentials"     → permanent_error
+    //   status == "error", details.error == "MessageTooBig"          → permanent_error
+    //   status == "error", details.error == "MessageRateExceeded"    → transient_error
+    //   status == "error", any other details.error or unparseable    → transient_error
+    //
+    // For batch-level failures (HTTP non-2xx, network exception, server-side
+    // timeout) every message in the batch is counted under the batch outcome:
+    //
+    //   HTTP 5xx or transport exception or server-side timeout       → transient_error
+    //   HTTP 4xx (InvalidCredentials-class auth/bad-request)         → permanent_error
+    //
+    // Client-driven cancellation (caller CT signaled) is not a send outcome
+    // — no counter or histogram measurement is recorded in that case, which
+    // mirrors the guard already established by SignalsMetrics.
+
+    /// <summary>Outcome: Expo acknowledged the message (<c>status=="ok"</c>).</summary>
+    public const string OutcomeSuccess = "success";
+
+    /// <summary>
+    /// Outcome: Expo reported <c>DeviceNotRegistered</c>. The token is dead
+    /// and the upstream notification repo should stop targeting it (existing
+    /// "failed" marking in <c>SendPushNotificationsJob</c> is preserved — this
+    /// bucket just makes the count queryable).
+    /// </summary>
+    public const string OutcomeDeviceInvalid = "device_invalid";
+
+    /// <summary>
+    /// Outcome: Expo reported a transient error (<c>MessageRateExceeded</c>,
+    /// any unknown error code, HTTP 5xx, network/transport exception, or
+    /// server-side timeout). Safe default for any disposition that might
+    /// succeed on a later attempt.
+    /// </summary>
+    public const string OutcomeTransientError = "transient_error";
+
+    /// <summary>
+    /// Outcome: Expo reported a permanent error that will not recover on
+    /// retry without operator intervention — <c>InvalidCredentials</c>,
+    /// <c>MessageTooBig</c>, or an HTTP 4xx batch failure.
+    /// </summary>
+    public const string OutcomePermanentError = "permanent_error";
+
+    // ── Token-registration result tag values ────────────────────────────────
+    // Derived by comparing the newly-submitted token to the value already
+    // persisted on the resolved Device (returned by
+    // FindDeviceByFingerprintAsync):
+    //
+    //   device.ExpoPushToken == null                     → new
+    //   device.ExpoPushToken == request.ExpoPushToken    → unchanged
+    //   device.ExpoPushToken != request.ExpoPushToken    → updated
+    //
+    // Three-bucket catalog is deliberately tiny — the tag's operational job
+    // is to let operators see churn (updated-rate spikes typically indicate
+    // OS token rotation or app reinstalls) and to validate that no-op
+    // heartbeat traffic isn't dominating.
+
+    /// <summary>Result: first push token registration for this device.</summary>
+    public const string ResultNew = "new";
+
+    /// <summary>Result: device had a prior push token that was replaced.</summary>
+    public const string ResultUpdated = "updated";
+
+    /// <summary>Result: device already had this exact token — no semantic change.</summary>
+    public const string ResultUnchanged = "unchanged";
+
+    private readonly Meter _meter;
+
+    /// <summary>
+    /// <c>push_send_attempts_total</c> — incremented once per
+    /// <see cref="Hali.Application.Notifications.PushMessage"/> submitted in a
+    /// batch to Expo, tagged with the per-message
+    /// <see cref="TagOutcome"/>. Emitted from
+    /// <c>ExpoPushNotificationService.SendBatchAsync</c> because that is the
+    /// only layer that observes both the outgoing <c>PushMessage</c> list
+    /// and the Expo response body (or transport failure) that classifies
+    /// each message. No push token, Expo message id, batch id, device id,
+    /// account id, or notification title/body is ever attached.
+    ///
+    /// For a successful HTTP call the counter emits one measurement per
+    /// response <c>data[]</c> element keyed to its
+    /// <c>status</c>/<c>details.error</c>. For a whole-batch failure (HTTP
+    /// non-2xx, transport exception, server-side timeout) the counter emits
+    /// one measurement per request-side <c>PushMessage</c> with the
+    /// batch-level outcome — this keeps the counter truthful as a measure
+    /// of "messages attempted" even when Expo never returned structured
+    /// per-message dispositions.
+    /// </summary>
+    public Counter<long> PushSendAttemptsTotal { get; }
+
+    /// <summary>
+    /// <c>push_send_duration_seconds</c> — latency histogram covering the
+    /// outbound Expo send call. The recorded span starts immediately before
+    /// <c>PostAsJsonAsync</c> and ends after the response body has been read
+    /// and parsed (the only portion of the worker pass whose latency
+    /// depends on upstream health). It deliberately does not include queue
+    /// fetch, payload parse, or database mark-as-sent work — those are
+    /// owned by the caller path and measured separately by the worker's
+    /// own structured logs.
+    ///
+    /// Tag:
+    /// <list type="bullet">
+    ///   <item><description><see cref="TagOutcome"/> —
+    ///     <see cref="OutcomeSuccess"/> |
+    ///     <see cref="OutcomeTransientError"/> |
+    ///     <see cref="OutcomePermanentError"/>. The histogram never emits
+    ///     <see cref="OutcomeDeviceInvalid"/> because that is a per-message
+    ///     disposition observed on an otherwise-successful HTTP call.</description></item>
+    /// </list>
+    /// </summary>
+    public Histogram<double> PushSendDuration { get; }
+
+    /// <summary>
+    /// <c>push_token_registrations_total</c> — incremented once per
+    /// successful <c>POST /v1/devices/push-token</c> call, tagged with
+    /// <see cref="TagResult"/>. Emitted from
+    /// <c>DevicesController.RegisterPushToken</c> after the persist call
+    /// returns, so the counter observes the real post-write disposition
+    /// (no increment is emitted for validation failures or
+    /// device-not-found responses — those are already covered by the
+    /// API-wide exception counter).
+    ///
+    /// No device hash, push token value, account id, or correlation id is
+    /// ever attached.
+    /// </summary>
+    public Counter<long> PushTokenRegistrationsTotal { get; }
+
+    public PushNotificationsMetrics(IMeterFactory meterFactory)
+    {
+        ArgumentNullException.ThrowIfNull(meterFactory);
+        _meter = meterFactory.Create(MeterName);
+
+        PushSendAttemptsTotal = _meter.CreateCounter<long>(
+            name: PushSendAttemptsTotalName,
+            unit: "{message}",
+            description: "Number of push messages submitted to Expo, tagged by per-message send outcome.");
+
+        PushSendDuration = _meter.CreateHistogram<double>(
+            name: PushSendDurationName,
+            unit: "s",
+            description: "Duration of the Expo push send HTTP call, tagged by batch-level outcome.");
+
+        PushTokenRegistrationsTotal = _meter.CreateCounter<long>(
+            name: PushTokenRegistrationsTotalName,
+            unit: "{registration}",
+            description: "Number of successful push-token registrations, tagged by new/updated/unchanged result.");
+    }
+
+    public void Dispose() => _meter.Dispose();
+}

--- a/src/Hali.Infrastructure/Notifications/ExpoPushNotificationService.cs
+++ b/src/Hali.Infrastructure/Notifications/ExpoPushNotificationService.cs
@@ -75,27 +75,43 @@ public class ExpoPushNotificationService : IPushNotificationService
                 return;
             }
 
-            // 2xx — parse the response body to classify each message. If the
-            // body is unparseable, fall back to counting every message as
-            // success (matching the pre-metric behaviour, which treated any
-            // 2xx as "sent") rather than silently losing the attempts. The
-            // fallback path is unusual enough that emitting a warning is
-            // the right default.
+            // 2xx — parse the response body to classify each message. If
+            // the body is unparseable, fall back to counting every message
+            // as success (matching the pre-metric behaviour, which treated
+            // any 2xx as "sent") rather than silently losing the attempts.
+            // The fallback path is unusual enough that emitting a warning
+            // below is the right default — it lets operators spot upstream
+            // contract drift (Expo response shape changed) without needing
+            // to grep verbose debug logs.
             string responseBody = await response.Content.ReadAsStringAsync(ct);
             sw.Stop();
             var successDurationSeconds = sw.Elapsed.TotalSeconds;
             var successDurationMs = sw.Elapsed.TotalMilliseconds;
 
-            RecordPerMessageOutcomes(batch.Count, responseBody);
+            bool usedFallback = RecordPerMessageOutcomes(batch.Count, responseBody);
             _metrics.PushSendDuration.Record(
                 successDurationSeconds,
                 new KeyValuePair<string, object?>(
                     PushNotificationsMetrics.TagOutcome,
                     PushNotificationsMetrics.OutcomeSuccess));
 
-            _logger.LogInformation(
-                "Expo push batch sent {Count} messages in {DurationMs}ms",
-                batch.Count, successDurationMs);
+            if (usedFallback)
+            {
+                // Warning (not error) because the pre-metric contract
+                // still holds — every message counts as sent on any 2xx
+                // — but the classifier could not extract structured
+                // per-ticket dispositions from the response. Repeated
+                // occurrences suggest upstream drift worth investigating.
+                _logger.LogWarning(
+                    "Expo push batch 2xx response was unparseable or lacked a data[] array; counted {Count} messages as success in {DurationMs}ms",
+                    batch.Count, successDurationMs);
+            }
+            else
+            {
+                _logger.LogInformation(
+                    "Expo push batch sent {Count} messages in {DurationMs}ms",
+                    batch.Count, successDurationMs);
+            }
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -138,14 +154,36 @@ public class ExpoPushNotificationService : IPushNotificationService
     /// <summary>
     /// Parses an Expo success response (<c>{"data":[{"status":"ok"|"error",
     /// "details":{"error":"..."}}]}</c>) and emits one
-    /// <c>push_send_attempts_total</c> measurement per element. If the body
-    /// cannot be parsed or the <c>data</c> array length does not match the
-    /// request-side message count, falls back to counting every message as
+    /// <c>push_send_attempts_total</c> measurement per distinct outcome
+    /// bucket (with the per-bucket count rolled up before emission, so a
+    /// mixed batch yields one measurement per bucket, not one per ticket).
+    /// If the body cannot be parsed or no <c>data</c> array is present,
+    /// falls back to counting every request-side message as
     /// <see cref="PushNotificationsMetrics.OutcomeSuccess"/> — this matches
     /// the pre-metric contract (any 2xx counted as sent) while keeping
-    /// observability honest on the happy path.
+    /// the counter honest about attempts.
+    ///
+    /// <para>
+    /// <b>Length mismatch policy.</b> When Expo returns a <c>data</c>
+    /// array whose length differs from the request-side message count,
+    /// this method emits one increment per actual <c>data</c> element
+    /// rather than falling back to an all-<c>success</c> rollup. Expo's
+    /// documented contract is one element per request message, so a
+    /// length mismatch already indicates upstream misbehaviour; reporting
+    /// the dispositions Expo actually returned is more informative than
+    /// hiding them behind a blanket success. The unparseable-body
+    /// fallback above still applies whenever the response isn't JSON or
+    /// lacks a <c>data</c> array entirely.
+    /// </para>
     /// </summary>
-    private void RecordPerMessageOutcomes(int requestCount, string responseBody)
+    /// <returns>
+    /// <c>true</c> if the parser had to fall back to the
+    /// all-<c>success</c> path (body unparseable / no <c>data</c> array);
+    /// <c>false</c> if at least one ticket was classified from the
+    /// response body. The caller uses this to decide whether to log a
+    /// warning about upstream contract drift.
+    /// </returns>
+    private bool RecordPerMessageOutcomes(int requestCount, string responseBody)
     {
         var counts = new Dictionary<string, long>(capacity: 4);
 
@@ -184,6 +222,8 @@ public class ExpoPushNotificationService : IPushNotificationService
                 count,
                 new KeyValuePair<string, object?>(PushNotificationsMetrics.TagOutcome, outcome));
         }
+
+        return !parsedSuccessfully;
     }
 
     /// <summary>

--- a/src/Hali.Infrastructure/Notifications/ExpoPushNotificationService.cs
+++ b/src/Hali.Infrastructure/Notifications/ExpoPushNotificationService.cs
@@ -1,12 +1,16 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Hali.Application.Notifications;
+using Hali.Application.Observability;
 using Microsoft.Extensions.Logging;
 
 namespace Hali.Infrastructure.Notifications;
@@ -15,12 +19,17 @@ public class ExpoPushNotificationService : IPushNotificationService
 {
     private readonly HttpClient _http;
     private readonly ILogger<ExpoPushNotificationService> _logger;
+    private readonly PushNotificationsMetrics _metrics;
     private const string ExpoSendUrl = "https://exp.host/--/api/v2/push/send";
 
-    public ExpoPushNotificationService(HttpClient http, ILogger<ExpoPushNotificationService> logger)
+    public ExpoPushNotificationService(
+        HttpClient http,
+        ILogger<ExpoPushNotificationService> logger,
+        PushNotificationsMetrics metrics)
     {
         _http = http;
         _logger = logger;
+        _metrics = metrics;
     }
 
     public async Task SendBatchAsync(IEnumerable<PushMessage> messages, CancellationToken ct = default)
@@ -37,31 +46,190 @@ public class ExpoPushNotificationService : IPushNotificationService
             sound = "default"
         }).ToList();
 
-        var start = DateTime.UtcNow;
+        // Start the stopwatch as late as possible so the histogram reflects
+        // only the outbound HTTP segment — the portion whose latency depends
+        // on Expo rather than on our serialisation or CLR startup costs.
+        var sw = Stopwatch.StartNew();
+        HttpResponseMessage? response = null;
         try
         {
-            var response = await _http.PostAsJsonAsync(ExpoSendUrl, payload, ct);
-            var durationMs = (DateTime.UtcNow - start).TotalMilliseconds;
+            response = await _http.PostAsJsonAsync(ExpoSendUrl, payload, ct);
 
             if (!response.IsSuccessStatusCode)
             {
+                sw.Stop();
+                var durationMs = sw.Elapsed.TotalMilliseconds;
+                // HTTP 4xx (auth / bad request) is not recoverable by retry;
+                // 5xx (and anything else non-2xx) is treated as transient so
+                // operators can distinguish upstream brokenness from
+                // upstream misconfiguration at a glance.
+                var batchOutcome = IsClientError(response.StatusCode)
+                    ? PushNotificationsMetrics.OutcomePermanentError
+                    : PushNotificationsMetrics.OutcomeTransientError;
+
+                RecordBatchFailure(batch.Count, batchOutcome, sw.Elapsed.TotalSeconds);
+
                 _logger.LogWarning(
                     "Expo push batch failed {StatusCode} after {DurationMs}ms for {Count} messages",
                     (int)response.StatusCode, durationMs, batch.Count);
                 return;
             }
 
+            // 2xx — parse the response body to classify each message. If the
+            // body is unparseable, fall back to counting every message as
+            // success (matching the pre-metric behaviour, which treated any
+            // 2xx as "sent") rather than silently losing the attempts. The
+            // fallback path is unusual enough that emitting a warning is
+            // the right default.
+            string responseBody = await response.Content.ReadAsStringAsync(ct);
+            sw.Stop();
+            var successDurationSeconds = sw.Elapsed.TotalSeconds;
+            var successDurationMs = sw.Elapsed.TotalMilliseconds;
+
+            RecordPerMessageOutcomes(batch.Count, responseBody);
+            _metrics.PushSendDuration.Record(
+                successDurationSeconds,
+                new KeyValuePair<string, object?>(
+                    PushNotificationsMetrics.TagOutcome,
+                    PushNotificationsMetrics.OutcomeSuccess));
+
             _logger.LogInformation(
                 "Expo push batch sent {Count} messages in {DurationMs}ms",
-                batch.Count, durationMs);
+                batch.Count, successDurationMs);
+        }
+        catch (OperationCanceledException) when (ct.IsCancellationRequested)
+        {
+            // True caller cancellation (host shutdown / aborted worker pass).
+            // Mirrors SignalsMetrics: excluded from the outcome taxonomy so
+            // disconnects do not bias any counter bucket.
+            throw;
         }
         catch (Exception ex)
         {
-            var durationMs = (DateTime.UtcNow - start).TotalMilliseconds;
+            sw.Stop();
+            var durationMs = sw.Elapsed.TotalMilliseconds;
+            RecordBatchFailure(batch.Count, PushNotificationsMetrics.OutcomeTransientError, sw.Elapsed.TotalSeconds);
+
             _logger.LogError(ex,
                 "Expo push batch threw after {DurationMs}ms for {Count} messages",
                 durationMs, batch.Count);
             throw;
         }
+        finally
+        {
+            response?.Dispose();
+        }
     }
+
+    /// <summary>
+    /// Emits one <c>push_send_attempts_total</c> measurement per message in
+    /// the batch and one <c>push_send_duration_seconds</c> measurement for
+    /// the whole batch, all tagged with the same batch-level outcome. Used
+    /// on HTTP non-2xx and transport-exception paths where Expo never
+    /// returned structured per-message dispositions.
+    /// </summary>
+    private void RecordBatchFailure(int messageCount, string outcome, double durationSeconds)
+    {
+        var tag = new KeyValuePair<string, object?>(PushNotificationsMetrics.TagOutcome, outcome);
+        _metrics.PushSendAttemptsTotal.Add(messageCount, tag);
+        _metrics.PushSendDuration.Record(durationSeconds, tag);
+    }
+
+    /// <summary>
+    /// Parses an Expo success response (<c>{"data":[{"status":"ok"|"error",
+    /// "details":{"error":"..."}}]}</c>) and emits one
+    /// <c>push_send_attempts_total</c> measurement per element. If the body
+    /// cannot be parsed or the <c>data</c> array length does not match the
+    /// request-side message count, falls back to counting every message as
+    /// <see cref="PushNotificationsMetrics.OutcomeSuccess"/> — this matches
+    /// the pre-metric contract (any 2xx counted as sent) while keeping
+    /// observability honest on the happy path.
+    /// </summary>
+    private void RecordPerMessageOutcomes(int requestCount, string responseBody)
+    {
+        var counts = new Dictionary<string, long>(capacity: 4);
+
+        bool parsedSuccessfully = false;
+        try
+        {
+            using var doc = JsonDocument.Parse(responseBody);
+            if (doc.RootElement.ValueKind == JsonValueKind.Object
+                && doc.RootElement.TryGetProperty("data", out var data)
+                && data.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var element in data.EnumerateArray())
+                {
+                    var outcome = ClassifyExpoTicket(element);
+                    counts[outcome] = counts.GetValueOrDefault(outcome) + 1;
+                }
+                parsedSuccessfully = counts.Count > 0;
+            }
+        }
+        catch (JsonException)
+        {
+            // Fall through to the unparseable path below.
+        }
+
+        if (!parsedSuccessfully)
+        {
+            // Either the response wasn't JSON, had no data array, or had an
+            // empty data array — record every request-side message as
+            // success so the counter stays truthful about attempts.
+            counts[PushNotificationsMetrics.OutcomeSuccess] = requestCount;
+        }
+
+        foreach (var (outcome, count) in counts)
+        {
+            _metrics.PushSendAttemptsTotal.Add(
+                count,
+                new KeyValuePair<string, object?>(PushNotificationsMetrics.TagOutcome, outcome));
+        }
+    }
+
+    /// <summary>
+    /// Maps a single Expo ticket element to one of the four bounded outcome
+    /// buckets. Unknown or missing error codes fall through to
+    /// <see cref="PushNotificationsMetrics.OutcomeTransientError"/> — the
+    /// safe default for "might succeed on a later attempt".
+    /// </summary>
+    private static string ClassifyExpoTicket(JsonElement ticket)
+    {
+        if (ticket.ValueKind != JsonValueKind.Object)
+        {
+            return PushNotificationsMetrics.OutcomeTransientError;
+        }
+
+        string? status = ticket.TryGetProperty("status", out var s) && s.ValueKind == JsonValueKind.String
+            ? s.GetString()
+            : null;
+
+        if (string.Equals(status, "ok", StringComparison.Ordinal))
+        {
+            return PushNotificationsMetrics.OutcomeSuccess;
+        }
+
+        // Anything that isn't "ok" is an error — read details.error to
+        // decide the sub-bucket.
+        string? errorCode = null;
+        if (ticket.TryGetProperty("details", out var details)
+            && details.ValueKind == JsonValueKind.Object
+            && details.TryGetProperty("error", out var errElement)
+            && errElement.ValueKind == JsonValueKind.String)
+        {
+            errorCode = errElement.GetString();
+        }
+
+        return errorCode switch
+        {
+            "DeviceNotRegistered" => PushNotificationsMetrics.OutcomeDeviceInvalid,
+            "InvalidCredentials" => PushNotificationsMetrics.OutcomePermanentError,
+            "MessageTooBig" => PushNotificationsMetrics.OutcomePermanentError,
+            // MessageRateExceeded and any unrecognised error code are both
+            // treated as transient — the message may succeed if retried.
+            _ => PushNotificationsMetrics.OutcomeTransientError,
+        };
+    }
+
+    private static bool IsClientError(HttpStatusCode status) =>
+        (int)status >= 400 && (int)status < 500;
 }

--- a/src/Hali.Workers/WorkerProgram.cs
+++ b/src/Hali.Workers/WorkerProgram.cs
@@ -17,6 +17,14 @@ var builder = Host.CreateApplicationBuilder(args);
 
 builder.Services.AddInfrastructure(builder.Configuration);
 
+// PushNotificationsMetrics is a hard dependency of ExpoPushNotificationService,
+// which is resolved inside SendPushNotificationsJob. Registered as a singleton
+// so its underlying Meter is shared across every scoped send-service instance
+// — matching the API composition root's pattern for the other observability
+// meters. Safe to register here even though no OTel exporter is wired into
+// the worker host: the Meter still exists in-process at zero cost.
+builder.Services.AddSingleton<Hali.Application.Observability.PushNotificationsMetrics>();
+
 // Notification services needed by workers
 builder.Services.AddScoped<IFollowService, Hali.Application.Notifications.FollowService>();
 builder.Services.AddScoped<INotificationQueueService, Hali.Application.Notifications.NotificationQueueService>();

--- a/tests/Hali.Tests.Unit/Observability/PushNotificationsMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/PushNotificationsMetricsTests.cs
@@ -1,0 +1,482 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Controllers;
+using Hali.Application.Auth;
+using Hali.Application.Notifications;
+using Hali.Application.Observability;
+using Hali.Contracts.Notifications;
+using Hali.Domain.Entities.Auth;
+using Hali.Infrastructure.Notifications;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Hali.Tests.Unit.Observability;
+
+/// <summary>
+/// Verifies that the push-notification surface emits the three instruments
+/// owned by <see cref="PushNotificationsMetrics"/>:
+/// <list type="bullet">
+///   <item><description><c>push_send_attempts_total</c> — one increment per
+///     <see cref="PushMessage"/>, tagged with the per-message outcome
+///     derived from the Expo response or from the batch-level HTTP / transport
+///     disposition;</description></item>
+///   <item><description><c>push_send_duration_seconds</c> — one measurement
+///     per Expo send call, tagged with the batch-level outcome;</description></item>
+///   <item><description><c>push_token_registrations_total</c> — one
+///     increment per successful <c>POST /v1/devices/push-token</c> call,
+///     tagged with <c>result</c> (<c>new</c>, <c>updated</c>, or
+///     <c>unchanged</c>).</description></item>
+/// </list>
+///
+/// Each test owns an isolated <see cref="PushNotificationsMetrics"/> via
+/// <see cref="TestPushNotificationsMetrics"/> so the <see cref="MeterListener"/>
+/// only observes measurements from that test's meter — keeping the suite
+/// parallel-safe.
+/// </summary>
+public class PushNotificationsMetricsTests
+{
+    private sealed record DoubleMeasurement(double Value, Dictionary<string, object?> Tags);
+    private sealed record LongMeasurement(long Value, Dictionary<string, object?> Tags);
+
+    private sealed class MetricCapture : IDisposable
+    {
+        private readonly MeterListener _listener = new();
+        public List<LongMeasurement> AttemptMeasurements { get; } = new();
+        public List<DoubleMeasurement> DurationMeasurements { get; } = new();
+        public List<LongMeasurement> RegistrationMeasurements { get; } = new();
+
+        public MetricCapture(PushNotificationsMetrics metrics)
+        {
+            _listener.InstrumentPublished = (instrument, listener) =>
+            {
+                if (ReferenceEquals(instrument, metrics.PushSendAttemptsTotal)
+                    || ReferenceEquals(instrument, metrics.PushSendDuration)
+                    || ReferenceEquals(instrument, metrics.PushTokenRegistrationsTotal))
+                {
+                    listener.EnableMeasurementEvents(instrument);
+                }
+            };
+
+            _listener.SetMeasurementEventCallback<long>((instrument, measurement, tags, _) =>
+            {
+                var dict = ToDict(tags);
+                if (ReferenceEquals(instrument, metrics.PushSendAttemptsTotal))
+                {
+                    AttemptMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+                else if (ReferenceEquals(instrument, metrics.PushTokenRegistrationsTotal))
+                {
+                    RegistrationMeasurements.Add(new LongMeasurement(measurement, dict));
+                }
+            });
+
+            _listener.SetMeasurementEventCallback<double>((instrument, measurement, tags, _) =>
+            {
+                if (ReferenceEquals(instrument, metrics.PushSendDuration))
+                {
+                    DurationMeasurements.Add(new DoubleMeasurement(measurement, ToDict(tags)));
+                }
+            });
+
+            _listener.Start();
+        }
+
+        private static Dictionary<string, object?> ToDict(ReadOnlySpan<KeyValuePair<string, object?>> tags)
+        {
+            var dict = new Dictionary<string, object?>(tags.Length);
+            foreach (var tag in tags)
+            {
+                dict[tag.Key] = tag.Value;
+            }
+            return dict;
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    // ── ExpoPushNotificationService — counter + histogram ────────────────────
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+        private readonly string _body;
+
+        public StubHttpMessageHandler(HttpStatusCode status, string body)
+        {
+            _status = status;
+            _body = body;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            var response = new HttpResponseMessage(_status)
+            {
+                Content = new StringContent(_body, Encoding.UTF8, "application/json"),
+            };
+            return Task.FromResult(response);
+        }
+    }
+
+    private sealed class ThrowingHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Exception _ex;
+        public ThrowingHttpMessageHandler(Exception ex) { _ex = ex; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromException<HttpResponseMessage>(_ex);
+    }
+
+    private static ExpoPushNotificationService BuildService(
+        HttpMessageHandler handler,
+        PushNotificationsMetrics metrics)
+    {
+        var http = new HttpClient(handler);
+        return new ExpoPushNotificationService(
+            http,
+            NullLogger<ExpoPushNotificationService>.Instance,
+            metrics);
+    }
+
+    private static List<PushMessage> MakeBatch(int count)
+    {
+        var list = new List<PushMessage>(count);
+        for (int i = 0; i < count; i++)
+        {
+            list.Add(new PushMessage(
+                Token: $"ExponentPushToken[xxxxxxxxxxxx-{i}]",
+                Title: "Title",
+                Body: "Body",
+                Data: null));
+        }
+        return list;
+    }
+
+    [Fact]
+    public async Task Send_AllTicketsOk_EmitsOneSuccessPerMessageAndSuccessHistogram()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        string body = """{"data":[{"status":"ok"},{"status":"ok"},{"status":"ok"}]}""";
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.OK, body), scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(3));
+
+        // 3 success measurements (one per ticket); histogram fires once.
+        var attempt = Assert.Single(capture.AttemptMeasurements);
+        Assert.Equal(3L, attempt.Value);
+        Assert.Equal(PushNotificationsMetrics.OutcomeSuccess, attempt.Tags[PushNotificationsMetrics.TagOutcome]);
+
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.True(duration.Value >= 0);
+        Assert.Equal(PushNotificationsMetrics.OutcomeSuccess, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Send_MixedTickets_EmitsOneBucketPerDistinctOutcome()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        // Three messages with four distinct dispositions across them is the
+        // worst-case cardinality per response — asserts the classifier maps
+        // each bucket correctly and does not double-count.
+        string body = """
+        {
+          "data": [
+            { "status": "ok" },
+            { "status": "error", "details": { "error": "DeviceNotRegistered" } },
+            { "status": "error", "details": { "error": "MessageTooBig" } },
+            { "status": "error", "details": { "error": "MessageRateExceeded" } },
+            { "status": "error", "details": { "error": "InvalidCredentials" } }
+          ]
+        }
+        """;
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.OK, body), scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(5));
+
+        var byOutcome = new Dictionary<string, long>();
+        foreach (var m in capture.AttemptMeasurements)
+        {
+            var outcome = (string)m.Tags[PushNotificationsMetrics.TagOutcome]!;
+            byOutcome[outcome] = byOutcome.GetValueOrDefault(outcome) + m.Value;
+        }
+
+        Assert.Equal(1L, byOutcome[PushNotificationsMetrics.OutcomeSuccess]);
+        Assert.Equal(1L, byOutcome[PushNotificationsMetrics.OutcomeDeviceInvalid]);
+        // MessageTooBig + InvalidCredentials both map to permanent_error.
+        Assert.Equal(2L, byOutcome[PushNotificationsMetrics.OutcomePermanentError]);
+        // MessageRateExceeded maps to transient_error.
+        Assert.Equal(1L, byOutcome[PushNotificationsMetrics.OutcomeTransientError]);
+
+        // Histogram fires once with the batch-level success outcome because
+        // the HTTP call itself succeeded (2xx). device_invalid /
+        // permanent_error dispositions are per-message only.
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.OutcomeSuccess, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Send_UnknownErrorCode_DefaultsToTransient()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        // Unrecognised Expo error code must never slip into success/permanent
+        // — transient is the safe retriable default.
+        string body = """{"data":[{"status":"error","details":{"error":"SomeFutureErrorCodeExpoAdds"}}]}""";
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.OK, body), scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(1));
+
+        var attempt = Assert.Single(capture.AttemptMeasurements);
+        Assert.Equal(1L, attempt.Value);
+        Assert.Equal(PushNotificationsMetrics.OutcomeTransientError, attempt.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Send_Http5xx_EmitsTransientErrorForEveryMessageAndHistogram()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.BadGateway, "{}"), scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(2));
+
+        var attempt = Assert.Single(capture.AttemptMeasurements);
+        Assert.Equal(2L, attempt.Value);
+        Assert.Equal(PushNotificationsMetrics.OutcomeTransientError, attempt.Tags[PushNotificationsMetrics.TagOutcome]);
+
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.OutcomeTransientError, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Send_Http4xx_EmitsPermanentErrorForEveryMessageAndHistogram()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        // 401 is the canonical auth failure for Expo batches — must never
+        // be retried (would hammer Expo with bad credentials).
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.Unauthorized, "{}"), scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(4));
+
+        var attempt = Assert.Single(capture.AttemptMeasurements);
+        Assert.Equal(4L, attempt.Value);
+        Assert.Equal(PushNotificationsMetrics.OutcomePermanentError, attempt.Tags[PushNotificationsMetrics.TagOutcome]);
+
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.OutcomePermanentError, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Send_TransportException_EmitsTransientErrorAndStillRethrows()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var svc = BuildService(
+            new ThrowingHttpMessageHandler(new HttpRequestException("dns failure")),
+            scope.Metrics);
+
+        await Assert.ThrowsAsync<HttpRequestException>(() => svc.SendBatchAsync(MakeBatch(2)));
+
+        // Metrics must still record even though the exception propagates.
+        var attempt = Assert.Single(capture.AttemptMeasurements);
+        Assert.Equal(2L, attempt.Value);
+        Assert.Equal(PushNotificationsMetrics.OutcomeTransientError, attempt.Tags[PushNotificationsMetrics.TagOutcome]);
+
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.OutcomeTransientError, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
+    public async Task Send_CallerCancellation_DoesNotEmitMetrics()
+    {
+        // Mirrors SignalsMetrics / ClustersMetrics: a caller-signaled
+        // cancellation is not a send outcome — no counter or histogram
+        // measurement is recorded.
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+
+        var svc = BuildService(
+            new ThrowingHttpMessageHandler(new OperationCanceledException(cts.Token)),
+            scope.Metrics);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            svc.SendBatchAsync(MakeBatch(1), cts.Token));
+
+        Assert.Empty(capture.AttemptMeasurements);
+        Assert.Empty(capture.DurationMeasurements);
+    }
+
+    [Fact]
+    public async Task Send_EmptyBatch_EmitsNothing()
+    {
+        // Zero work = zero metrics. Guards against an off-by-one that
+        // would quietly inflate the counter on idle worker passes.
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.OK, "{}"), scope.Metrics);
+
+        await svc.SendBatchAsync(Array.Empty<PushMessage>());
+
+        Assert.Empty(capture.AttemptMeasurements);
+        Assert.Empty(capture.DurationMeasurements);
+    }
+
+    [Fact]
+    public async Task Send_UnparseableResponseBody_FallsBackToSuccessPerRequestMessage()
+    {
+        // A 2xx with malformed body should not silently lose attempts —
+        // counter falls back to one success per request-side message.
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var svc = BuildService(
+            new StubHttpMessageHandler(HttpStatusCode.OK, "not-json"),
+            scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(3));
+
+        var attempt = Assert.Single(capture.AttemptMeasurements);
+        Assert.Equal(3L, attempt.Value);
+        Assert.Equal(PushNotificationsMetrics.OutcomeSuccess, attempt.Tags[PushNotificationsMetrics.TagOutcome]);
+
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.OutcomeSuccess, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    // ── DevicesController.RegisterPushToken — registration counter ───────────
+
+    private static DevicesController CreateDevicesController(
+        PushNotificationsMetrics metrics,
+        IAuthRepository auth)
+    {
+        var controller = new DevicesController(
+            auth,
+            NullLogger<DevicesController>.Instance,
+            metrics);
+        controller.ControllerContext = new ControllerContext { HttpContext = new DefaultHttpContext() };
+        return controller;
+    }
+
+    [Fact]
+    public async Task RegisterPushToken_NewToken_EmitsResultNew()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var device = new Device
+        {
+            Id = Guid.NewGuid(),
+            DeviceFingerprintHash = "hash",
+            ExpoPushToken = null,
+        };
+        var auth = Substitute.For<IAuthRepository>();
+        auth.FindDeviceByFingerprintAsync("hash", Arg.Any<CancellationToken>()).Returns(device);
+
+        var controller = CreateDevicesController(scope.Metrics, auth);
+        var dto = new RegisterPushTokenRequestDto { ExpoPushToken = "ExponentPushToken[aaa]", DeviceHash = "hash" };
+
+        await controller.RegisterPushToken(dto, CancellationToken.None);
+
+        var m = Assert.Single(capture.RegistrationMeasurements);
+        Assert.Equal(1L, m.Value);
+        Assert.Equal(PushNotificationsMetrics.ResultNew, m.Tags[PushNotificationsMetrics.TagResult]);
+    }
+
+    [Fact]
+    public async Task RegisterPushToken_DifferentToken_EmitsResultUpdated()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var device = new Device
+        {
+            Id = Guid.NewGuid(),
+            DeviceFingerprintHash = "hash",
+            ExpoPushToken = "ExponentPushToken[old]",
+        };
+        var auth = Substitute.For<IAuthRepository>();
+        auth.FindDeviceByFingerprintAsync("hash", Arg.Any<CancellationToken>()).Returns(device);
+
+        var controller = CreateDevicesController(scope.Metrics, auth);
+        var dto = new RegisterPushTokenRequestDto { ExpoPushToken = "ExponentPushToken[new]", DeviceHash = "hash" };
+
+        await controller.RegisterPushToken(dto, CancellationToken.None);
+
+        var m = Assert.Single(capture.RegistrationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.ResultUpdated, m.Tags[PushNotificationsMetrics.TagResult]);
+    }
+
+    [Fact]
+    public async Task RegisterPushToken_SameToken_EmitsResultUnchanged()
+    {
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        // Exact ordinal match — the comparison must be case-sensitive to
+        // avoid collapsing two legitimately different Expo tokens onto the
+        // same "unchanged" bucket.
+        var device = new Device
+        {
+            Id = Guid.NewGuid(),
+            DeviceFingerprintHash = "hash",
+            ExpoPushToken = "ExponentPushToken[same]",
+        };
+        var auth = Substitute.For<IAuthRepository>();
+        auth.FindDeviceByFingerprintAsync("hash", Arg.Any<CancellationToken>()).Returns(device);
+
+        var controller = CreateDevicesController(scope.Metrics, auth);
+        var dto = new RegisterPushTokenRequestDto { ExpoPushToken = "ExponentPushToken[same]", DeviceHash = "hash" };
+
+        await controller.RegisterPushToken(dto, CancellationToken.None);
+
+        var m = Assert.Single(capture.RegistrationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.ResultUnchanged, m.Tags[PushNotificationsMetrics.TagResult]);
+    }
+
+    [Fact]
+    public async Task RegisterPushToken_CaseDifferenceCountsAsUpdated()
+    {
+        // Expo tokens are opaque case-sensitive strings. A case-only diff
+        // must not be collapsed onto "unchanged".
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var device = new Device
+        {
+            Id = Guid.NewGuid(),
+            DeviceFingerprintHash = "hash",
+            ExpoPushToken = "ExponentPushToken[ABC]",
+        };
+        var auth = Substitute.For<IAuthRepository>();
+        auth.FindDeviceByFingerprintAsync("hash", Arg.Any<CancellationToken>()).Returns(device);
+
+        var controller = CreateDevicesController(scope.Metrics, auth);
+        var dto = new RegisterPushTokenRequestDto { ExpoPushToken = "ExponentPushToken[abc]", DeviceHash = "hash" };
+
+        await controller.RegisterPushToken(dto, CancellationToken.None);
+
+        var m = Assert.Single(capture.RegistrationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.ResultUpdated, m.Tags[PushNotificationsMetrics.TagResult]);
+    }
+}

--- a/tests/Hali.Tests.Unit/Observability/PushNotificationsMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/PushNotificationsMetricsTests.cs
@@ -343,6 +343,50 @@ public class PushNotificationsMetricsTests
     }
 
     [Fact]
+    public async Task Send_DataArrayLengthMismatchesRequest_EmitsPerReturnedTicket()
+    {
+        // Expo's documented contract is one data[] element per request
+        // message. If Expo misbehaves and returns fewer or more tickets,
+        // the classifier reports the dispositions Expo actually returned
+        // rather than hiding them behind a blanket all-success rollup.
+        // This test documents that contract so a future refactor toward
+        // request-count-based fallback is a conscious decision, not a
+        // silent regression.
+        using var scope = TestPushNotificationsMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        // Sent 3 messages, Expo returned 2 tickets (1 ok + 1 error).
+        string body = """
+        {
+          "data": [
+            { "status": "ok" },
+            { "status": "error", "details": { "error": "DeviceNotRegistered" } }
+          ]
+        }
+        """;
+        var svc = BuildService(new StubHttpMessageHandler(HttpStatusCode.OK, body), scope.Metrics);
+
+        await svc.SendBatchAsync(MakeBatch(3));
+
+        var byOutcome = new Dictionary<string, long>();
+        foreach (var m in capture.AttemptMeasurements)
+        {
+            var outcome = (string)m.Tags[PushNotificationsMetrics.TagOutcome]!;
+            byOutcome[outcome] = byOutcome.GetValueOrDefault(outcome) + m.Value;
+        }
+
+        // Per-ticket emission: two counts total, not three, reflecting
+        // exactly what Expo returned.
+        Assert.Equal(1L, byOutcome[PushNotificationsMetrics.OutcomeSuccess]);
+        Assert.Equal(1L, byOutcome[PushNotificationsMetrics.OutcomeDeviceInvalid]);
+        Assert.False(byOutcome.ContainsKey(PushNotificationsMetrics.OutcomeTransientError));
+        Assert.False(byOutcome.ContainsKey(PushNotificationsMetrics.OutcomePermanentError));
+
+        var duration = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal(PushNotificationsMetrics.OutcomeSuccess, duration.Tags[PushNotificationsMetrics.TagOutcome]);
+    }
+
+    [Fact]
     public async Task Send_UnparseableResponseBody_FallsBackToSuccessPerRequestMessage()
     {
         // A 2xx with malformed body should not silently lose attempts —

--- a/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
+++ b/tests/Hali.Tests.Unit/Observability/TestMetrics.cs
@@ -177,3 +177,46 @@ internal static class TestClustersMetrics
         return new TestClustersMetricsScope(provider, new ClustersMetrics(factory));
     }
 }
+
+/// <summary>
+/// Disposable wrapper around a test-owned <see cref="PushNotificationsMetrics"/>
+/// and the <see cref="ServiceProvider"/> that hosts its <see cref="IMeterFactory"/>.
+/// Mirrors <see cref="TestClustersMetricsScope"/> for the push-notifications
+/// meter so each test gets an isolated
+/// <see cref="System.Diagnostics.Metrics.Meter"/> instance and
+/// <see cref="System.Diagnostics.Metrics.MeterListener"/> observations stay
+/// scoped to that test.
+/// </summary>
+internal sealed class TestPushNotificationsMetricsScope : IDisposable
+{
+    private readonly ServiceProvider _provider;
+    public PushNotificationsMetrics Metrics { get; }
+
+    internal TestPushNotificationsMetricsScope(ServiceProvider provider, PushNotificationsMetrics metrics)
+    {
+        _provider = provider;
+        Metrics = metrics;
+    }
+
+    public void Dispose()
+    {
+        Metrics.Dispose();
+        _provider.Dispose();
+    }
+}
+
+/// <summary>
+/// Factory for <see cref="TestPushNotificationsMetricsScope"/>. Callers own
+/// the returned scope and must dispose it (via <c>using</c> or a fixture).
+/// </summary>
+internal static class TestPushNotificationsMetrics
+{
+    public static TestPushNotificationsMetricsScope Create()
+    {
+        var services = new ServiceCollection();
+        services.AddMetrics();
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IMeterFactory>();
+        return new TestPushNotificationsMetricsScope(provider, new PushNotificationsMetrics(factory));
+    }
+}


### PR DESCRIPTION
Closes #170

## Problem
The Phase 1 push-notification pipeline (`ExpoPushNotificationService`,
`SendPushNotificationsJob`, `POST /v1/devices/push-token`) had structured
logs but no queryable time series for send success/failure/latency.
Restoration prompts and new-cluster-in-followed-ward pushes are the only
user-visible asynchronous output the citizen app produces, and silent
failures (expired tokens, Expo outages, auth misconfig) would have been
visible to operators only through log scraping.

## Root cause
The observability lane established by #164/#166/#167/#168 did not yet
cover the notifications layer. `ExpoPushNotificationService` only checked
`response.IsSuccessStatusCode` and never parsed the Expo response body,
so per-message dispositions (`DeviceNotRegistered`, `MessageTooBig`,
`MessageRateExceeded`, …) were invisible to any downstream layer.

## What changed
- Added `PushNotificationsMetrics` under
  `src/Hali.Application/Observability/` — parallel to `SignalsMetrics`
  and `ClustersMetrics`. Owns the `Hali.Notifications` meter and the
  three instruments below.
- Rewrote `ExpoPushNotificationService.SendBatchAsync` to parse the
  Expo success response (`{"data":[{"status":"ok"|"error",
  "details":{"error":"…"}}]}`) and classify each ticket into one of
  four bounded outcomes. Whole-batch failures (HTTP non-2xx, transport
  exceptions) fan out a single counter `.Add(batchCount, …)` with the
  batch-level outcome tag. Latency is measured around the HTTP call
  only.
- Added a registration-result counter on
  `DevicesController.RegisterPushToken`. The `result` tag is derived
  from an ordinal comparison of `device.ExpoPushToken` (snapshotted
  before the write) against the request body.
- Registered `PushNotificationsMetrics` as a singleton in both the API
  (`Program.cs`) and worker (`WorkerProgram.cs`) composition roots.
  Added to the OTel `AddMeter(...)` list on the API.
- 14 new unit tests under
  `tests/Hali.Tests.Unit/Observability/PushNotificationsMetricsTests.cs`
  and a reusable `TestPushNotificationsMetrics` scope in
  `TestMetrics.cs`.

## Metric names and tags
| Instrument | Kind | Tag | Values |
| --- | --- | --- | --- |
| `push_send_attempts_total` | `Counter<long>` (unit `{message}`) | `outcome` | `success`, `device_invalid`, `transient_error`, `permanent_error` |
| `push_send_duration_seconds` | `Histogram<double>` (unit `s`) | `outcome` | `success`, `transient_error`, `permanent_error` |
| `push_token_registrations_total` | `Counter<long>` (unit `{registration}`) | `result` | `new`, `updated`, `unchanged` |

Steady-state cardinality: 4 + 3 + 3 = **10 time series**.

## Where each metric is measured
- `push_send_attempts_total`: emitted in
  `ExpoPushNotificationService.SendBatchAsync` after the Expo response
  is read (per-ticket classification) or on HTTP non-2xx / transport
  exception (one fan-out increment equal to the request-side message
  count). This is the only layer that observes real per-message
  dispositions.
- `push_send_duration_seconds`: recorded in the same method around
  `PostAsJsonAsync` + `ReadAsStringAsync` — the outbound HTTP segment
  whose latency depends on Expo. Queue fetch, payload parse, and
  `MarkSentAsync` work are deliberately excluded (they are owned by
  the caller path and already have structured logs).
- `push_token_registrations_total`: emitted in
  `DevicesController.RegisterPushToken` after the persist call returns
  — the only layer with both the pre-write token and the new request
  body. No increment is emitted for validation failures or
  device-not-found responses (already covered by the API-wide
  exception counter).

## How success/failure outcomes are represented
Bounded four-way classification derived from Expo's documented response
shape:

```
status == "ok"                                         → success
status == "error", details.error == "DeviceNotRegistered" → device_invalid
status == "error", details.error == "InvalidCredentials"  → permanent_error
status == "error", details.error == "MessageTooBig"       → permanent_error
status == "error", details.error == "MessageRateExceeded" → transient_error
status == "error", any other / unparseable details.error  → transient_error
```

For batch-level failures (HTTP non-2xx, transport exception,
server-side timeout) every message in the batch is counted under a
batch outcome:

```
HTTP 4xx                 → permanent_error
HTTP 5xx                 → transient_error
HTTP timeout / network   → transient_error
```

Client-driven cancellation (caller CT signaled) is excluded from the
outcome taxonomy — nothing is recorded. Mirrors the guard established
by `SignalsMetrics` / `ClustersMetrics`.

## Why the chosen tags are safe
- `outcome`: bounded 4-value static catalog. No free-form exception
  message, no Expo message id, no push token, no notification body.
- `result`: bounded 3-value static catalog. No device fingerprint, no
  token prefix, no account id.
- No correlation id, trace id, device id, account id, locality name, or
  idempotency key is ever attached to any tag.

## Tests added/updated
All new tests live in
`tests/Hali.Tests.Unit/Observability/PushNotificationsMetricsTests.cs`:

- `Send_AllTicketsOk_EmitsOneSuccessPerMessageAndSuccessHistogram`
- `Send_MixedTickets_EmitsOneBucketPerDistinctOutcome` — success +
  `DeviceNotRegistered` + `MessageTooBig` + `MessageRateExceeded` +
  `InvalidCredentials` in one response.
- `Send_UnknownErrorCode_DefaultsToTransient`
- `Send_Http5xx_EmitsTransientErrorForEveryMessageAndHistogram`
- `Send_Http4xx_EmitsPermanentErrorForEveryMessageAndHistogram`
- `Send_TransportException_EmitsTransientErrorAndStillRethrows`
- `Send_CallerCancellation_DoesNotEmitMetrics`
- `Send_EmptyBatch_EmitsNothing`
- `Send_DataArrayLengthMismatchesRequest_EmitsPerReturnedTicket` —
  3 sent, Expo returns 2 tickets (1 ok + 1 `DeviceNotRegistered`);
  asserts per-ticket emission, not a blanket success rollup.
- `Send_UnparseableResponseBody_FallsBackToSuccessPerRequestMessage`
- `RegisterPushToken_NewToken_EmitsResultNew`
- `RegisterPushToken_DifferentToken_EmitsResultUpdated`
- `RegisterPushToken_SameToken_EmitsResultUnchanged`
- `RegisterPushToken_CaseDifferenceCountsAsUpdated`

Shared infrastructure:
`TestPushNotificationsMetrics` scope added to `TestMetrics.cs`.

Verification:
- `dotnet build` — 0 errors
- `dotnet test` — 442 unit + 64 integration tests pass
- `dotnet format --verify-no-changes` on touched files — clean

## Out of scope
- Migrating off Expo Push — forbidden by CLAUDE.md stack rules.
- Per-device / per-account tag dimensions — cardinality would blow up.
- User-level delivery telemetry or open-rate tracking.
- Dashboards and alert rules — separate observability lane.
- Retry / backoff redesign, queueing changes, provider abstraction
  rewrite.
- OpenAPI changes — none required (response contracts unchanged).

## Risk assessment
- **Behaviour change**: none. The send path still returns on HTTP
  non-2xx (log + return) and still rethrows transport exceptions.
  `MarkSentAsync` / `MarkFailedAsync` branching in
  `SendPushNotificationsJob` is untouched.
- **Performance**: one extra `ReadAsStringAsync` + `JsonDocument.Parse`
  on the 2xx happy path (the response body was already materialised by
  `PostAsJsonAsync` on the framework side — no extra network round
  trip). Counter / histogram emission is in-process and zero-cost when
  no OTel exporter is configured.
- **Cardinality**: 10 time series at steady state. Static catalogs
  prevent runaway tag growth.
- **Compatibility**: no mobile or API response contract changes. Meter
  is optional at runtime — if OTel is unconfigured, instruments still
  exist in-process and are never exported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
