### PR TITLE
[Issue #188 follow-up] /packages/ gitignore negation + root package.json description

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,13 @@ coverage-report/
 # ── NuGet ─────────────────────────────────────────────────────────────────────
 *.nupkg
 *.snupkg
+# Ignore NuGet restore output (typically under .NET project bin/obj or legacy
+# solution-level packages/), but never ignore the repo-root /packages/ monorepo
+# workspace directory.
 **/[Pp]ackages/*
 !**/[Pp]ackages/build/
+!/packages/
+!/packages/**
 *.nuspec
 project.lock.json
 project.fragment.lock.json

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hali-monorepo",
   "version": "0.0.0",
   "private": true,
-  "description": "Hali monorepo root — workspaces for Phase 2+ web apps (institution-web, institution-admin-web, hali-ops-web) and shared packages (contracts, design-system, config). apps/citizen-mobile is intentionally outside the workspace while it continues to ship an independent npm toolchain; see pnpm-workspace.yaml for the migration note.",
+  "description": "Hali monorepo root — shared packages (contracts, design-system, config) and planned Phase 2+ web app workspaces (institution-web, institution-admin-web, hali-ops-web) that will land under apps/ as they are scaffolded. apps/citizen-mobile is intentionally outside the workspace while it continues to ship an independent npm toolchain; see pnpm-workspace.yaml for current workspace membership and the migration note.",
   "packageManager": "pnpm@9.12.0",
   "engines": {
     "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "hali-monorepo",
   "version": "0.0.0",
   "private": true,
-  "description": "Hali monorepo root — workspaces for apps (citizen-mobile, institution-web, …) and shared packages (contracts, design-system, config).",
+  "description": "Hali monorepo root — workspaces for Phase 2+ web apps (institution-web, institution-admin-web, hali-ops-web) and shared packages (contracts, design-system, config). apps/citizen-mobile is intentionally outside the workspace while it continues to ship an independent npm toolchain; see pnpm-workspace.yaml for the migration note.",
   "packageManager": "pnpm@9.12.0",
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
## Summary

Two small follow-ups to the monorepo scaffold merged in #228:

1. **\`.gitignore\`** — the pre-existing NuGet rule \`**/[Pp]ackages/*\` would make *future* files added under \`/packages/\` silently ignored (existing files bypass gitignore, so #228 tracked cleanly; but a new \`packages/contracts/src/foo.ts\` added later wouldn't show up in \`git status\`). Add an explicit negation for the repo-root \`/packages/\` tree.

2. **\`package.json\`** — description previously listed citizen-mobile among the workspaces, but \`pnpm-workspace.yaml\` explicitly excludes it while it continues to use its own npm toolchain. Align description with actual scope and point at \`pnpm-workspace.yaml\` for the migration rationale.

Both changes were Copilot review findings on the #188 / #228 scaffold.

## Test plan

- [x] \`git check-ignore -v packages/contracts/src/foo.ts\` returns the negation.
- [x] \`dotnet build\` unaffected.
- [x] CI must pass.

Follow-up to #188 (#228).

🤖 Generated with [Claude Code](https://claude.com/claude-code)