### PR TITLE
[Issue #176] Harden home observability test coverage

### DIFF
--- a/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
@@ -206,6 +206,26 @@ public class HomeMetricsTests
     }
 
     [Fact]
+    public async Task GetHome_AuthenticatedExplicitLocality_EmitsHistogramOnce_WithExplicitTag()
+    {
+        // Closes the previously untested tag-product combination:
+        // authenticated=true + locality_scope=explicit.  An authenticated
+        // caller who supplies an explicit ?localityId must have both tags set
+        // correctly on the histogram — the explicit scope is resolved before
+        // the follow lookup runs, so it is independent of follow state.
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+        var (feedQuery, follows, redis) = BuildEmptyDeps(followsLocality: false);
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await controller.GetHome(null, null, TestLocalityId, CancellationToken.None);
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeExplicit, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
+    [Fact]
     public async Task GetHome_AnonymousNoLocality_EmitsHistogramOnce_WithGuestEmptyTag()
     {
         using var scope = TestHomeMetrics.Create();
@@ -413,5 +433,43 @@ public class HomeMetricsTests
         Assert.Single(capture.CacheMissMeasurements);
         Assert.Single(capture.CacheHitMeasurements);
         Assert.Equal(2, capture.DurationMeasurements.Count);
+    }
+
+    [Fact]
+    public async Task GetHome_RedisThrows_HistogramStillEmitsOnce_NoCacheCountersFire()
+    {
+        // Pins the Redis-throw path on the cache-eligible route (no cursor,
+        // authenticated caller with at least one followed locality).
+        //
+        // When StringGetAsync faults, the throw propagates through the catch
+        // block (which re-throws any non-OperationCanceledException) and the
+        // finally block still runs — so the latency histogram must record
+        // exactly once. Neither cache counter should fire: the throw occurs
+        // before HomeFeedCacheHitsTotal.Add() and HomeFeedCacheMissesTotal.Add()
+        // are ever reached.
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var feedQuery = Substitute.For<IHomeFeedQueryService>();
+        var follows = Substitute.For<IFollowService>();
+        var redis = Substitute.For<IDatabase>();
+        follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .Returns(new List<Follow> { new() { LocalityId = TestLocalityId } });
+        redis.StringGetAsync(Arg.Any<RedisKey>(), Arg.Any<CommandFlags>())
+            .ThrowsAsync(new InvalidOperationException("Redis connection unavailable"));
+
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => controller.GetHome(null, null, null, CancellationToken.None));
+
+        // Histogram records once from the `finally` block regardless of the Redis fault.
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.True(m.Value >= 0);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeFallback, m.Tags[HomeMetrics.TagLocalityScope]);
+        // Neither cache counter fires: the throw happens before either Add() call.
+        Assert.Empty(capture.CacheHitMeasurements);
+        Assert.Empty(capture.CacheMissMeasurements);
     }
 }


### PR DESCRIPTION
Closes #176

## Problem
The retrospective review of merged PR #173 (home-feed observability metrics, #166) identified two minor test-coverage gaps in `tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs`:

1. **Redis-throw path was not explicitly asserted.** On the cache-eligible path (`cursor is null && localityIds.Count > 0`) at `HomeController.cs:154`, `_redis.StringGetAsync` throwing falls through the generic `catch (Exception ex) when (ex is not OperationCanceledException)` at `HomeController.cs:198` (which logs + rethrows), and the `finally` at `HomeController.cs:205` still records the histogram. No prior test asserted this — a future refactor silently incrementing `miss` (or `hit`) on a Redis fault would not be caught.
2. **Tag-product coverage was 5 of 6.** The existing 13 tests covered every `(authenticated, locality_scope)` pairing except `(authenticated=true, locality_scope=explicit)` — an authenticated caller supplying `?localityId=...`. The code path is deterministic (`localityId.HasValue` short-circuits at `HomeController.cs:90–94`) but the table was asymmetric.

## Root cause
Both gaps are test-coverage gaps, not production-code defects. PR #173 was merged with these as follow-up items tracked in #176.

## What changed
Test-only. Two focused tests added to `tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs`. No production code touched.

- `GetHome_AuthenticatedExplicitLocality_EmitsHistogramOnce_WithExplicitTag` — authenticated caller + explicit `localityId`. Asserts the histogram emits once with tags `authenticated=true` and `locality_scope=explicit` (the exact tag pair previously uncovered).
- `GetHome_RedisThrows_HistogramStillEmitsOnce_NoCacheCountersFire` — authenticated caller on the cache-eligible path with `StringGetAsync` faulting via `InvalidOperationException`. Uses `Assert.ThrowsAsync<InvalidOperationException>` to confirm propagation, then asserts:
  - `home_feed_request_duration_seconds` records exactly once (`Assert.Single(capture.DurationMeasurements)`) with tags `authenticated=true`, `locality_scope=fallback`.
  - `home_feed_cache_hits_total` does not fire (`Assert.Empty(capture.CacheHitMeasurements)`).
  - `home_feed_cache_misses_total` does not fire (`Assert.Empty(capture.CacheMissMeasurements)`).

Both tests use the existing `MetricCapture` listener, `TestHomeMetrics.Create()` per-test meter, and `CreateController` / `BuildEmptyDeps` helpers — no parallel style was introduced.

## Gaps closed
- [x] Redis-throw path metric coverage — histogram-once + neither cache counter pinned.
- [x] Authenticated explicit-locality tag coverage — `(authenticated=true, locality_scope=explicit)` pinned.

After this PR, all 6 `(authenticated, locality_scope)` histogram tag combinations are covered, and the cache-eligible Redis fault path is pinned for metric correctness under dependency outage.

## Tests added/updated
**Added (in `tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs`):**
- `GetHome_AuthenticatedExplicitLocality_EmitsHistogramOnce_WithExplicitTag`
- `GetHome_RedisThrows_HistogramStillEmitsOnce_NoCacheCountersFire`

**Updated:** none. All 13 prior tests continue to pass unchanged.

`dotnet build tests/Hali.Tests.Unit` — 0 errors.
`dotnet test --filter "FullyQualifiedName~HomeMetricsTests"` — **15 passed, 0 failed** (13 prior + 2 new).
`dotnet test --filter "FullyQualifiedName~Observability|FullyQualifiedName~Home"` — **134 passed, 0 failed**.
`dotnet format --verify-no-changes` on `HomeMetricsTests.cs` — clean.

## Out of scope
- No change to `HomeController.cs`, `HomeMetrics.cs`, `Program.cs`, or any other production file.
- No cache eligibility / TTL / serialization behaviour change.
- No locality resolution behaviour change.
- No metric name, tag key, or tag value change.
- No additional tag-key taxonomy.
- No dashboards, alert rules, or runbook changes.
- No OpenAPI changes.
- The `OperationCanceledException` / `RequestAborted` cancellation-policy concern is tracked separately in #174 and is deliberately not addressed here.

## Risk assessment
**Low.** Test-only change. No wire response shape, cache semantics, or metric contract is modified. The new assertions document current intended behaviour; if any of them ever fail, that is a genuine production-metric regression that must be fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)