### PR TITLE
fix(ci): skip spec verifier gracefully when ANTHROPIC_API_KEY is absent

### DIFF
--- a/.github/workflows/spec_verifier.yml
+++ b/.github/workflows/spec_verifier.yml
@@ -50,7 +50,13 @@ jobs:
           CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
           CI_RUN_URL: ${{ github.event.workflow_run.html_url }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: python3 scripts/spec_verifier.py
+        run: |
+          if [ -z "$ANTHROPIC_API_KEY" ]; then
+            echo "ANTHROPIC_API_KEY secret not configured — skipping spec verification."
+            echo "Add ANTHROPIC_API_KEY to repository secrets to enable post-CI analysis."
+            exit 0
+          fi
+          python3 scripts/spec_verifier.py
 
       - name: Commit updated lessons if changed
         run: |

--- a/scripts/spec_verifier.py
+++ b/scripts/spec_verifier.py
@@ -14,7 +14,7 @@ from anthropic import Anthropic
 from tenacity import retry, stop_after_attempt, wait_exponential, retry_if_exception_type
 from anthropic import APIStatusError, APIConnectionError
 
-ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY")
+ANTHROPIC_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "").strip()
 CI_CONCLUSION     = os.environ.get("CI_CONCLUSION", "unknown")
 CI_RUN_URL        = os.environ.get("CI_RUN_URL", "")
 MODEL             = "claude-sonnet-4-6"
@@ -82,6 +82,11 @@ def append_lessons(lessons_text: str, source: str):
 
 def run():
     print(f"Post-CI Spec Verifier — CI conclusion: {CI_CONCLUSION}")
+
+    if not ANTHROPIC_API_KEY:
+        print("ANTHROPIC_API_KEY is not set — skipping spec verification (no-op).")
+        print("To enable post-CI analysis, add ANTHROPIC_API_KEY to repository secrets.")
+        sys.exit(0)
 
     test_summary  = read_trx_summary("ci-artifacts/**/*.trx")
     cov_summary   = read_coverage_summary()


### PR DESCRIPTION
## Summary

- The `Post-CI Spec Verification` job was hard-failing when `ANTHROPIC_API_KEY` is not set as a repository secret, causing it to crash with a `TypeError` from the Anthropic SDK
- This failure was appearing on the head commit of PR #216 (develop → main) and contributing to the BLOCKED merge state
- Fix adds an early-exit guard in both the workflow YAML shell step and the Python script — when the key is absent the job exits cleanly with a no-op message

## Root cause

`spec_verifier.py` calls `Anthropic(api_key=ANTHROPIC_API_KEY)` where `ANTHROPIC_API_KEY` is empty string/None. The Anthropic SDK raises `TypeError: "Could not resolve authentication method..."` before any retry logic runs, causing the job to exit with code 1.

## Changes

- `.github/workflows/spec_verifier.yml`: shell-level guard checks `$ANTHROPIC_API_KEY` before invoking the Python script
- `scripts/spec_verifier.py`: application-level guard at start of `run()` exits with code 0 when key is absent

## Test plan

- [ ] CI passes on this PR branch
- [ ] Post-CI Spec Verification check exits cleanly (no failure) on next Hali CI run
- [ ] PR #216 unblocked once this merges to develop and the spec verifier re-runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)