### PR TITLE
[Issue #174] Skip home latency metric on RequestAborted cancellation

### DIFF
--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -95,11 +95,12 @@ public class HomeController : ControllerBase
 
         // Tracks a client-disconnect unwind so the `finally` block can skip
         // histogram emission, mirroring the ExceptionHandlingMiddleware
-        // carve-out (#164 / PR #171). The catch filter matches the middleware
-        // pattern exactly: an OperationCanceledException *and* a signalled
-        // HttpContext.RequestAborted. A non-aborted OperationCanceledException
-        // (e.g. server-side internal timeout) does not flip this flag, so its
-        // latency is still observed as a normal failure-path measurement.
+        // client-disconnect carve-out. The catch filter matches the
+        // middleware pattern exactly: an OperationCanceledException *and* a
+        // signalled HttpContext.RequestAborted. A non-aborted
+        // OperationCanceledException (e.g. server-side internal timeout)
+        // does not flip this flag, so its latency is still observed as a
+        // normal failure-path measurement.
         bool clientAborted = false;
 
         try
@@ -206,12 +207,12 @@ public class HomeController : ControllerBase
         }
         catch (OperationCanceledException) when (HttpContext?.RequestAborted.IsCancellationRequested == true)
         {
-            // Client disconnected — mirror ExceptionHandlingMiddleware (PR #171):
-            // a caller-aborted request is not a handled API exception, and its
-            // latency must not contribute to the home-feed distribution. Flag
-            // the unwind so the `finally` block skips histogram emission; the
-            // exception still propagates so the middleware can drop the 500
-            // envelope.
+            // Client disconnected — mirror the ExceptionHandlingMiddleware
+            // client-disconnect carve-out: a caller-aborted request is not a
+            // handled API exception, and its latency must not contribute to
+            // the home-feed distribution. Flag the unwind so the `finally`
+            // block skips histogram emission; the exception still propagates
+            // so the middleware can drop the 500 envelope.
             clientAborted = true;
             throw;
         }

--- a/src/Hali.Api/Controllers/HomeController.cs
+++ b/src/Hali.Api/Controllers/HomeController.cs
@@ -93,6 +93,15 @@ public class HomeController : ControllerBase
                 ? HomeMetrics.LocalityScopeFallback
                 : HomeMetrics.LocalityScopeGuestEmpty;
 
+        // Tracks a client-disconnect unwind so the `finally` block can skip
+        // histogram emission, mirroring the ExceptionHandlingMiddleware
+        // carve-out (#164 / PR #171). The catch filter matches the middleware
+        // pattern exactly: an OperationCanceledException *and* a signalled
+        // HttpContext.RequestAborted. A non-aborted OperationCanceledException
+        // (e.g. server-side internal timeout) does not flip this flag, so its
+        // latency is still observed as a normal failure-path measurement.
+        bool clientAborted = false;
+
         try
         {
             // Both authenticated and anonymous callers may scope the feed to
@@ -195,6 +204,17 @@ public class HomeController : ControllerBase
                 ObservabilityEvents.HomeRequestCompleted, sw.ElapsedMilliseconds);
             return Ok(fullResponse);
         }
+        catch (OperationCanceledException) when (HttpContext?.RequestAborted.IsCancellationRequested == true)
+        {
+            // Client disconnected — mirror ExceptionHandlingMiddleware (PR #171):
+            // a caller-aborted request is not a handled API exception, and its
+            // latency must not contribute to the home-feed distribution. Flag
+            // the unwind so the `finally` block skips histogram emission; the
+            // exception still propagates so the middleware can drop the 500
+            // envelope.
+            clientAborted = true;
+            throw;
+        }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
             _logger?.LogError(ex,
@@ -209,13 +229,24 @@ public class HomeController : ControllerBase
             // section-paged, validation/throw). Tag values are set above before
             // the request can branch; the defaults used if an exception fires
             // before the decision is made are still bounded by the catalog.
+            //
+            // The single carve-out: if the request is unwinding through a
+            // client-disconnect cancellation (caller-aborted OperationCanceledException
+            // with HttpContext.RequestAborted signalled), skip emission to stay
+            // consistent with ExceptionHandlingMiddleware's exception-metric
+            // cancellation policy. Ordinary success and error paths — including
+            // non-aborted OperationCanceledException (e.g. server-side timeout) —
+            // still emit.
             sw.Stop();
-            var tags = new TagList
+            if (!clientAborted)
             {
-                { HomeMetrics.TagAuthenticated, isAuthenticated ? "true" : "false" },
-                { HomeMetrics.TagLocalityScope, localityScope }
-            };
-            _metrics.HomeFeedRequestDuration.Record(sw.Elapsed.TotalSeconds, tags);
+                var tags = new TagList
+                {
+                    { HomeMetrics.TagAuthenticated, isAuthenticated ? "true" : "false" },
+                    { HomeMetrics.TagLocalityScope, localityScope }
+                };
+                _metrics.HomeFeedRequestDuration.Record(sw.Elapsed.TotalSeconds, tags);
+            }
         }
     }
 

