### PR TITLE
[Issue #178] Canonicalize SignalState serialization in outbox payloads

### DIFF
--- a/src/Hali.Application/Clusters/CivisEvaluationService.cs
+++ b/src/Hali.Application/Clusters/CivisEvaluationService.cs
@@ -155,18 +155,32 @@ public class CivisEvaluationService : ICivisEvaluationService
     }
 
     /// <summary>
-    /// Maps a <see cref="SignalState"/> to the canonical snake_case tag
-    /// value used by <see cref="ClustersMetrics.ClusterLifecycleTransitionsTotal"/>.
-    /// Only the three lifecycle states that participate in transitions
-    /// emitted by this service are mapped.
+    /// Maps a <see cref="SignalState"/> to its canonical snake_case wire
+    /// value. Used for both
+    /// <c>cluster_lifecycle_transitions_total</c> metric tags
+    /// (<see cref="ClustersMetrics.ClusterLifecycleTransitionsTotal"/>)
+    /// and the <c>cluster_state_changed</c> outbox payload's
+    /// <c>from_state</c> / <c>to_state</c> fields, so metric dashboards and
+    /// downstream outbox consumers observe the same string for the same
+    /// transition.
+    ///
+    /// Explicit mapping is deliberate. Using <c>state.ToString().ToLowerInvariant()</c>
+    /// collapses <c>PossibleRestoration</c> to <c>"possiblerestoration"</c>
+    /// (no underscore), which breaks the canonical snake_case contract
+    /// required by consumers matching on <c>to_state == "possible_restoration"</c>
+    /// (see <c>docs/arch/CODING_STANDARDS.md</c> §Enum serialization rules).
+    /// Only the four states that participate in transitions emitted by this
+    /// service are mapped; any other value indicates a caller bug and throws.
     /// </summary>
-    private static string ToStateTag(SignalState state) => state switch
+    private static string ToCanonicalStateString(SignalState state) => state switch
     {
+        SignalState.Unconfirmed => ClustersMetrics.StateUnconfirmed,
         SignalState.Active => ClustersMetrics.StateActive,
         SignalState.PossibleRestoration => ClustersMetrics.StatePossibleRestoration,
         SignalState.Resolved => ClustersMetrics.StateResolved,
-        SignalState.Unconfirmed => ClustersMetrics.StateUnconfirmed,
-        _ => state.ToString().ToLowerInvariant(),
+        _ => throw new ArgumentOutOfRangeException(
+            nameof(state), state,
+            "SignalState is not a lifecycle transition state emitted by CivisEvaluationService."),
     };
 
     public async Task ApplyDecayAsync(Guid clusterId, CancellationToken ct = default(CancellationToken))
@@ -221,11 +235,18 @@ public class CivisEvaluationService : ICivisEvaluationService
                 AggregateType = "cluster",
                 AggregateId = clusterId,
                 EventType = "cluster_state_changed",
+                // Canonical snake_case wire values via ToCanonicalStateString,
+                // matching the literal `"unconfirmed"` / `"active"` form used
+                // at the activation emission in EvaluateClusterAsync and the
+                // `"active"` / `"possible_restoration"` literals used in
+                // ParticipationService.EvaluateRestorationAsync. Using
+                // `ToString().ToLowerInvariant()` here previously produced
+                // `"possiblerestoration"` (no underscore) — see issue #178.
                 Payload = JsonSerializer.Serialize(new
                 {
                     cluster_id = clusterId,
-                    from_state = fromState.ToString().ToLowerInvariant(),
-                    to_state = toState.ToString().ToLowerInvariant()
+                    from_state = ToCanonicalStateString(fromState),
+                    to_state = ToCanonicalStateString(toState)
                 }),
                 OccurredAt = now
             }, ct);
@@ -233,20 +254,18 @@ public class CivisEvaluationService : ICivisEvaluationService
             // Lifecycle counter (R3.c / #168) — fires at the same
             // transition point as the outbox event and the
             // ClusterPossibleRestoration / ClusterResolvedByDecay log
