### PR TITLE
[Issue #189] Extract shared design-system baseline from v0 artifacts

### DIFF
--- a/docs/reference-ui/v0/mobile-token-visual-audit.md
+++ b/docs/reference-ui/v0/mobile-token-visual-audit.md
@@ -1,0 +1,261 @@
+# Mobile Token Visual Audit — Retroactive
+
+**Issue:** #189. **Generated:** 2026-04-17. **Purpose:** internal accuracy
+record, not a design decision.
+
+The Phase A design tokens in `apps/citizen-mobile/src/theme/` were
+extracted from the web MVP's `globals.css` rather than from a direct
+visual inspection of specific v0 mobile screens. This document is the
+retroactive audit: for each token group, it declares the source, cites
+the v0 screen(s) that validate or contradict the value, flags the
+assumptions that have no direct visual evidence, and calls out the
+cross-surface risks for Phase B.
+
+There is no human review gate on this audit (per the Phase 1 brief) —
+it is an accuracy ledger that exists so Phase B does not rediscover
+the same gaps.
+
+---
+
+## 1. Extraction source declaration
+
+| Token group | Source used for Phase A extraction | Direct v0 screen evidence? |
+|---|---|---|
+| Colors — surface (background, card, foreground, muted, border) | `v0-hali-mobile-ui/app/globals.css` OKLCH values, hex-converted | **Yes** — every mobile screen renders against these surface tokens |
+| Colors — primary brand (teal) | `v0-hali-mobile-ui/app/globals.css` `--primary` | **Yes** — home-screen header, issue-card active state, FAB background |
+| Colors — destructive (warm orange/red) | `globals.css` `--destructive` | **Partial** — error paths not consistently rendered in v0 components |
+| Colors — condition badges (amber/orange/red/sky/violet/stone/slate/yellow/emerald) | `v0-hali-mobile-ui/components/issue-card.tsx` explicit class map (authoritative) | **Yes** — issue-card.tsx maps condition labels to Tailwind palette classes directly |
+| Typography — font family (Geist) | `v0-hali-mobile-ui/app/layout.tsx` (`Geist`, `Geist_Mono` imports) | **Yes** — mobile layout loads Geist from Google Fonts |
+| Typography — scale (FontSize.*) | Tailwind classes used across v0 components (`text-2xl`, `text-sm`, etc.) translated to dp | **Inferred** — scale mapping is a judgment call; no pixel measurement taken from a rendered v0 screen |
+| Spacing — scale (4dp base, xs..6xl) | Tailwind default 4px base matches RN 4dp convention | **Inferred** — not directly measured |
+| Radius — scale | `globals.css` `--radius: 0.75rem` | **Yes** — v0 uses `rounded-xl` (12px) on cards, FAB, modal surfaces |
+| Shadows | Tailwind defaults | **Partial** — some v0 components rely on opacity-based separation rather than shadow |
+| Animations (pulse, fade-up, count-pop, breathe, slide-in-right) | Web MVP keyframe set | **Inferred** — animation timing not directly observable from static component source |
+
+---
+
+## 2. Screen-level citations
+
+### Colors
+
+- **`Colors.primary` (#2D8A8F / `oklch(0.55 0.12 190)`)** — Confirmed across:
+  - `home-screen.tsx`: `text-primary` on the locality pin icon, the
+    clickable locality label, and the "All clear" emerald affirmative
+    subtext color is contrasted against it.
+  - `issue-card.tsx`: uses it for active state accents.
+  - `floating-action-button.tsx`: FAB background.
+  - `locality-selector.tsx`: selected locality chip.
+  - **Verdict:** confirmed across 4+ screens. Safe to treat as canonical.
+
+- **`Colors.background` (#F7FAFA / `oklch(0.98 0.005 200)`)** — Confirmed
+  on the app root shell in `home-screen.tsx` (`bg-background`). Every
+  screen composes on top of this surface. **Safe.**
+
+- **`Colors.foreground` (#383D42 / `oklch(0.25 0.02 220)`)** — Used as
+  the default text color on `home-screen.tsx`, `issue-detail.tsx`, and
+  the app-name header. **Safe.**
+
+- **`Colors.mutedForeground` (#757B82 / `oklch(0.50 0.02 220)`)** — Used
+  for secondary text across `home-screen.tsx` (subtext under locality
+  name, "Active Now" section label) and in empty-state copy. **Safe.**
+
+- **`Colors.border` (#E2E7E7 / `oklch(0.90 0.01 200)`)** — Used on
+  header bottom-border (`border-border/50`) and section dividers
+  (`border-t border-border/30`). **Safe.**
+
+- **`Colors.faintForeground` (#9CA3AF)** — No direct v0 mobile evidence;
+  the mobile theme introduces this as a finer-grained variant between
+  `muted-foreground` and the backgrounds. **[ASSUMPTION — no direct
+  v0 evidence]** — the v0 often uses opacity modifiers
+  (`text-muted-foreground/70`) rather than a separate token. Phase B
+  should either adopt opacity-modifier convention on mobile or validate
+  that `faintForeground` reads correctly against real content.
+
+- **`Colors.destructive` (#D4603A)** — OKLCH to hex conversion. No
+  direct error-state v0 screen exists to validate the hue. **[ASSUMPTION
+  — no direct v0 evidence]**. Phase B will exercise this when error
+  envelopes render in real screens.
+
+- **`Colors.emerald` / `Colors.emeraldSubtle`** — Confirmed in
+  `home-screen.tsx` "All clear" empty state (`bg-emerald-50`,
+  `text-emerald-600`). Palette is the Tailwind `emerald-*` set; hex
+  values in the mobile theme match Tailwind. **Safe.**
+
+### Typography
+
+- **Font family (Geist)** — Confirmed loaded in mobile v0
+  `app/layout.tsx`. The citizen mobile app loads it via
+  `@expo-google-fonts/geist`. **Safe.**
+
+- **`FontSize.appName` (24dp / `text-2xl`)** — Confirmed in
+  `home-screen.tsx` header (`text-2xl font-semibold`). **Safe.**
+
+- **`FontSize.title` (20dp / `text-xl`)** — Used in
+  `issue-detail.tsx`, `official-update-detail.tsx`, and
+  `report-modal.tsx` for screen titles. **Safe.**
+
+- **`FontSize.cardTitle` (15dp)** — **[ASSUMPTION — no direct v0 evidence]**.
+  v0 cards use `text-sm` (14dp) or `text-base` (16dp). 15dp was a
+  judgment call midway between the two. Phase B risk: cards may read
+  either slightly smaller or slightly larger than the v0 intent; check
+  when issue-card is rendered with real content.
+
+- **`FontSize.body` (14dp / `text-sm`)** — Confirmed in
+  `home-screen.tsx` "All clear in {locality}" copy. **Safe.**
+
+- **`FontSize.bodySmall` (13dp)** — **[ASSUMPTION — no direct v0 evidence]**.
+  v0 uses either `text-sm` (14dp) or `text-xs` (12dp); 13dp is
+  interpolated. Phase B risk: institution name labels and timestamp
+  subtext may render at slightly different sizes than the v0.
+
+- **`FontSize.badge` (12dp / `text-xs`)** — Confirmed in v0 condition
+  badges and meta text. **Safe.**
+
+- **`FontSize.sectionHeader` / `FontSize.micro` (both 10dp)** —
+  Confirmed in `home-screen.tsx` "Active Now" (`text-xs`, slightly
+  smaller custom) and "Official Updates" (`text-[10px]`). **Safe.**
+
+### Spacing
+
+- **`Spacing.lg` (16dp) = default screen padding** — Confirmed via
+  v0 Tailwind `p-4` on `home-screen.tsx` scroll container. **Safe.**
+
+- **`Spacing.2xl` (24dp) = section gap** — Confirmed via v0
+  `space-y-6` on home feed sections. **Safe.**
+
+- **Other scale steps (xs, sm, md, xl, 3xl, 4xl, 6xl)** — mobile theme
+  mirrors the Tailwind 4-unit scale. Where specific v0 usage is
+  unclear, the token is labeled **[ASSUMPTION — no direct v0 evidence]**.
+  Phase B risk: tight scales (xs, sm) may drift slightly from v0 intent.
+
+### Radius
+
+- **`Radius` default 0.75rem (12dp, `rounded-xl`)** — Confirmed across
+  v0 cards, buttons, FAB, and modal surfaces. **Safe.**
+
+- **Smaller radii (sm, md)** — **[ASSUMPTION — derived from shadcn/ui
+  convention]**. Not separately measured against v0 artifacts.
+
+### Shadows
+
+- **All shadow tokens** — **[ASSUMPTION — no direct v0 evidence]**. The
+  v0 mobile reference frequently relies on opacity modifiers
+  (`bg-background/95`, `border-border/50`, `backdrop-blur-sm`) rather
+  than explicit shadows. Phase B should audit whether mobile should
+  switch to opacity-based separation or keep discrete shadow tokens.
+
+### Animations
+
+- **Animation presets (fade-up, count-pop, breathe, slide-in-right,
+  modal-content)** — **[ASSUMPTION — timing not measurable from static
+  component source]**. Values were ported from the web MVP keyframes
+  as intent-preserving approximations. Phase B should review
+  `apps/citizen-mobile/src/theme/animations.ts` against a running
+  reference if animation polish is in scope.
+  - `startPulseSoft` / `pulseSoftConfig` have been removed in #187
+    after LiveDot was deleted — those were the only consumers.
+
+---
+
+## 3. Assumption flags summary
+
+| Token | Status | Phase B action |
+|---|---|---|
+| `Colors.faintForeground` | No direct v0 evidence | Validate against real screens or switch to opacity modifiers |
+| `Colors.destructive` exact hue | No direct v0 error screens | Check against error envelopes when they render |
+| `FontSize.cardTitle` (15dp) | Interpolated between 14 and 16 | Measure against real card rendering |
+| `FontSize.bodySmall` (13dp) | Interpolated between 12 and 14 | Measure against institution-name labels |
+| Spacing scale steps except lg/2xl | Derived from Tailwind default | Sanity-check during Phase B layout work |
+| Radius `sm` / `md` | Derived from shadcn/ui convention | Validate on native pill / chip components |
+| Shadow tokens (all) | No direct v0 shadow usage observed | Decide: opacity-based vs shadow tokens |
+| Animation timing | Ported from web MVP, not measured | Visual review when motion polish is in scope |
+
+---
+
+## 4. Condition badge colour map
+
+The `getConditionBadgePalette()` mapping in
+`apps/citizen-mobile/src/theme/colors.ts` is string-match based. For
+each palette key, its v0 evidence:
+
+| Palette key | v0 evidence |
+|---|---|
+| `amber` — "No power", "Power outage", "No water", "Transformer", "Sewage", "Bad smell" | **Confirmed** — `v0-hali-mobile-ui/components/issue-card.tsx` maps these condition labels to `bg-amber-50 text-amber-700 border-amber-200` |
+| `orange` — "Difficult to pass", "Multiple potholes", "Lane blocked", "Slow moving", "Heavy traffic", "Poor road condition", "Road damage", "Partially blocked", "Sidewalk/walkway", "Uncollected", "Overflowing" | **Confirmed** — same `issue-card.tsx` map |
+| `red` — "Impassable", "Road blocked", "Traffic blocked", "Accident", "Crash", "Collision" | **Confirmed** — same map |
+| `sky` — "Flooding", "Water on road", "Partially flooded" | **Confirmed** — same map |
+| `violet` — "Noise", "Noisy", "Loud" | **Confirmed** — same map (v0 covers "Loud music", "Noisy construction") |
+| `stone` — "Dust", "Dusty" | **Confirmed** — same map |
+| `slate` — "Dark", "No street lighting", "No light" | **Confirmed** — same map ("Dark streets", "No street lighting") |
+| `yellow` — "Low pressure", "Weak pressure", "Unstable power", "Power going on/off", "Air pollution" | **Confirmed** — same map |
+| `emerald` — "Restoration", "Possible restoration", "Restored", "Recovery" | **Judgment call** — v0 `issue-card.tsx` uses emerald for the "Restored / possible restoration" cluster state; extending it to "recovery" free-text was the theme's choice |
+| `muted` — fallback | **Canonical** — safety net for unknown condition labels; not a v0 artifact decision |
+
+The mobile theme's string-matching helper is an order-sensitive match
+over a regex/substring list. Ordering (e.g. `amber` before `orange`)
+was chosen to keep "No power" from matching the `amber` clause before
+a more specific clause could claim it. Phase B adding a new condition
+must also add a new clause in the same ordered helper.
+
+---
+
+## 5. Cross-surface flags
+
+The most important divergences between mobile v0 and institution v0
+tokens that Phase 1.5 / Phase B will need to reconcile:
+
+| Token | Mobile v0 | Institution v0 | Resolution needed? |
+|---|---|---|---|
+| Primary color | `oklch(0.55 0.12 190)` — cooler, deeper teal | `oklch(0.65 0.12 180)` — lighter, slightly greener teal | **Yes** — Phase 1.5 should decide whether brand primary converges or deliberately stays surface-specific |
+| Background | `oklch(0.98 0.005 200)` | `oklch(0.985 0.002 180)` — very slightly warmer | Minor; probably acceptable |
+| Foreground | `oklch(0.25 0.02 220)` | `oklch(0.2 0.02 200)` — darker, less blue-hued | **Yes** — worth an explicit decision for shared body text |
+| Border | `oklch(0.90 0.01 200)` | `oklch(0.92 0.01 180)` — slightly lighter | Minor |
+| Destructive | `oklch(0.60 0.15 30)` — warm orange-red | `oklch(0.577 0.245 27.325)` — more saturated, closer to pure red | **Yes** — error states should feel consistent |
+| Sidebar tokens | Not applicable (no sidebar on mobile) | Full sidebar-* palette defined | Institution web is the only consumer; no conflict |
+| Radius | `0.75rem` (both) | `0.75rem` (both) | **No difference** |
+| Typography (Geist family) | Confirmed | Confirmed | **No difference** |
+
+These cross-surface flags are inputs to the Phase 1.5 UI/UX synthesis;
+the final decisions live in that synthesis document, not here.
+
+---
+
+## 6. Phase B risk summary
+
+Tokens most likely to need adjustment once real screens are rendered
+against them:
+
+1. **`Colors.faintForeground`** — no direct v0 evidence; may be
+   replaced with opacity modifiers on existing `mutedForeground`
+   rather than kept as a discrete token.
+2. **`FontSize.cardTitle` (15dp)** — interpolated; likely drifts up to
+   16dp or down to 14dp once cards render with real content.
+3. **`FontSize.bodySmall` (13dp)** — same interpolation concern.
+4. **Shadow tokens** — the v0 reference favours opacity-based
+   separation, so the mobile shadow set may be simplified or removed.
+5. **Animation timing** — values are intent-preserving approximations;
+   actual perceived motion may need adjustment.
+6. **Cross-surface primary/destructive** — decision pending from
+   Phase 1.5; mobile tokens may need a follow-up update if Phase 1.5
+   chooses convergence.
+
+None of these block Phase B from starting; they are a known watchlist
+for when Phase B encounters the relevant surfaces.
+
+---
+
+## 7. Audit outcome
+
+- **Number of "safe" tokens:** 13 (every surface color, primary,
+  foreground, muted-foreground, border, emerald subset, page-level
+  radius, body/title/badge/appName/micro font sizes, Geist family,
+  default screen spacing)
+- **Number of "assumption-flagged" tokens:** 8 (faintForeground,
+  destructive hue, cardTitle, bodySmall, most spacing scale steps,
+  smaller radii, shadow set, animation timing)
+- **Cross-surface conflicts requiring Phase 1.5 decisions:** 4
+  (primary color, foreground color, destructive hue, sidebar usage)
+
+The assumption count is manageable and the cross-surface conflicts are
+all narrow. No blocking issue; Phase B can proceed on the current
+mobile theme with this document as the change log for follow-ups.

--- a/docs/reference-ui/v0/mobile-token-visual-audit.md
+++ b/docs/reference-ui/v0/mobile-token-visual-audit.md
@@ -21,11 +21,11 @@ the same gaps.
 
 | Token group | Source used for Phase A extraction | Direct v0 screen evidence? |
 |---|---|---|
-| Colors — surface (background, card, foreground, muted, border) | `v0-hali-mobile-ui/app/globals.css` OKLCH values, hex-converted | **Yes** — every mobile screen renders against these surface tokens |
-| Colors — primary brand (teal) | `v0-hali-mobile-ui/app/globals.css` `--primary` | **Yes** — home-screen header, issue-card active state, FAB background |
+| Colors — surface (background, card, foreground, muted, border) | `docs/reference-ui/v0/v0-hali-mobile-ui.zip:app/globals.css` OKLCH values, hex-converted | **Yes** — every mobile screen renders against these surface tokens |
+| Colors — primary brand (teal) | `docs/reference-ui/v0/v0-hali-mobile-ui.zip:app/globals.css` `--primary` | **Yes** — home-screen header, issue-card active state, FAB background |
 | Colors — destructive (warm orange/red) | `globals.css` `--destructive` | **Partial** — error paths not consistently rendered in v0 components |
-| Colors — condition badges (amber/orange/red/sky/violet/stone/slate/yellow/emerald) | `v0-hali-mobile-ui/components/issue-card.tsx` explicit class map (authoritative) | **Yes** — issue-card.tsx maps condition labels to Tailwind palette classes directly |
-| Typography — font family (Geist) | `v0-hali-mobile-ui/app/layout.tsx` (`Geist`, `Geist_Mono` imports) | **Yes** — mobile layout loads Geist from Google Fonts |
+| Colors — condition badges (amber/orange/red/sky/violet/stone/slate/yellow/emerald) | `docs/reference-ui/v0/v0-hali-mobile-ui.zip:components/issue-card.tsx` explicit class map (authoritative) | **Yes** — issue-card.tsx maps condition labels to Tailwind palette classes directly |
+| Typography — font family (Geist) | `docs/reference-ui/v0/v0-hali-mobile-ui.zip:app/layout.tsx` (`Geist`, `Geist_Mono` imports) | **Yes** — mobile layout loads Geist from Google Fonts |
 | Typography — scale (FontSize.*) | Tailwind classes used across v0 components (`text-2xl`, `text-sm`, etc.) translated to dp | **Inferred** — scale mapping is a judgment call; no pixel measurement taken from a rendered v0 screen |
 | Spacing — scale (4dp base, xs..6xl) | Tailwind default 4px base matches RN 4dp convention | **Inferred** — not directly measured |
 | Radius — scale | `globals.css` `--radius: 0.75rem` | **Yes** — v0 uses `rounded-xl` (12px) on cards, FAB, modal surfaces |
@@ -152,8 +152,9 @@ the same gaps.
   as intent-preserving approximations. Phase B should review
   `apps/citizen-mobile/src/theme/animations.ts` against a running
   reference if animation polish is in scope.
-  - `startPulseSoft` / `pulseSoftConfig` have been removed in #187
-    after LiveDot was deleted — those were the only consumers.
+  - `startPulseSoft` / `pulseSoftConfig` were removed from
+    `apps/citizen-mobile/src/theme/animations.ts` after the LiveDot
+    component was deleted — those were the only consumers.
 
 ---
 
@@ -180,7 +181,7 @@ each palette key, its v0 evidence:
 
 | Palette key | v0 evidence |
 |---|---|
-| `amber` — "No power", "Power outage", "No water", "Transformer", "Sewage", "Bad smell" | **Confirmed** — `v0-hali-mobile-ui/components/issue-card.tsx` maps these condition labels to `bg-amber-50 text-amber-700 border-amber-200` |
+| `amber` — "No power", "Power outage", "No water", "Transformer", "Sewage", "Bad smell" | **Confirmed** — `docs/reference-ui/v0/v0-hali-mobile-ui.zip:components/issue-card.tsx` maps these condition labels to `bg-amber-50 text-amber-700 border-amber-200` |
 | `orange` — "Difficult to pass", "Multiple potholes", "Lane blocked", "Slow moving", "Heavy traffic", "Poor road condition", "Road damage", "Partially blocked", "Sidewalk/walkway", "Uncollected", "Overflowing" | **Confirmed** — same `issue-card.tsx` map |
 | `red` — "Impassable", "Road blocked", "Traffic blocked", "Accident", "Crash", "Collision" | **Confirmed** — same map |
 | `sky` — "Flooding", "Water on road", "Partially flooded" | **Confirmed** — same map |

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -1,6 +1,7 @@
 # @hali/design-system
 
-Shared Hali design system tokens and primitives.
+Shared Hali design system tokens and primitives derived from the v0
+reference artifacts in `docs/reference-ui/v0/`.
 
 **Web-only.** Never import this package from `apps/citizen-mobile`.
 Mobile ships its own React Native theme in
@@ -9,14 +10,55 @@ and web CSS are not interchangeable. The rule is stated explicitly in
 `CLAUDE.md` under "Stack rules": _"Do NOT import /packages/design-system
 into citizen-mobile"_.
 
+## Canonical vs reference-only
+
+| Layer | Status |
+|---|---|
+| **Color tokens** (`CitizenColors`, `InstitutionColors`) | **Canonical** — extracted from `docs/reference-ui/v0/v0-hali-*-ui.zip` `app/globals.css`. The two surfaces differ; see §5 of `docs/reference-ui/v0/mobile-token-visual-audit.md` for the cross-surface flags. |
+| **Condition badge class names** (`ConditionBadgeClassNames`) | **Canonical** — mirrors the explicit `issue-card.tsx` mapping in the v0 mobile UI, which is the authoritative source for condition → palette mapping. |
+| **Spacing scale** | **Canonical** — aligned with the mobile theme (4px base, xs..6xl steps). |
+| **Radius scale** | **Canonical default** (`0.75rem`), derived steps for `sm`/`md` per shadcn/ui convention. |
+| **Typography tokens** (Geist family, weights, sizes, line-heights) | **Canonical** — Geist matches both v0 surfaces; scale aligned with citizen mobile. |
+| **Component primitives** (buttons, inputs, cards, shells) | **Reference-only** — v0 artifacts ship concrete components but they are NOT imported into this package. Phase 1.5 synthesis decides which patterns become canonical; Phase 3 implementation ships them. |
+
 ## Usage
 
 ```ts
-import { DesignSystemVersion } from "@hali/design-system";
-import { /* tokens */ } from "@hali/design-system/tokens";
+import {
+  CitizenColors,
+  InstitutionColors,
+  ConditionBadgeClassNames,
+  Spacing,
+  Radius,
+  FontFamily,
+  FontSize,
+  DesignSystemVersion,
+} from "@hali/design-system";
 ```
 
-The concrete token set — colors, typography, spacing, radius, shadows,
-and the shell / dashboard primitives — is populated by the
-design-system extraction work. See that PR for the canonical source
-and the v0 visual audit.
+Consumers typically feed these into Tailwind v4 (via CSS custom
+properties generated at build time) or CSS-in-JS at runtime. The
+package exports raw values (OKLCH strings, rem strings, numeric
+weights) so the consumer picks the consumption strategy — the
+package does not ship a Tailwind config of its own yet; that lands
+with the first web app build.
+
+## What lives here vs not
+
+- ✅ Token values extracted verbatim from the v0 reference artifacts.
+- ✅ Cross-surface variants (citizen vs institution) when the v0 surfaces
+  differ.
+- ✅ Shared constants that both surfaces consume identically
+  (condition-badge palette, font family, radius default).
+- ❌ Concrete React components (ship with each web app, or land after
+  Phase 1.5 decides on the canonical component set).
+- ❌ Tailwind config (one Tailwind config per app — the shared tokens
+  are imported into each app's config rather than centralised here).
+- ❌ React Native primitives (mobile ships its own theme).
+
+## See also
+
+- `docs/reference-ui/v0/mobile-token-visual-audit.md` — retroactive
+  audit of the citizen mobile theme against the v0 artifacts.
+- `docs/arch/SECURITY_POSTURE.md` §6 — secure defaults for new web apps.
+- `docs/arch/OBSERVABILITY_MODEL.md` §5 — institution web telemetry.

--- a/packages/design-system/src/tokens/colors.ts
+++ b/packages/design-system/src/tokens/colors.ts
@@ -33,7 +33,11 @@ export const CitizenColors = {
   accent: "oklch(0.92 0.02 180)",
   accentForeground: "oklch(0.30 0.02 220)",
   destructive: "oklch(0.60 0.15 30)",
-  destructiveForeground: "oklch(0.60 0.15 30)",
+  // NOTE: the v0 artifact ships --destructive-foreground equal to
+  // --destructive, which leaves destructive text unreadable on
+  // destructive backgrounds. We deviate from the artifact here and
+  // use the same near-white as primaryForeground so contrast works.
+  destructiveForeground: "oklch(0.99 0 0)",
   border: "oklch(0.90 0.01 200)",
   input: "oklch(0.92 0.01 200)",
   ring: "oklch(0.55 0.12 190)",
@@ -61,7 +65,9 @@ export const InstitutionColors = {
   accent: "oklch(0.92 0.03 180)",
   accentForeground: "oklch(0.25 0.02 200)",
   destructive: "oklch(0.577 0.245 27.325)",
-  destructiveForeground: "oklch(0.577 0.245 27.325)",
+  // Same deviation as citizen: v0 ships foreground==destructive which
+  // is unreadable. Near-white foreground preserves contrast.
+  destructiveForeground: "oklch(0.99 0 0)",
   border: "oklch(0.92 0.01 180)",
   input: "oklch(0.92 0.01 180)",
   ring: "oklch(0.65 0.12 180)",

--- a/packages/design-system/src/tokens/colors.ts
+++ b/packages/design-system/src/tokens/colors.ts
@@ -1,0 +1,102 @@
+// Canonical color tokens extracted from the v0 reference artifacts
+// (docs/reference-ui/v0/v0-hali-*-ui.zip). These are WEB-ONLY — the
+// citizen mobile app maintains its own React Native theme in
+// apps/citizen-mobile/src/theme/colors.ts because OKLCH and
+// semantic CSS tokens are not representable in React Native.
+//
+// The two v0 surfaces differ subtly — the citizen mobile reference
+// uses a cooler primary (oklch 0.55 0.12 190) while the institution
+// reference uses a slightly more saturated variant (oklch 0.65 0.12
+// 180). Both are captured here so each web consumer picks the
+// surface-correct palette; convergence decisions are deferred to the
+// Phase 1.5 UI/UX synthesis work.
+
+/**
+ * Canonical citizen web palette — matches the v0 mobile UI artifact
+ * (`v0-hali-mobile-ui/app/globals.css`). Values are raw OKLCH strings
+ * so downstream consumers can feed them directly into Tailwind v4 or
+ * CSS custom properties without lossy hex conversion.
+ */
+export const CitizenColors = {
+  background: "oklch(0.98 0.005 200)",
+  foreground: "oklch(0.25 0.02 220)",
+  card: "oklch(1 0 0)",
+  cardForeground: "oklch(0.25 0.02 220)",
+  popover: "oklch(1 0 0)",
+  popoverForeground: "oklch(0.25 0.02 220)",
+  primary: "oklch(0.55 0.12 190)",
+  primaryForeground: "oklch(0.99 0 0)",
+  secondary: "oklch(0.94 0.01 200)",
+  secondaryForeground: "oklch(0.35 0.02 220)",
+  muted: "oklch(0.95 0.005 200)",
+  mutedForeground: "oklch(0.50 0.02 220)",
+  accent: "oklch(0.92 0.02 180)",
+  accentForeground: "oklch(0.30 0.02 220)",
+  destructive: "oklch(0.60 0.15 30)",
+  destructiveForeground: "oklch(0.60 0.15 30)",
+  border: "oklch(0.90 0.01 200)",
+  input: "oklch(0.92 0.01 200)",
+  ring: "oklch(0.55 0.12 190)",
+} as const;
+
+/**
+ * Canonical institution web palette — matches the v0 institution UI
+ * artifact (`v0-hali-institution-ui/app/globals.css`). Sidebar-prefixed
+ * tokens are included because the institution dashboard shell has a
+ * persistent sidebar while the citizen mobile reference does not.
+ */
+export const InstitutionColors = {
+  background: "oklch(0.985 0.002 180)",
+  foreground: "oklch(0.2 0.02 200)",
+  card: "oklch(1 0 0)",
+  cardForeground: "oklch(0.2 0.02 200)",
+  popover: "oklch(1 0 0)",
+  popoverForeground: "oklch(0.2 0.02 200)",
+  primary: "oklch(0.65 0.12 180)",
+  primaryForeground: "oklch(0.99 0 0)",
+  secondary: "oklch(0.96 0.01 180)",
+  secondaryForeground: "oklch(0.25 0.02 200)",
+  muted: "oklch(0.96 0.008 180)",
+  mutedForeground: "oklch(0.5 0.02 200)",
+  accent: "oklch(0.92 0.03 180)",
+  accentForeground: "oklch(0.25 0.02 200)",
+  destructive: "oklch(0.577 0.245 27.325)",
+  destructiveForeground: "oklch(0.577 0.245 27.325)",
+  border: "oklch(0.92 0.01 180)",
+  input: "oklch(0.92 0.01 180)",
+  ring: "oklch(0.65 0.12 180)",
+  sidebar: "oklch(0.99 0.005 180)",
+  sidebarForeground: "oklch(0.25 0.02 200)",
+  sidebarPrimary: "oklch(0.65 0.12 180)",
+  sidebarPrimaryForeground: "oklch(0.99 0 0)",
+  sidebarAccent: "oklch(0.96 0.01 180)",
+  sidebarAccentForeground: "oklch(0.25 0.02 200)",
+  sidebarBorder: "oklch(0.92 0.01 180)",
+  sidebarRing: "oklch(0.65 0.12 180)",
+} as const;
+
+/**
+ * Semantic condition-badge palette shared across surfaces. Each entry
+ * is a trio of (background, text, border) Tailwind class names taken
+ * directly from the v0 mobile `issue-card.tsx` mapping, which is the
+ * authoritative source. The citizen mobile app mirrors these palettes
+ * as hex tokens in `apps/citizen-mobile/src/theme/colors.ts`.
+ *
+ * When adding a new condition label to CSI-NLP, extend the mapping in
+ * the citizen mobile `getConditionBadgePalette` helper rather than
+ * introducing a new palette key here.
+ */
+export const ConditionBadgeClassNames = {
+  amber: "bg-amber-50 text-amber-700 border-amber-200",
+  orange: "bg-orange-50 text-orange-700 border-orange-200",
+  red: "bg-red-50 text-red-700 border-red-200",
+  sky: "bg-sky-50 text-sky-700 border-sky-200",
+  violet: "bg-violet-50 text-violet-700 border-violet-200",
+  stone: "bg-stone-50 text-stone-700 border-stone-200",
+  slate: "bg-slate-50 text-slate-700 border-slate-200",
+  yellow: "bg-yellow-50 text-yellow-700 border-yellow-200",
+  emerald: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  muted: "bg-muted text-muted-foreground border-border",
+} as const;
+
+export type ConditionBadgeKey = keyof typeof ConditionBadgeClassNames;

--- a/packages/design-system/src/tokens/index.ts
+++ b/packages/design-system/src/tokens/index.ts
@@ -1,6 +1,14 @@
-// Token barrel — the concrete token set is introduced by the
-// design-system extraction work. Keeping this file so downstream
-// imports from "@hali/design-system/tokens" resolve cleanly ahead of
-// that work.
+// Token barrel. Explicit re-exports so consumers can see the surface
+// area in one place and treeshaking has named entry points.
 
-export const DesignSystemVersion = "0.0.0";
+export * from "./colors";
+export * from "./spacing";
+export * from "./radius";
+export * from "./typography";
+
+/**
+ * Package version sentinel for downstream import-existence checks
+ * before the concrete component set lands. Bump when the token set
+ * changes in a way that breaks consumers.
+ */
+export const DesignSystemVersion = "0.1.0";

--- a/packages/design-system/src/tokens/radius.ts
+++ b/packages/design-system/src/tokens/radius.ts
@@ -1,12 +1,16 @@
 // Border radius scale. The canonical v0 value is --radius: 0.75rem
-// (`rounded-xl`). Smaller values are derived by the shadcn/ui
-// convention (sm = radius - 4px, md = radius - 2px).
+// (12px), used directly on cards, FAB, and modal surfaces as
+// `rounded-xl`. Smaller steps follow the shadcn/ui convention:
+//   sm = --radius - 4px  (8px, 0.5rem)
+//   md = --radius - 2px  (10px, 0.625rem)
+// Consumers that need a tighter 4px chip corner should reach for an
+// explicit pixel value rather than a new token key.
 
 export const Radius = {
-  /** 4px — sm */
-  sm: "0.25rem",
-  /** 6px — md */
-  md: "0.375rem",
+  /** 8px — sm (0.75rem - 4px per shadcn/ui convention) */
+  sm: "0.5rem",
+  /** 10px — md (0.75rem - 2px per shadcn/ui convention) */
+  md: "0.625rem",
   /** 12px — default; matches v0 globals.css --radius */
   default: "0.75rem",
   /** 16px — lg */

--- a/packages/design-system/src/tokens/radius.ts
+++ b/packages/design-system/src/tokens/radius.ts
@@ -1,0 +1,18 @@
+// Border radius scale. The canonical v0 value is --radius: 0.75rem
+// (`rounded-xl`). Smaller values are derived by the shadcn/ui
+// convention (sm = radius - 4px, md = radius - 2px).
+
+export const Radius = {
+  /** 4px — sm */
+  sm: "0.25rem",
+  /** 6px — md */
+  md: "0.375rem",
+  /** 12px — default; matches v0 globals.css --radius */
+  default: "0.75rem",
+  /** 16px — lg */
+  lg: "1rem",
+  /** 9999px — full (pills, avatars) */
+  full: "9999px",
+} as const;
+
+export type RadiusKey = keyof typeof Radius;

--- a/packages/design-system/src/tokens/spacing.ts
+++ b/packages/design-system/src/tokens/spacing.ts
@@ -1,0 +1,27 @@
+// Spacing scale — base unit 4px, aligned with the citizen mobile
+// theme (apps/citizen-mobile/src/theme/spacing.ts). Values are raw
+// rem strings so consumers can feed them into Tailwind, CSS
+// custom properties, or CSS-in-JS without arithmetic per consumer.
+
+export const Spacing = {
+  /** 4px — xs */
+  xs: "0.25rem",
+  /** 8px — sm */
+  sm: "0.5rem",
+  /** 12px — md */
+  md: "0.75rem",
+  /** 16px — lg, the default screen/card padding */
+  lg: "1rem",
+  /** 20px — xl */
+  xl: "1.25rem",
+  /** 24px — 2xl, standard section gap */
+  "2xl": "1.5rem",
+  /** 32px — 3xl */
+  "3xl": "2rem",
+  /** 48px — 4xl */
+  "4xl": "3rem",
+  /** 96px — 6xl */
+  "6xl": "6rem",
+} as const;
+
+export type SpacingKey = keyof typeof Spacing;

--- a/packages/design-system/src/tokens/typography.ts
+++ b/packages/design-system/src/tokens/typography.ts
@@ -30,7 +30,9 @@ export const FontSize = {
   bodySmall: "0.8125rem",
   /** 12px — condition badges, meta counts */
   badge: "0.75rem",
-  /** 10px — section headers (uppercase), micro labels */
+  /** 10px — section headers (uppercase) */
+  sectionHeader: "0.625rem",
+  /** 10px — micro labels (timestamps, updated-at) */
   micro: "0.625rem",
 } as const;
 

--- a/packages/design-system/src/tokens/typography.ts
+++ b/packages/design-system/src/tokens/typography.ts
@@ -1,0 +1,48 @@
+// Typography tokens. Both v0 artifacts load the Geist family from
+// Google Fonts in their Next.js layout. The scale below is derived
+// from the Tailwind classes used in the v0 components — appName /
+// title / cardTitle / body / badge / sectionHeader / micro — and
+// aligned with the citizen mobile scale
+// (apps/citizen-mobile/src/theme/typography.ts).
+
+export const FontFamily = {
+  sans: "Geist, 'Geist Fallback', system-ui, sans-serif",
+  mono: "'Geist Mono', 'Geist Mono Fallback', ui-monospace, monospace",
+} as const;
+
+export const FontWeight = {
+  regular: 400,
+  medium: 500,
+  semiBold: 600,
+  bold: 700,
+} as const;
+
+export const FontSize = {
+  /** 24px — app name ("Hali" header) */
+  appName: "1.5rem",
+  /** 20px — screen/modal titles */
+  title: "1.25rem",
+  /** 15px — card titles, prominent labels */
+  cardTitle: "0.9375rem",
+  /** 14px — body text */
+  body: "0.875rem",
+  /** 13px — secondary body (institution names, context) */
+  bodySmall: "0.8125rem",
+  /** 12px — condition badges, meta counts */
+  badge: "0.75rem",
+  /** 10px — section headers (uppercase), micro labels */
+  micro: "0.625rem",
+} as const;
+
+export const LineHeight = {
+  tight: 1.2,
+  snug: 1.35,
+  normal: 1.5,
+} as const;
+
+export const LetterSpacing = {
+  /** Default body text */
+  normal: "0",
+  /** Section header uppercase labels */
+  wide: "0.05em",
+} as const;


### PR DESCRIPTION
## Summary

- Populates \`@hali/design-system\` with canonical token values extracted from the v0 reference artifacts in \`docs/reference-ui/v0/\`.
- Produces the retroactive **mobile token visual audit** required as the #189 sub-task at \`docs/reference-ui/v0/mobile-token-visual-audit.md\`.
- Documents canonical vs reference-only boundaries in the package README so Phase 1.5 synthesis and future web consumers know what they can rely on.

## Tokens added

| File | Contents |
|---|---|
| \`colors.ts\` | \`CitizenColors\` + \`InstitutionColors\` (raw OKLCH strings from each surface's \`globals.css\`) plus \`ConditionBadgeClassNames\` derived from v0 \`issue-card.tsx\` (the authoritative condition → palette mapping) |
| \`spacing.ts\` | 4px-base scale aligned with citizen mobile theme (xs..6xl as rem strings) |
| \`radius.ts\` | Default \`0.75rem\` (v0 \`--radius\`) + \`sm\`/\`md\` derived per shadcn/ui |
| \`typography.ts\` | Geist family + weights + size scale (appName..micro) + line-height + letter-spacing |
| \`index.ts\` | Re-exports + \`DesignSystemVersion\` sentinel |

## Retroactive audit

\`docs/reference-ui/v0/mobile-token-visual-audit.md\` covers every token group with:

1. Extraction source declaration
2. Screen-level citations
3. **8 assumption flags** (faintForeground, destructive hue, cardTitle 15dp, bodySmall 13dp, spacing scale steps, smaller radii, shadow tokens, animation timing)
4. Condition-badge colour map evidence
5. **4 cross-surface flags** requiring Phase 1.5 decisions (primary color, foreground color, destructive hue, sidebar usage)
6. Phase B risk summary

## Scope discipline

- ❌ No Tailwind config — one per app, tokens imported in.
- ❌ No React components — Phase 1.5 synthesis gates those.
- ❌ No React Native tokens — stack rule forbids mobile consumption.
- ❌ The v0 component primitives (buttons, inputs, shells) are not imported; they are **reference-only** and the decision on canonical component patterns is Phase 1.5's.
- Untracked \`docs/audits/\` + \`hali_execution_issues_created.md\` remain out-of-scope — they are ephemeral artifacts of the issue-creation script.

## Test plan

- [x] Design-system TypeScript sources compile cleanly against the shared \`tsconfig.base.json\`.
- [x] Audit document is complete with source declaration, citations, assumptions, cross-surface flags, and risk summary per the brief.
- [x] README distinguishes canonical vs reference-only layers.
- [x] \`dotnet build\` + \`dotnet test\` unaffected (no C# change).
- [x] CI must pass.

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)