--- a/src/Hali.Api/Observability/HomeMetrics.cs
+++ b/src/Hali.Api/Observability/HomeMetrics.cs
@@ -100,11 +100,11 @@ public sealed class HomeMetrics : IDisposable
     /// unwinds — specifically, an <see cref="OperationCanceledException"/>
     /// propagating while <c>HttpContext.RequestAborted.IsCancellationRequested</c>
     /// is <c>true</c>. This mirrors the <c>api_exceptions_total</c>
-    /// carve-out in <c>ExceptionHandlingMiddleware</c> (PR #171) so downstream
-    /// alerts and dashboards can correlate the two instruments under one
-    /// cancellation policy. Non-aborted <see cref="OperationCanceledException"/>
-    /// paths (e.g. server-side internal timeouts) still emit as ordinary
-    /// failure-path latency observations.
+    /// cancellation carve-out in <c>ExceptionHandlingMiddleware</c> so
+    /// downstream alerts and dashboards can correlate the two instruments
+    /// under one cancellation policy. Non-aborted
+    /// <see cref="OperationCanceledException"/> paths (e.g. server-side
+    /// internal timeouts) still emit as ordinary failure-path latency observations.
     /// </summary>
     public Histogram<double> HomeFeedRequestDuration { get; }
 

--- a/src/Hali.Api/Observability/HomeMetrics.cs
+++ b/src/Hali.Api/Observability/HomeMetrics.cs
@@ -95,6 +95,16 @@ public sealed class HomeMetrics : IDisposable
     /// </list>
     /// No request-derived value (path, method, locality id, account id,
     /// correlation id, cursor, section name) is ever attached.
+    ///
+    /// Cancellation policy: emission is skipped on client-disconnect
+    /// unwinds — specifically, an <see cref="OperationCanceledException"/>
+    /// propagating while <c>HttpContext.RequestAborted.IsCancellationRequested</c>
+    /// is <c>true</c>. This mirrors the <c>api_exceptions_total</c>
+    /// carve-out in <c>ExceptionHandlingMiddleware</c> (PR #171) so downstream
+    /// alerts and dashboards can correlate the two instruments under one
+    /// cancellation policy. Non-aborted <see cref="OperationCanceledException"/>
+    /// paths (e.g. server-side internal timeouts) still emit as ordinary
+    /// failure-path latency observations.
     /// </summary>
     public Histogram<double> HomeFeedRequestDuration { get; }
 

--- a/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
@@ -435,6 +435,83 @@ public class HomeMetricsTests
         Assert.Equal(2, capture.DurationMeasurements.Count);
     }
 