-            // events below. Tag values come from the ClustersMetrics
-            // state catalog (canonical snake_case) rather than the raw
-            // enum ToString, because `SignalState.PossibleRestoration`
-            // lowercases to "possiblerestoration" without an underscore —
-            // using the catalog keeps metric tags uniform and alertable
-            // (`to_state="possible_restoration"`).
+            // events below. Tag values come from ToCanonicalStateString,
+            // the same helper used by the outbox payload above, so metric
+            // dashboards and downstream outbox consumers observe the same
+            // string for the same transition.
             _clustersMetrics?.ClusterLifecycleTransitionsTotal.Add(
                 1,
                 new KeyValuePair<string, object?>(
                     ClustersMetrics.TagFromState,
-                    ToStateTag(fromState)),
+                    ToCanonicalStateString(fromState)),
                 new KeyValuePair<string, object?>(
                     ClustersMetrics.TagToState,
-                    ToStateTag(toState)));
+                    ToCanonicalStateString(toState)));
 
             if (_notificationQueue != null)
             {

--- a/src/Hali.Application/Observability/ClustersMetrics.cs
+++ b/src/Hali.Application/Observability/ClustersMetrics.cs
@@ -193,11 +193,13 @@ public sealed class ClustersMetrics : IDisposable
     // Canonical snake_case values used by the cluster_lifecycle_transitions
     // counter. These are deliberately NOT derived from SignalState.ToString()
     // because `SignalState.PossibleRestoration.ToString().ToLowerInvariant()`
-    // yields "possiblerestoration" (no underscore) — the existing outbox
-    // event payload for cluster_state_changed currently uses that form, but
-    // the metric tag stays snake_case so dashboards and alerts remain
-    // readable and human-friendly. Normalizing the outbox payload is a
-    // separate, out-of-scope change.
+    // yields "possiblerestoration" (no underscore), which violates
+    // `docs/arch/CODING_STANDARDS.md` §Enum serialization rules.
+    // The `cluster_state_changed` outbox payload emits the same canonical
+    // strings via `CivisEvaluationService.ToCanonicalStateString`, so
+    // dashboards, alerts, and downstream outbox consumers observe the same
+    // value for the same transition (see issue #178 for the fix that removed
+    // the prior `"possiblerestoration"` divergence in `ApplyDecayAsync`).
     // Only the four states that participate in lifecycle transitions are
     // listed here — Expired and Suppressed are not produced by any of the
     // instrumented code paths and are omitted from the tag catalog to keep

--- a/src/Hali.Application/Observability/ClustersMetrics.cs
+++ b/src/Hali.Application/Observability/ClustersMetrics.cs
@@ -196,10 +196,15 @@ public sealed class ClustersMetrics : IDisposable
     // yields "possiblerestoration" (no underscore), which violates
     // `docs/arch/CODING_STANDARDS.md` §Enum serialization rules.
     // The `cluster_state_changed` outbox payload emits the same canonical
-    // strings via `CivisEvaluationService.ToCanonicalStateString`, so
-    // dashboards, alerts, and downstream outbox consumers observe the same
-    // value for the same transition (see issue #178 for the fix that removed
-    // the prior `"possiblerestoration"` divergence in `ApplyDecayAsync`).
+    // strings — the activation emission in
+    // `CivisEvaluationService.EvaluateClusterAsync` and the citizen-vote
+    // emission in `ParticipationService.EvaluateRestorationAsync` use string
+    // literals, and the decay-driven emission in
+    // `CivisEvaluationService.ApplyDecayAsync` uses the module's
+    // `SignalState` → snake_case mapper. Dashboards, alerts, and downstream
+    // outbox consumers therefore observe the same value for the same
+    // transition (see issue #178 for the fix that removed the prior
+    // `"possiblerestoration"` divergence in `ApplyDecayAsync`).
     // Only the four states that participate in lifecycle transitions are
     // listed here — Expired and Suppressed are not produced by any of the
     // instrumented code paths and are omitted from the tag catalog to keep

--- a/tests/Hali.Tests.Unit/Clusters/CivisEvaluationServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Clusters/CivisEvaluationServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Threading.Tasks;
 using Hali.Application.Clusters;
 using Hali.Domain.Entities.Clusters;
@@ -251,6 +252,68 @@ public class CivisEvaluationServiceTests
 		await svc.ApplyDecayAsync(cluster.Id);
 		Assert.Single(repo.OutboxEvents);
 		Assert.Equal("cluster_state_changed", repo.OutboxEvents[0].EventType);
+	}
+
+	// Issue #178 — the decay-driven active → possible_restoration outbox
+	// emission previously used `SignalState.ToString().ToLowerInvariant()`,
+	// producing `"possiblerestoration"` (no underscore) instead of the
+	// canonical `"possible_restoration"`. Lock the canonical snake_case
+	// values for both decay transitions and the activation transition so the
+	// broken formatting cannot silently reappear on any of the three
+	// `cluster_state_changed` emission paths in `CivisEvaluationService`.
+
+	[Fact]
+	public async Task ApplyDecay_ActiveToPossibleRestoration_WritesCanonicalSnakeCaseOutboxPayload()
+	{
+		SignalCluster cluster = ActiveRoadsCluster();
+		var (svc, repo) = BuildDecay(cluster);
+
+		await svc.ApplyDecayAsync(cluster.Id);
+
+		Assert.Single(repo.OutboxEvents);
+		using JsonDocument payload = JsonDocument.Parse(repo.OutboxEvents[0].Payload);
+		string fromState = payload.RootElement.GetProperty("from_state").GetString()!;
+		string toState = payload.RootElement.GetProperty("to_state").GetString()!;
+		Assert.Equal("active", fromState);
+		Assert.Equal("possible_restoration", toState);
+		// Regression guard: the broken `ToString().ToLowerInvariant()`
+		// format must never re-enter this payload (see issue #178).
+		Assert.DoesNotContain("possiblerestoration", repo.OutboxEvents[0].Payload);
+	}
+
+	[Fact]
+	public async Task ApplyDecay_PossibleRestorationToResolved_WritesCanonicalSnakeCaseOutboxPayload()
+	{
+		SignalCluster cluster = ActiveRoadsCluster();
+		cluster.State = SignalState.PossibleRestoration;
+		cluster.PossibleRestorationAt = DateTime.UtcNow.AddHours(-100.0);
+		var (svc, repo) = BuildDecay(cluster);
+
+		await svc.ApplyDecayAsync(cluster.Id);
+
+		Assert.Single(repo.OutboxEvents);
+		using JsonDocument payload = JsonDocument.Parse(repo.OutboxEvents[0].Payload);
+		string fromState = payload.RootElement.GetProperty("from_state").GetString()!;
+		string toState = payload.RootElement.GetProperty("to_state").GetString()!;
+		Assert.Equal("possible_restoration", fromState);
+		Assert.Equal("resolved", toState);
+		Assert.DoesNotContain("possiblerestoration", repo.OutboxEvents[0].Payload);
+	}
+
+	[Fact]
+	public async Task EvaluateCluster_UnconfirmedToActive_WritesCanonicalSnakeCaseOutboxPayload()
+	{
+		SignalCluster cluster = UnconfirmedRoadsCluster(3);
+		var (svc, repo) = Build(cluster, 3, 3, 2);
+
+		await svc.EvaluateClusterAsync(cluster.Id);
+
+		Assert.Single(repo.OutboxEvents);
+		using JsonDocument payload = JsonDocument.Parse(repo.OutboxEvents[0].Payload);
+		string fromState = payload.RootElement.GetProperty("from_state").GetString()!;
+		string toState = payload.RootElement.GetProperty("to_state").GetString()!;
+		Assert.Equal("unconfirmed", fromState);
+		Assert.Equal("active", toState);
 	}
 
 	// B-2: Deactivation threshold must be read from CivisOptions (not hardcoded).


