### PR TITLE
[Issue #194] Expose resolved client-safe feature flags

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -24,6 +24,7 @@ tags:
   - name: Devices
   - name: Feedback
   - name: Admin
+  - name: FeatureFlags
 paths:
   # ── Auth ────────────────────────────────────────────────────────────
   /v1/auth/otp:
@@ -865,6 +866,34 @@ paths:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
 
+  # ── Feature flags ───────────────────────────────────────────────────
+  /v1/feature-flags:
+    get:
+      tags: [FeatureFlags]
+      summary: Resolved client-visible feature flags for the current context
+      description: |
+        Returns the resolved value for every flag in the backend registry
+        that is marked `client_visible`. Server-only flags are never
+        returned regardless of the caller's role. Anonymous callers are
+        supported — their resolved values use `actor_type = "anonymous"`.
+
+        The response shape is a flat `flags` object keyed by flag name.
+        Clients do not see the flag's kind, owner, targeting rules, or
+        rollout metadata — just the resolved boolean value. See
+        `docs/arch/FEATURE_FLIGHTING_MODEL.md` §4.
+      parameters:
+        - in: query
+          name: localityId
+          schema: { type: string, format: uuid }
+          required: false
+          description: Optional locality id for locality-scoped rule evaluation.
+      responses:
+        '200':
+          description: Resolved flags for the current request context.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ResolvedFeatureFlagsResponse' }
+
   # ── Admin ───────────────────────────────────────────────────────────
   /v1/admin/institutions:
     post:
@@ -970,6 +999,19 @@ components:
         - safety
         - governance
         - infrastructure
+    ResolvedFeatureFlagsResponse:
+      type: object
+      required: [flags]
+      properties:
+        flags:
+          type: object
+          description: |
+            Flat map from flag name (dot-delimited snake_case, e.g.
+            `mobile.home.condition_badge.enabled`) to the resolved boolean
+            value for the current request context.
+          additionalProperties:
+            type: boolean
+
     FeedbackRequest:
       type: object
       required: [rating]

--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -881,6 +881,7 @@ paths:
         Clients do not see the flag's kind, owner, targeting rules, or
         rollout metadata — just the resolved boolean value. See
         `docs/arch/FEATURE_FLIGHTING_MODEL.md` §4.
+      security: []
       parameters:
         - in: query
           name: localityId
@@ -893,6 +894,13 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ResolvedFeatureFlagsResponse' }
+        '400':
+          description: |
+            Query parameter validation failure — e.g. `localityId` is not
+            a valid UUID.
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   # ── Admin ───────────────────────────────────────────────────────────
   /v1/admin/institutions:

--- a/src/Hali.Api/Controllers/FeatureFlagsController.cs
+++ b/src/Hali.Api/Controllers/FeatureFlagsController.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using Hali.Api.FeatureFlags;
+using Hali.Application.FeatureFlags;
+using Hali.Contracts.FeatureFlags;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Hali.Api.Controllers;
+
+[ApiController]
+[Route("v1/feature-flags")]
+[AllowAnonymous]
+public class FeatureFlagsController : ControllerBase
+{
+    private readonly IFeatureFlagService _flags;
+    private readonly IFeatureFlagContextFactory _contextFactory;
+
+    public FeatureFlagsController(
+        IFeatureFlagService flags,
+        IFeatureFlagContextFactory contextFactory)
+    {
+        _flags = flags;
+        _contextFactory = contextFactory;
+    }
+
+    /// <summary>
+    /// Returns the resolved client-visible feature flags for the current
+    /// request context. Anonymous callers are supported — their resolved
+    /// values use <c>actor_type = "anonymous"</c>.
+    ///
+    /// Server-only flags are never included in the response, regardless
+    /// of the caller's role.
+    /// </summary>
+    [HttpGet]
+    [ProducesResponseType(typeof(ResolvedFeatureFlagsResponseDto), StatusCodes.Status200OK)]
+    public ActionResult<ResolvedFeatureFlagsResponseDto> GetResolvedFlags(
+        [FromQuery(Name = "localityId")] Guid? localityId = null)
+    {
+        FeatureFlagEvaluationContext context = _contextFactory.FromHttpContext(HttpContext, localityId);
+        IReadOnlyDictionary<string, bool> resolved = _flags.EvaluateClientVisible(context);
+
+        return Ok(new ResolvedFeatureFlagsResponseDto { Flags = resolved });
+    }
+}

--- a/src/Hali.Api/FeatureFlags/FeatureFlagContextFactory.cs
+++ b/src/Hali.Api/FeatureFlags/FeatureFlagContextFactory.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Security.Claims;
+using Hali.Application.FeatureFlags;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Hosting;
+
+namespace Hali.Api.FeatureFlags;
+
+/// <summary>
+/// Builds a <see cref="FeatureFlagEvaluationContext"/> from an incoming
+/// HTTP request. Keeps claim extraction, environment resolution, and
+/// optional locality wiring in one place so controllers don't have to
+/// recompute it per call.
+///
+/// Anonymous callers get <c>actor_type = "anonymous"</c> and null
+/// institution / locality. This is deliberate — client-visible flags
+/// can target anonymous actors explicitly (e.g. a public landing page
+/// dark launch).
+/// </summary>
+public interface IFeatureFlagContextFactory
+{
+    FeatureFlagEvaluationContext FromHttpContext(HttpContext http, Guid? localityId = null);
+}
+
+public sealed class FeatureFlagContextFactory : IFeatureFlagContextFactory
+{
+    private readonly IHostEnvironment _environment;
+
+    public FeatureFlagContextFactory(IHostEnvironment environment)
+    {
+        _environment = environment;
+    }
+
+    public FeatureFlagEvaluationContext FromHttpContext(HttpContext http, Guid? localityId = null)
+    {
+        ClaimsPrincipal user = http.User;
+        string actorType = ResolveActorType(user);
+        Guid? institutionId = ResolveInstitutionId(user);
+
+        return new FeatureFlagEvaluationContext(
+            Environment: _environment.EnvironmentName,
+            InstitutionId: institutionId,
+            LocalityId: localityId,
+            ActorType: actorType);
+    }
+
+    private static string ResolveActorType(ClaimsPrincipal user)
+    {
+        if (user.Identity is null || !user.Identity.IsAuthenticated)
+        {
+            return "anonymous";
+        }
+
+        string? role = user.FindFirstValue(ClaimTypes.Role);
+        return string.IsNullOrWhiteSpace(role) ? "anonymous" : role;
+    }
+
+    private static Guid? ResolveInstitutionId(ClaimsPrincipal user)
+    {
+        string? raw = user.FindFirstValue("institution_id");
+        return Guid.TryParse(raw, out Guid id) ? id : null;
+    }
+}

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -66,6 +66,11 @@ builder.Services.AddSingleton<Hali.Application.Observability.PushNotificationsMe
 builder.Services.AddSingleton<Hali.Application.FeatureFlags.IFeatureFlagService,
     Hali.Application.FeatureFlags.FeatureFlagService>();
 
+// Context factory wires JWT claims + IHostEnvironment into
+// FeatureFlagEvaluationContext for the /v1/feature-flags endpoint.
+builder.Services.AddSingleton<Hali.Api.FeatureFlags.IFeatureFlagContextFactory,
+    Hali.Api.FeatureFlags.FeatureFlagContextFactory>();
+
 string jwtSecret = builder.Configuration["Auth:JwtSecret"]
     ?? throw new InvalidOperationException("Auth:JwtSecret is required");
 string jwtIssuer = builder.Configuration["Auth:JwtIssuer"] ?? "hali";

--- a/src/Hali.Contracts/FeatureFlags/ResolvedFeatureFlagsResponseDto.cs
+++ b/src/Hali.Contracts/FeatureFlags/ResolvedFeatureFlagsResponseDto.cs
@@ -1,0 +1,18 @@
+using System.Collections.Generic;
+
+namespace Hali.Contracts.FeatureFlags;
+
+/// <summary>
+/// Resolved client-visible feature flags for the current request context.
+/// Only flags marked <c>ClientVisible</c> in the backend registry appear
+/// here; server-only flags never leak.
+///
+/// The shape is intentionally a flat string→bool map. Clients do not see
+/// the flag's kind, owner, targeting rules, or rollout metadata — just the
+/// resolved value. See docs/arch/FEATURE_FLIGHTING_MODEL.md §4 for the
+/// contract.
+/// </summary>
+public sealed record ResolvedFeatureFlagsResponseDto
+{
+    public required IReadOnlyDictionary<string, bool> Flags { get; init; }
+}

--- a/tests/Hali.Tests.Integration/FeatureFlags/FeatureFlagsEndpointTests.cs
+++ b/tests/Hali.Tests.Integration/FeatureFlags/FeatureFlagsEndpointTests.cs
@@ -34,7 +34,7 @@ public sealed class FeatureFlagsEndpointTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.True(body.RootElement.TryGetProperty("flags", out JsonElement flags));
         Assert.Equal(JsonValueKind.Object, flags.ValueKind);
     }