+    // ── Cancellation-policy tests ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetHome_ClientAborted_OperationCanceled_DoesNotEmitHistogram()
+    {
+        // Client-disconnect carve-out (#174): when the caller aborts the
+        // request mid-flight, HttpContext.RequestAborted signals and the
+        // in-flight awaited work unwinds as OperationCanceledException.
+        // The controller's finally block must skip the histogram emission
+        // so the home-feed latency distribution stays consistent with
+        // ExceptionHandlingMiddleware's api_exceptions_total carve-out
+        // (PR #171) — downstream alerts assume the two instruments share
+        // one cancellation policy.
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var feedQuery = Substitute.For<IHomeFeedQueryService>();
+        var follows = Substitute.For<IFollowService>();
+        var redis = Substitute.For<IDatabase>();
+        follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("client disconnect"));
+
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+
+        // Mirror a real client-disconnect unwind: RequestAborted is
+        // signalled at the moment the OCE surfaces. The catch filter
+        // reads HttpContext.RequestAborted, not the exception's token,
+        // so assigning a cancelled token here is what the carve-out
+        // actually guards against.
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        controller.ControllerContext.HttpContext.RequestAborted = cts.Token;
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => controller.GetHome(null, null, null, CancellationToken.None));
+
+        // Histogram must not record the cancelled request.
+        Assert.Empty(capture.DurationMeasurements);
+        // Cache counters are untouched because the throw precedes the
+        // Redis lookup on the follow-resolution path.
+        Assert.Empty(capture.CacheHitMeasurements);
+        Assert.Empty(capture.CacheMissMeasurements);
+    }
+
+    [Fact]
+    public async Task GetHome_NonAbortedOperationCanceled_StillEmitsHistogram()
+    {
+        // Server-side cancellation (e.g. an internal timeout CT unrelated
+        // to the client connection) surfaces as OperationCanceledException
+        // while HttpContext.RequestAborted is NOT signalled. The carve-out
+        // is scoped specifically to caller-aborted requests — a server-
+        // internal OCE is still a failure-path latency observation and
+        // must emit, tagged identically to any other exception path.
+        using var scope = TestHomeMetrics.Create();
+        using var capture = new MetricCapture(scope.Metrics);
+
+        var feedQuery = Substitute.For<IHomeFeedQueryService>();
+        var follows = Substitute.For<IFollowService>();
+        var redis = Substitute.For<IDatabase>();
+        follows.GetFollowedAsync(Arg.Any<Guid>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException("server-side internal timeout"));
+
+        var controller = CreateController(scope.Metrics, feedQuery, follows, redis, authenticated: true);
+        // HttpContext.RequestAborted stays at its DefaultHttpContext
+        // default (not cancelled), so the inner catch filter evaluates
+        // false and the exception falls through to the finally block
+        // where clientAborted is still false — histogram emits.
+
+        await Assert.ThrowsAsync<OperationCanceledException>(
+            () => controller.GetHome(null, null, null, CancellationToken.None));
+
+        var m = Assert.Single(capture.DurationMeasurements);
+        Assert.True(m.Value >= 0);
+        Assert.Equal("true", m.Tags[HomeMetrics.TagAuthenticated]);
+        Assert.Equal(HomeMetrics.LocalityScopeFallback, m.Tags[HomeMetrics.TagLocalityScope]);
+    }
+
     [Fact]
     public async Task GetHome_RedisThrows_HistogramStillEmitsOnce_NoCacheCountersFire()
     {

--- a/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
+++ b/tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs
@@ -440,13 +440,13 @@ public class HomeMetricsTests
     [Fact]
     public async Task GetHome_ClientAborted_OperationCanceled_DoesNotEmitHistogram()
     {
-        // Client-disconnect carve-out (#174): when the caller aborts the
-        // request mid-flight, HttpContext.RequestAborted signals and the
-        // in-flight awaited work unwinds as OperationCanceledException.
-        // The controller's finally block must skip the histogram emission
-        // so the home-feed latency distribution stays consistent with
-        // ExceptionHandlingMiddleware's api_exceptions_total carve-out
-        // (PR #171) — downstream alerts assume the two instruments share
+        // Client-disconnect carve-out: when the caller aborts the request
+        // mid-flight, HttpContext.RequestAborted signals and the in-flight
+        // awaited work unwinds as OperationCanceledException. The
+        // controller's finally block must skip the histogram emission so
+        // the home-feed latency distribution stays consistent with
+        // ExceptionHandlingMiddleware's api_exceptions_total cancellation
+        // carve-out — downstream alerts assume the two instruments share
         // one cancellation policy.
         using var scope = TestHomeMetrics.Create();
         using var capture = new MetricCapture(scope.Metrics);


### PR DESCRIPTION
Closes #174

## Problem
Home latency histogram emits on client-aborted requests, unlike middleware metrics.

## Root cause
Metric emission in finally block lacks RequestAborted carve-out.

## What changed
- skip histogram when RequestAborted is true
- preserve all other paths
- added tests to lock behavior

## Cancellation policy
- skipped: true client disconnects
- emitted: all other paths

Mirrors `ExceptionHandlingMiddleware` (PR #171) filter exactly: `catch (OperationCanceledException) when (context.RequestAborted.IsCancellationRequested)`.

| Path | `clientAborted` | Histogram |
|---|---|---|
| Success | false | emits |
| Non-OCE exception | false | emits |
| OCE + RequestAborted signalled (client disconnect) | true | skipped |
| OCE + RequestAborted NOT signalled (server-side timeout) | false | emits |

## Tests
Added in `tests/Hali.Tests.Unit/Observability/HomeMetricsTests.cs`:

- `GetHome_ClientAborted_OperationCanceled_DoesNotEmitHistogram` — proves the caller-aborted path produces zero histogram emissions (and zero cache-counter emissions, since the throw precedes the Redis lookup).
- `GetHome_NonAbortedOperationCanceled_StillEmitsHistogram` — proves server-side OCE (with RequestAborted NOT signalled) still records exactly one histogram measurement, tagged `authenticated=true`, `locality_scope=fallback`.

Pre-existing tests already lock in success-path and non-cancellation exception-path emission across the full tag product, so a redundant "non-cancelled still emits" test would duplicate coverage and was omitted per scope discipline.

## Risk
Minimal — observability-only behavior change. No production response, status code, or exception-propagation semantics changed. Only the one histogram instrument, only on the new cancellation branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)