### PR DESCRIPTION
Closes #178

## Problem
`CivisEvaluationService.ApplyDecayAsync` (the decay-driven path that emits `active → possible_restoration` and `possible_restoration → resolved` transitions) serialized the `cluster_state_changed` outbox payload's `from_state` / `to_state` fields via `SignalState.ToString().ToLowerInvariant()`. For `SignalState.PossibleRestoration` that produced `"possiblerestoration"` (no underscore) rather than the canonical snake_case `"possible_restoration"`.

Downstream outbox consumers that match on `to_state == "possible_restoration"` (restoration-prompt notification fan-out, analytics) silently skipped the decay-driven subset of restoration transitions. Two other `cluster_state_changed` emission sites in the same module already used the correct literal form:

- `CivisEvaluationService.EvaluateClusterAsync` — `"unconfirmed"` / `"active"` literals.
- `ParticipationService.EvaluateRestorationAsync` — `"active"` / `"possible_restoration"` literals.

Only the decay path was mis-serialized, so the two decay-driven transitions (out of three cluster-state transition emissions) drifted off the canonical wire format.

## Root cause
Pre-existing code; predates PR #177 (#168 observability). PR #177 detected the quirk when wiring the `cluster_lifecycle_transitions_total` metric tag and explicitly scoped the outbox-payload fix out — the metric uses a canonical snake_case catalog (`ClustersMetrics.State*`) so dashboards stay readable, but the underlying outbox payload was left untouched until #178.