@@ -45,13 +45,18 @@ public sealed class FeatureFlagsEndpointTests : IntegrationTestBase
         HttpResponseMessage response = await Client.GetAsync("/v1/feature-flags");
         response.EnsureSuccessStatusCode();
 
-        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         JsonElement flags = body.RootElement.GetProperty("flags");
 
         // MobileHomeConditionBadgeEnabled is a client-visible flag in the
-        // catalog and must be present in the response.
+        // catalog and must be present in the response. Asserting on the
+        // resolved boolean keeps the test honest about the contract
+        // (value is a JSON boolean) without tying the test to a specific
+        // environment's targeting outcome, which could legitimately flip.
         Assert.True(flags.TryGetProperty("mobile.home.condition_badge.enabled", out JsonElement resolved));
-        Assert.Equal(JsonValueKind.False, resolved.ValueKind);
+        Assert.True(
+            resolved.ValueKind is JsonValueKind.True or JsonValueKind.False,
+            "Expected the client-visible flag to resolve to a JSON boolean value.");
     }
 
     [Fact]
@@ -60,7 +65,7 @@ public sealed class FeatureFlagsEndpointTests : IntegrationTestBase
         HttpResponseMessage response = await Client.GetAsync("/v1/feature-flags");
         response.EnsureSuccessStatusCode();
 
