### PR TITLE
[Issue #188 follow-up] Add /packages/ negation to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,9 @@ dist/
 web-build/
 *.jsbundle
 
+# ── Turborepo ─────────────────────────────────────────────────────────────────
+.turbo/
+
 # ── React Native ─────────────────────────────────────────────────────────────
 android/.gradle
 android/app/build/

--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,13 @@ coverage-report/
 # ── NuGet ─────────────────────────────────────────────────────────────────────
 *.nupkg
 *.snupkg
+# Ignore NuGet restore output (typically under .NET project bin/obj or legacy
+# solution-level packages/), but never ignore the repo-root /packages/ monorepo
+# workspace directory.
 **/[Pp]ackages/*
 !**/[Pp]ackages/build/
+!/packages/
+!/packages/**
 *.nuspec
 project.lock.json
 project.fragment.lock.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hali-monorepo",
   "version": "0.0.0",
   "private": true,
-  "description": "Hali monorepo root — workspaces for apps (citizen-mobile, institution-web, …) and shared packages (contracts, design-system, config).",
+  "description": "Hali monorepo root — workspaces for Phase 2+ web apps (institution-web, institution-admin-web, hali-ops-web) and shared packages (contracts, design-system, config). apps/citizen-mobile is intentionally outside the workspace while it continues to ship an independent npm toolchain; see pnpm-workspace.yaml for the migration note.",
   "packageManager": "pnpm@9.12.0",
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "hali-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Hali monorepo root — workspaces for apps (citizen-mobile, institution-web, …) and shared packages (contracts, design-system, config).",
+  "packageManager": "pnpm@9.12.0",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "typecheck": "turbo run typecheck",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "test": "turbo run test"
+  },
+  "devDependencies": {
+    "turbo": "^2.1.0",
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -1,0 +1,21 @@
+# @hali/config
+
+Non-secret app constants shared across Hali surfaces — civic category
+enums, signal-state enums, and wire-level limits (composer character
+cap, max wards followed, etc.).
+
+## Usage
+
+```ts
+import { CIVIC_CATEGORIES, SIGNAL_TEXT_MAX_LENGTH } from "@hali/config";
+```
+
+## Scope
+
+- ✅ Enum values that are defined authoritatively on the backend and
+  must stay in sync on the client.
+- ✅ Wire-level numeric limits that are validated on both sides.
+- ❌ Secrets, API keys, environment-dependent URLs — see
+  `docs/arch/SECURITY_POSTURE.md` §5.
+- ❌ Product strings / copy — those live per surface (mobile / web
+  have different copy constraints).

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hali/config",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Non-secret app constants shared across Hali surfaces (category enums, taxonomy constants, wire-level limits).",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -1,0 +1,40 @@
+// @hali/config — non-secret app constants shared across surfaces.
+//
+// Secrets, API keys, and environment-dependent values do not live
+// here — see docs/arch/SECURITY_POSTURE.md §5.
+
+// The eight canonical civic categories in Hali. Mirrors
+// src/Hali.Domain/Enums/CivicCategory.cs and the OpenAPI enum.
+export const CIVIC_CATEGORIES = [
+  "roads",
+  "transport",
+  "electricity",
+  "water",
+  "environment",
+  "safety",
+  "governance",
+  "infrastructure",
+] as const;
+
+export type CivicCategory = (typeof CIVIC_CATEGORIES)[number];
+
+// Signal lifecycle states emitted on the wire. Mirrors the backend
+// SignalState enum's snake_case serialisation.
+export const SIGNAL_STATES = [
+  "unconfirmed",
+  "active",
+  "possible_restoration",
+  "resolved",
+] as const;
+
+export type SignalState = (typeof SIGNAL_STATES)[number];
+
+// Composer character limit for the citizen signal-submit free-text
+// field. Mirrors the backend max-length constraint in the signal
+// submit DTO. Shared here so both the mobile composer and any future
+// web submission UI use the same value.
+export const SIGNAL_TEXT_MAX_LENGTH = 300;
+
+// Maximum wards a citizen can follow. Mirrors the rule in
+// CLAUDE.md and the WardFollow service constraint.
+export const MAX_WARDS_FOLLOWED = 5;

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -31,9 +31,10 @@ export type SignalState = (typeof SIGNAL_STATES)[number];
 
 // Composer character limit for the citizen signal-submit free-text
 // field. Mirrors the backend max-length constraint in the signal
-// submit DTO. Shared here so both the mobile composer and any future
-// web submission UI use the same value.
-export const SIGNAL_TEXT_MAX_LENGTH = 300;
+// submit DTO (see SignalPreviewRequest.freeText in 02_openapi.yaml
+// and apps/citizen-mobile/src/config/constants.ts). Shared here so
+// any future web submission UI uses the same value.
+export const SIGNAL_TEXT_MAX_LENGTH = 500;
 
 // Maximum wards a citizen can follow. Mirrors the rule in
 // CLAUDE.md and the WardFollow service constraint.

--- a/packages/config/tsconfig.json
+++ b/packages/config/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,0 +1,20 @@
+# @hali/contracts
+
+Framework-agnostic TypeScript types derived from the Hali OpenAPI
+contract (`02_openapi.yaml`). Consumed by every front-end surface so the
+wire contract is shared and drift is caught at the type level.
+
+## Usage
+
+```ts
+import type { ResolvedFeatureFlagsResponse } from "@hali/contracts";
+```
+
+## Contract discipline
+
+- Every type in this package corresponds to a wire shape defined in
+  `02_openapi.yaml`. Backend-internal types do not belong here.
+- When an OpenAPI shape changes, update the type in this package in the
+  same PR.
+- Never export types that only one surface uses — those live with that
+  surface.

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@hali/contracts",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Framework-agnostic TypeScript types derived from the Hali OpenAPI contract. Consumed by all front-end surfaces.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,0 +1,14 @@
+// @hali/contracts — framework-agnostic TypeScript types derived from
+// 02_openapi.yaml. Consumed by all front-end surfaces (citizen mobile,
+// institution web, institution admin web, future hali-ops web) so the
+// wire contract is shared and drift-checked at the type level.
+//
+// Adding types: follow the OpenAPI spec in 02_openapi.yaml. Do not add
+// types that do not correspond to a wire shape — types derived from
+// backend internal models live in each consumer as needed.
+
+// Client-visible feature flag exposure — matches
+// ResolvedFeatureFlagsResponse in 02_openapi.yaml.
+export interface ResolvedFeatureFlagsResponse {
+  flags: Record<string, boolean>;
+}

--- a/packages/contracts/tsconfig.json
+++ b/packages/contracts/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,0 +1,22 @@
+# @hali/design-system
+
+Shared Hali design system tokens and primitives.
+
+**Web-only.** Never import this package from `apps/citizen-mobile`.
+Mobile ships its own React Native theme in
+`apps/citizen-mobile/src/theme/` because React Native style primitives
+and web CSS are not interchangeable. Keeping them separate is a
+deliberate boundary — see `docs/arch/FEATURE_FLIGHTING_MODEL.md` and
+`CLAUDE.md` stack rules.
+
+## Usage
+
+```ts
+import { DesignSystemVersion } from "@hali/design-system";
+import { /* tokens */ } from "@hali/design-system/tokens";
+```
+
+The concrete token set — colors, typography, spacing, radius, shadows,
+and the shell / dashboard primitives — is populated by the
+design-system extraction work. See that PR for the canonical source
+and the v0 visual audit.

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -5,9 +5,9 @@ Shared Hali design system tokens and primitives.
 **Web-only.** Never import this package from `apps/citizen-mobile`.
 Mobile ships its own React Native theme in
 `apps/citizen-mobile/src/theme/` because React Native style primitives
-and web CSS are not interchangeable. Keeping them separate is a
-deliberate boundary — see `docs/arch/FEATURE_FLIGHTING_MODEL.md` and
-`CLAUDE.md` stack rules.
+and web CSS are not interchangeable. The rule is stated explicitly in
+`CLAUDE.md` under "Stack rules": _"Do NOT import /packages/design-system
+into citizen-mobile"_.
 
 ## Usage
 

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@hali/design-system",
+  "version": "0.0.0",
+  "private": true,
+  "description": "Shared Hali design system tokens and primitives. WEB-ONLY — never imported by citizen-mobile.",
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./tokens": "./src/tokens/index.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "typescript": "^5.4.5"
+  }
+}

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,0 +1,14 @@
+// @hali/design-system — shared Hali design system baseline.
+//
+// WEB-ONLY. Never import this package from apps/citizen-mobile —
+// the mobile app maintains its own React Native theme in
+// apps/citizen-mobile/src/theme/ because React Native styles and web
+// CSS are not interchangeable.
+//
+// The baseline tokens (colors, typography, spacing, radius, shadows)
+// are populated in the design-system extraction work (#189). This
+// file currently exposes only the package shape so downstream web
+// apps (institution-web, institution-admin-web, future hali-ops-web)
+// can import it before the token set lands.
+
+export * from "./tokens";

--- a/packages/design-system/src/tokens/index.ts
+++ b/packages/design-system/src/tokens/index.ts
@@ -1,0 +1,6 @@
+// Token barrel — the concrete token set is introduced by the
+// design-system extraction work. Keeping this file so downstream
+// imports from "@hali/design-system/tokens" resolve cleanly ahead of
+// that work.
+
+export const DesignSystemVersion = "0.0.0";

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "composite": true
+  },
+  "include": ["src/**/*"]
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,15 @@
+# Hali monorepo workspaces.
+#
+# - apps/*      — deployable applications (citizen-mobile, and future
+#                 institution-web, institution-admin-web, hali-ops-web)
+# - packages/*  — shared libraries consumed by apps (contracts,
+#                 design-system, config)
+#
+# Note: apps/citizen-mobile currently uses npm and ships its own
+# package-lock.json. Leaving it in the workspace list does not force
+# a migration — pnpm at the root only discovers workspace packages
+# and does not override an app's own package manager.
+
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,15 +1,20 @@
 # Hali monorepo workspaces.
 #
-# - apps/*      — deployable applications (citizen-mobile, and future
-#                 institution-web, institution-admin-web, hali-ops-web)
+# - apps/*      — deployable applications (future institution-web,
+#                 institution-admin-web, hali-ops-web)
 # - packages/*  — shared libraries consumed by apps (contracts,
 #                 design-system, config)
 #
-# Note: apps/citizen-mobile currently uses npm and ships its own
-# package-lock.json. Leaving it in the workspace list does not force
-# a migration — pnpm at the root only discovers workspace packages
-# and does not override an app's own package manager.
+# apps/citizen-mobile is DELIBERATELY EXCLUDED for now. The mobile app
+# ships an independent npm workflow with its own package-lock.json, and
+# pulling it into the pnpm workspace risks pnpm install at the root
+# trying to co-manage its node_modules and conflicting with the existing
+# npm toolchain. The mobile app migrates into the workspace as a
+# separate planned change, at which point this glob can broaden to
+# "apps/*".
 
 packages:
-  - "apps/*"
+  - "apps/institution-web"
+  - "apps/institution-admin-web"
+  - "apps/hali-ops-web"
   - "packages/*"

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -7,7 +7,7 @@
       "outputs": ["dist/**"]
     },
     "typecheck": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^typecheck"]
     },
     "lint": {},
     "test": {

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"]
+    },
+    "lint": {},
+    "test": {
+      "dependsOn": ["^build"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

The monorepo scaffold (#228) tracked \`/packages/*\` files because existing files bypass \`.gitignore\`. But the pre-existing NuGet rule \`**/[Pp]ackages/*\` would make any *future* files added under \`/packages/\` silently ignored. Add an explicit negation for the repo-root \`/packages/\` tree so future contributors have \`git status\` pick up new files.

## Test plan

- [x] \`git check-ignore -v packages/contracts/src/foo.ts\` returns the negation rule rather than the NuGet glob.
- [x] Existing tracked files are unaffected (gitignore doesn't impact tracked files).

Follow-up to #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)