Violates `docs/arch/CODING_STANDARDS.md` §Enum serialization rules: *"Never use `.ToString().ToLowerInvariant()` on multi-word PascalCase enums for wire output — it produces `possiblerestoration` instead of `possible_restoration`."* Restated in `docs/arch/COPILOT_LESSONS.md` §5.

## What changed
**`src/Hali.Application/Clusters/CivisEvaluationService.cs`**
- Promoted the existing `ToStateTag` switch (previously only used by the lifecycle metric) into a single source of truth named `ToCanonicalStateString` — same four-arm switch against the `ClustersMetrics.State*` canonical catalog, but the default arm now throws `ArgumentOutOfRangeException` instead of falling back to `state.ToString().ToLowerInvariant()`. This closes the doctrinal hole: any future caller that passes a non-lifecycle state fails loudly rather than silently regressing the wire contract.
- `ApplyDecayAsync` outbox payload now emits `from_state = ToCanonicalStateString(fromState)` / `to_state = ToCanonicalStateString(toState)` instead of the two `ToString().ToLowerInvariant()` calls.
- The lifecycle metric emission in the same method also uses `ToCanonicalStateString`, so metric tags and outbox payload are guaranteed to carry identical strings for the same transition.
- Inline comment on the outbox block documents the #178 history so the fragile pattern cannot quietly re-enter this surface.

**`src/Hali.Application/Observability/ClustersMetrics.cs`**
- Updated the `State tag values` comment block. It previously noted that the outbox deliberately diverged from the metric tag (the outbox used `"possiblerestoration"`, the metric used `"possible_restoration"`). That divergence is gone — the comment now points to the shared helper and references #178.
- No tag-value constants, no instrument definitions, and no code paths changed.

**`tests/Hali.Tests.Unit/Clusters/CivisEvaluationServiceTests.cs`**
- Three new `[Fact]` tests, one per `cluster_state_changed` emission path, parse the outbox `Payload` JSON and assert the canonical snake_case values:
  - `ApplyDecay_ActiveToPossibleRestoration_WritesCanonicalSnakeCaseOutboxPayload` — `from_state="active"`, `to_state="possible_restoration"`; also asserts the literal `"possiblerestoration"` substring never appears in the payload.
  - `ApplyDecay_PossibleRestorationToResolved_WritesCanonicalSnakeCaseOutboxPayload` — `from_state="possible_restoration"`, `to_state="resolved"`; same regression guard against the broken substring.
  - `EvaluateCluster_UnconfirmedToActive_WritesCanonicalSnakeCaseOutboxPayload` — `from_state="unconfirmed"`, `to_state="active"`; locks the already-correct activation path.

## Old → new serialized values