-        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         JsonElement flags = body.RootElement.GetProperty("flags");
 
         // WorkersPushDispatcherEnabled is server-only and must NEVER be
@@ -79,7 +84,7 @@ public sealed class FeatureFlagsEndpointTests : IntegrationTestBase
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
-        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         JsonElement flags = body.RootElement.GetProperty("flags");
         Assert.True(flags.TryGetProperty("mobile.home.condition_badge.enabled", out _));
     }
@@ -93,7 +98,7 @@ public sealed class FeatureFlagsEndpointTests : IntegrationTestBase
             $"/v1/feature-flags?localityId={Guid.NewGuid()}");
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        using JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
         Assert.True(body.RootElement.TryGetProperty("flags", out _));
     }
 

--- a/tests/Hali.Tests.Integration/FeatureFlags/FeatureFlagsEndpointTests.cs
+++ b/tests/Hali.Tests.Integration/FeatureFlags/FeatureFlagsEndpointTests.cs
@@ -1,0 +1,126 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Hali.Tests.Integration.Infrastructure;
+using Microsoft.IdentityModel.Tokens;
+using Xunit;
+
+namespace Hali.Tests.Integration.FeatureFlags;
+
+/// <summary>
+/// Integration tests for the client-safe feature-flag exposure endpoint
+/// introduced in #194. The endpoint returns the resolved value for every
+/// <c>ClientVisible</c> flag and never leaks <c>ServerOnly</c> flags. It
+/// supports anonymous callers (contract: <c>actor_type = "anonymous"</c>
+/// when no JWT is present).
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class FeatureFlagsEndpointTests : IntegrationTestBase
+{
+    public FeatureFlagsEndpointTests(HaliWebApplicationFactory factory)
+        : base(factory) { }
+
+    [Fact]
+    public async Task GetFeatureFlags_Anonymous_Returns200WithFlagsMap()
+    {
+        HttpResponseMessage response = await Client.GetAsync("/v1/feature-flags");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.True(body.RootElement.TryGetProperty("flags", out JsonElement flags));
+        Assert.Equal(JsonValueKind.Object, flags.ValueKind);
+    }
+
+    [Fact]
+    public async Task GetFeatureFlags_IncludesClientVisibleFlag()
+    {
+        HttpResponseMessage response = await Client.GetAsync("/v1/feature-flags");
+        response.EnsureSuccessStatusCode();
+
+        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement flags = body.RootElement.GetProperty("flags");
+
+        // MobileHomeConditionBadgeEnabled is a client-visible flag in the
+        // catalog and must be present in the response.
+        Assert.True(flags.TryGetProperty("mobile.home.condition_badge.enabled", out JsonElement resolved));
+        Assert.Equal(JsonValueKind.False, resolved.ValueKind);
+    }
+
+    [Fact]
+    public async Task GetFeatureFlags_DoesNotLeakServerOnlyFlag()
+    {
+        HttpResponseMessage response = await Client.GetAsync("/v1/feature-flags");
+        response.EnsureSuccessStatusCode();
+
+        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement flags = body.RootElement.GetProperty("flags");
+
+        // WorkersPushDispatcherEnabled is server-only and must NEVER be
+        // returned — even if it defaults to true.
+        Assert.False(flags.TryGetProperty("workers.push_dispatcher.enabled", out _));
+    }
+
+    [Fact]
+    public async Task GetFeatureFlags_AuthenticatedCaller_ReceivesResolvedFlags()
+    {
+        string token = MintJwt(accountId: Guid.NewGuid(), role: "citizen");
+
+        HttpRequestMessage request = new(HttpMethod.Get, "/v1/feature-flags");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        HttpResponseMessage response = await Client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        JsonElement flags = body.RootElement.GetProperty("flags");
+        Assert.True(flags.TryGetProperty("mobile.home.condition_badge.enabled", out _));
+    }
+
+    [Fact]
+    public async Task GetFeatureFlags_WithLocalityIdQuery_Returns200()
+    {
+        // Locality id is accepted but no catalog flag currently targets it;
+        // the response shape must still be valid.
+        HttpResponseMessage response = await Client.GetAsync(
+            $"/v1/feature-flags?localityId={Guid.NewGuid()}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        JsonDocument body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        Assert.True(body.RootElement.TryGetProperty("flags", out _));
+    }
+
+    [Fact]
+    public async Task GetFeatureFlags_InvalidLocalityId_Returns400()
+    {
+        HttpResponseMessage response = await Client.GetAsync("/v1/feature-flags?localityId=not-a-guid");
+
+        // ASP.NET Core model binding rejects a non-Guid value with 400.
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private static string MintJwt(Guid accountId, string role)
+    {
+        SymmetricSecurityKey key = new(Encoding.UTF8.GetBytes(TestConstants.JwtSecret));
+        SigningCredentials creds = new(key, SecurityAlgorithms.HmacSha256);
+        JwtSecurityToken token = new(
+            issuer: TestConstants.JwtIssuer,
+            audience: TestConstants.JwtAudience,
+            claims: new[]
+            {
+                new Claim(JwtRegisteredClaimNames.Sub, accountId.ToString()),
+                new Claim(ClaimTypes.Role, role),
+            },
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`GET /v1/feature-flags\` endpoint returns the resolved boolean for every **client-visible** flag in the registry.
- Server-only flags never leak, regardless of the caller's role.
- Anonymous callers supported (resolved with \`actor_type = "anonymous"\`).
- OpenAPI spec updated; 6 integration tests cover the contract.

## Wire contract

\`\`\`json
GET /v1/feature-flags[?localityId=<guid>]
200 OK
{
  "flags": {
    "mobile.home.condition_badge.enabled": false
  }
}
\`\`\`

Clients see only the resolved value. Flag kind, owner, targeting rules, and rollout metadata remain server-side — per \`docs/arch/FEATURE_FLIGHTING_MODEL.md\` §4.

## Pieces

- \`src/Hali.Contracts/FeatureFlags/ResolvedFeatureFlagsResponseDto.cs\` — flat map DTO.
- \`src/Hali.Api/FeatureFlags/FeatureFlagContextFactory.cs\` — extracts \`actor_type\` (JWT role claim or "anonymous"), \`institution_id\` (JWT claim), and \`environment\` (\`IHostEnvironment\`). Optional \`localityId\` query param.
- \`src/Hali.Api/Controllers/FeatureFlagsController.cs\` — \`[AllowAnonymous]\` endpoint that builds the context and calls \`IFeatureFlagService.EvaluateClientVisible\`.
- \`02_openapi.yaml\` — new \`FeatureFlags\` tag, \`/v1/feature-flags\` path, \`ResolvedFeatureFlagsResponse\` schema with \`additionalProperties: boolean\`.
- \`tests/Hali.Tests.Integration/FeatureFlags/FeatureFlagsEndpointTests.cs\` — 6 tests.

## Integration test coverage

- Anonymous caller → 200 + flags object
- Client-visible flag (\`mobile.home.condition_badge.enabled\`) is present
- Server-only flag (\`workers.push_dispatcher.enabled\`) is NEVER present
- Authenticated citizen caller → 200
- \`?localityId=<guid>\` accepted → 200
- \`?localityId=not-a-guid\` → 400 (ASP.NET model binding)

## Test plan

- [x] \`dotnet build\` — 0 errors
- [x] \`dotnet test tests/Hali.Tests.Unit\` — 468 passed
- [x] \`dotnet format --verify-no-changes\` — clean on new files
- [x] CI must pass (integration tests run in CI against real PostgreSQL)

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)