| Transition | Path | Before | After |
|---|---|---|---|
| `active → possible_restoration` | `ApplyDecayAsync` outbox | `from_state="active"`, `to_state="possiblerestoration"` | `from_state="active"`, `to_state="possible_restoration"` |
| `possible_restoration → resolved` | `ApplyDecayAsync` outbox | `from_state="possiblerestoration"`, `to_state="resolved"` | `from_state="possible_restoration"`, `to_state="resolved"` |
| `unconfirmed → active` | `EvaluateClusterAsync` outbox | `from_state="unconfirmed"`, `to_state="active"` (already correct) | unchanged |
| `active → possible_restoration` | `ParticipationService.EvaluateRestorationAsync` outbox | `from_state="active"`, `to_state="possible_restoration"` (already correct) | unchanged |

The only observable wire-contract change is the two `ApplyDecayAsync` rows above. All other cluster_state_changed payloads on `EvaluatePossibleRestorationJob`, `OfficialPostsService`, `ParticipationService`, and `EvaluateClusterAsync` already used string literals and are byte-for-byte unchanged.

## Where the canonical serialization is now defined
`CivisEvaluationService.ToCanonicalStateString(SignalState)` — single private static helper, four explicit arms against `ClustersMetrics.StateUnconfirmed`, `StateActive`, `StatePossibleRestoration`, `StateResolved`, throws on any other value. Used by both the outbox payload and the lifecycle metric in the same method, so the two surfaces can never drift apart again.

## Tests added/updated

Added three regression tests in `tests/Hali.Tests.Unit/Clusters/CivisEvaluationServiceTests.cs`, covering all three `cluster_state_changed` emission paths in `CivisEvaluationService`. The first two explicitly assert the broken `"possiblerestoration"` substring is absent from the payload, so the `ToString().ToLowerInvariant()` pattern cannot silently re-enter this surface. No existing tests were modified.

### Validation
- `dotnet build` — 0 errors, 125 warnings (all pre-existing on develop, unchanged by this PR).
- `dotnet test tests/Hali.Tests.Unit` — **445 passed, 0 failed, 0 skipped**.
- `dotnet format src/Hali.Api/Hali.Api.csproj --verify-no-changes --no-restore` (the CI-enforced format gate) — clean.

## Out of scope
- No schema, outbox-event shape, or `02_openapi.yaml` changes. The `cluster_state_changed` event structure and all other emissions are untouched.
- No state-machine, transition-semantics, notification, or observability-metric behaviour changes.
- Not broadening into other `.ToString().ToLowerInvariant()` sites elsewhere in the codebase (`ExceptionHandlingMiddleware`, `Program.cs` health-status, `ClusteringService.BuildClusterTitle`, `SignalRepository`, etc.) — those are single-word enums (`CivicCategory`, `HealthStatus`, `ErrorCategory`) where the format is already correct, or out-of-scope surfaces. #178's scope is explicitly the outbox payload divergence in `ApplyDecayAsync`.
- Not touching `ParticipationRequestDto.Type` case-insensitive enum-name parse behaviour (a separate pre-existing controller behaviour called out in #177's out-of-scope list).
- No mobile / OpenAPI / docs changes beyond the inline comment references to #178 in the two touched C# files.

## Risk assessment
**Low — targeted wire-contract correction.**

- The change is isolated to two `SignalState` values in one method (`ApplyDecayAsync`). No control flow, no persistence, no timing, no notification dispatch changed.
- The two decay-driven `cluster_state_changed` rows now match the canonical format used by every other `cluster_state_changed` emission in the module. Any downstream consumer that was already tolerating the broken `"possiblerestoration"` form will continue to see the correct form; any consumer that was failing to match will now start matching (which is the intended fix).
- The `ToCanonicalStateString` helper is `private static` with four explicit arms — future refactors cannot silently drop it, and the throwing default arm surfaces any non-lifecycle caller at test time rather than silently re-introducing the bug in a wire payload.
- The full unit suite (445 tests, 0 failures) and the three new regression tests pin the canonical behaviour in place.
- `dotnet format` on the CI-enforced project (`src/Hali.Api/Hali.Api.csproj`) remains clean.
- No change to the `02_openapi.yaml` state enum (unaffected), no schema migration, no new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)