### PR TITLE
test: shared institution-auth integration test helper (#241)

### DIFF
--- a/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
+++ b/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
@@ -36,11 +36,12 @@ namespace Hali.Tests.Integration.Helpers;
 ///     institution_admin behaviour under the cookie session surface.
 ///
 ///   * <see cref="CreateBearerClient"/> — mints a JWT against
-///     <see cref="TestConstants"/>. The bearer path is a real auth path:
-///     <c>InstitutionSessionMiddleware</c> short-circuits requests that
-///     carry a Bearer header, falling through to JwtBearer validation.
-///     Use for tests that explicitly assert bearer-flow behaviour (e.g.
-///     "bearer JWT cannot satisfy step-up", citizen-role 403 checks).
+///     <see cref="Infrastructure.TestConstants"/>. The bearer path is
+///     a real auth path: <c>InstitutionSessionMiddleware</c>
+///     short-circuits requests that carry a Bearer header, falling
+///     through to JwtBearer validation. Use for tests that explicitly
+///     assert bearer-flow behaviour (e.g. "bearer JWT cannot satisfy
+///     step-up", citizen-role 403 checks).
 ///
 /// Every account / institution created by the helper uses UUID-suffixed
 /// identifiers so concurrent test runs cannot collide on unique-email
@@ -75,7 +76,7 @@ public static class InstitutionAuthHelper
     ///   5. Optionally drive TOTP enroll + confirm so the session carries
     ///      a fresh <c>step_up_verified_at</c> timestamp.
     /// </summary>
-    /// <param name="factory">The shared <see cref="HaliWebApplicationFactory"/>.</param>
+    /// <param name="factory">The shared <see cref="Infrastructure.HaliWebApplicationFactory"/>.</param>
     /// <param name="role">Either <c>"institution"</c> or <c>"institution_admin"</c>.
     ///     Determines the account's <c>IsInstitutionAdmin</c> flag, which
     ///     controls the role snapshotted onto the session row.</param>
@@ -355,9 +356,17 @@ RETURNING id", conn);
 /// <see cref="InstitutionAuthHelper.CreateSessionAsync"/>. Holds the
 /// HttpClient plus the plaintext CSRF token tests need to echo into the
 /// X-CSRF-Token header for every write verb.
+///
+/// Implements <see cref="IDisposable"/> so test call sites can write
+/// <c>using var session = await InstitutionAuthHelper.CreateSessionAsync(...)</c>
+/// and have the underlying HttpClient disposed with the test's scope —
+/// the old JWT-minted pattern used <c>using var client = ...</c>, and
+/// this keeps the same deterministic cleanup contract.
 /// </summary>
-public sealed class InstitutionAuthSession
+public sealed class InstitutionAuthSession : IDisposable
 {
+    private bool _disposed;
+
     public HttpClient Client { get; }
     public Guid AccountId { get; }
     public Guid InstitutionId { get; }
@@ -376,5 +385,12 @@ public sealed class InstitutionAuthSession
         InstitutionId = institutionId;
         CsrfPlaintext = csrfPlaintext;
         SessionPlaintext = sessionPlaintext;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        Client.Dispose();
     }
 }

--- a/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
+++ b/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
@@ -1,0 +1,380 @@
+using System;
+using System.Collections.Generic;
+using System.IdentityModel.Tokens.Jwt;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Security.Claims;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Auth;
+using Hali.Domain.Entities.Auth;
+using Hali.Domain.Enums;
+using Hali.Infrastructure.Data.Auth;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.IdentityModel.Tokens;
+using Npgsql;
+using Xunit;
+
+namespace Hali.Tests.Integration.Helpers;
+
+/// <summary>
+/// Shared auth helper for Phase 2 integration tests (#241).
+///
+/// Phase 2 test classes previously minted JWTs directly, duplicating the
+/// same claim-shape across multiple files and bypassing the institution
+/// session middleware entirely. This helper centralises both auth paths
+/// institution surfaces actually serve in production:
+///
+///   * <see cref="CreateSessionAsync"/> — drives the REAL magic-link
+///     (+ optional TOTP step-up) flow end-to-end and returns a cookie-
+///     bearing HttpClient. Use for tests that exercise institution /
+///     institution_admin behaviour under the cookie session surface.
+///
+///   * <see cref="CreateBearerClient"/> — mints a JWT against
+///     <see cref="TestConstants"/>. The bearer path is a real auth path:
+///     <c>InstitutionSessionMiddleware</c> short-circuits requests that
+///     carry a Bearer header, falling through to JwtBearer validation.
+///     Use for tests that explicitly assert bearer-flow behaviour (e.g.
+///     "bearer JWT cannot satisfy step-up", citizen-role 403 checks).
+///
+/// Every account / institution created by the helper uses UUID-suffixed
+/// identifiers so concurrent test runs cannot collide on unique-email
+/// constraints. Cleanup relies on the existing <c>CleanTablesAsync</c>
+/// TRUNCATE pattern — the helper writes no state that survives a test.
+/// </summary>
+public static class InstitutionAuthHelper
+{
+    private static readonly JsonSerializerOptions s_json = new(JsonSerializerDefaults.Web);
+
+    // Cookie names match InstitutionAuthOptions defaults — kept as
+    // constants here so callers (and this helper) never have to guess.
+    public const string SessionCookieName = "hali_institution_session";
+    public const string CsrfCookieName = "hali_institution_csrf";
+
+    /// <summary>
+    /// Authenticates an institution user via the REAL magic-link flow
+    /// and returns a session-bearing <see cref="InstitutionAuthSession"/>.
+    ///
+    /// Flow:
+    ///   1. Ensure an institution exists (create a fresh one if not given).
+    ///   2. Create an institution account with the requested role flag,
+    ///      using a unique email so parallel runs cannot collide.
+    ///   3. Issue a magic link via <see cref="IMagicLinkService"/> and
+    ///      bind it to the account id (same deterministic-tie pattern the
+    ///      existing tests use — MagicLinkService.IssueAsync does the
+    ///      email→account join itself, but this helper re-asserts it
+    ///      defensively so the test is independent of the lookup order).
+    ///   4. POST /v1/auth/institution/magic-link/verify to receive the
+    ///      session + CSRF cookies. The cookie-aware HttpClient retains
+    ///      them across subsequent requests.
+    ///   5. Optionally drive TOTP enroll + confirm so the session carries
+    ///      a fresh <c>step_up_verified_at</c> timestamp.
+    /// </summary>
+    /// <param name="factory">The shared <see cref="HaliWebApplicationFactory"/>.</param>
+    /// <param name="role">Either <c>"institution"</c> or <c>"institution_admin"</c>.
+    ///     Determines the account's <c>IsInstitutionAdmin</c> flag, which
+    ///     controls the role snapshotted onto the session row.</param>
+    /// <param name="institutionId">Pre-existing institution id to tie the
+    ///     account to. When null, the helper seeds a new one.</param>
+    /// <param name="withStepUp">When true, the helper enrols TOTP and
+    ///     confirms the current code so <c>step_up_verified_at</c> is
+    ///     fresh. Required by privileged write endpoints.</param>
+    public static async Task<InstitutionAuthSession> CreateSessionAsync(
+        Infrastructure.HaliWebApplicationFactory factory,
+        string role = "institution",
+        Guid? institutionId = null,
+        bool withStepUp = false,
+        CancellationToken ct = default)
+    {
+        if (role is not ("institution" or "institution_admin"))
+        {
+            throw new ArgumentException(
+                $"Role must be 'institution' or 'institution_admin'; got '{role}'. " +
+                "Citizen callers should use CreateBearerClient.",
+                nameof(role));
+        }
+
+        Guid actualInstitutionId = institutionId ?? await CreateInstitutionAsync(ct);
+        Guid accountId = await CreateInstitutionAccountAsync(
+            factory, actualInstitutionId,
+            isAdmin: role == "institution_admin", ct);
+
+        string email = await GetAccountEmailAsync(factory, accountId, ct);
+
+        string plaintextToken;
+        using (var scope = factory.Services.CreateScope())
+        {
+            var magic = scope.ServiceProvider.GetRequiredService<IMagicLinkService>();
+            MagicLinkIssued issued = await magic.IssueAsync(email, ct);
+            plaintextToken = issued.PlaintextToken;
+
+            // Defensive re-bind: ensure the magic-link row points at the
+            // account we just created. MagicLinkService.IssueAsync does
+            // this via the email→account join, but the test wants a
+            // deterministic tie — mirrors the pattern in
+            // InstitutionAdminIntegrationTests.LogInAdminWithStepUpAsync.
+            await using var conn = new NpgsqlConnection(Infrastructure.TestConstants.ConnectionString);
+            await conn.OpenAsync(ct);
+            await using var cmd = new NpgsqlCommand(
+                "UPDATE magic_link_tokens SET account_id = @aid WHERE token_hash = @hash", conn);
+            cmd.Parameters.AddWithValue("aid", accountId);
+            cmd.Parameters.AddWithValue("hash", magic.HashToken(plaintextToken));
+            await cmd.ExecuteNonQueryAsync(ct);
+        }
+
+        var client = factory.CreateClient();
+        var verify = await client.PostAsJsonAsync(
+            "/v1/auth/institution/magic-link/verify",
+            new { token = plaintextToken }, s_json, ct);
+        verify.EnsureSuccessStatusCode();
+
+        string? csrf = ExtractCookieValue(verify, CsrfCookieName);
+        string? session = ExtractCookieValue(verify, SessionCookieName);
+        Assert.False(string.IsNullOrEmpty(csrf), "CSRF cookie must be set on magic-link verify");
+        Assert.False(string.IsNullOrEmpty(session), "Session cookie must be set on magic-link verify");
+
+        if (withStepUp)
+        {
+            await CompleteTotpStepUpAsync(factory, client, csrf!, accountId, ct);
+        }
+
+        return new InstitutionAuthSession(
+            client, accountId, actualInstitutionId, csrf!, session!);
+    }
+
+    /// <summary>
+    /// Mints a bearer JWT for tests that explicitly exercise the
+    /// Bearer-authentication path. The token is validated by the real
+    /// <c>TokenValidationParameters</c> configured in <c>Program.cs</c> —
+    /// <see cref="Infrastructure.TestConstants"/> values are mirrored
+    /// into the host's config by <c>HaliWebApplicationFactory</c>.
+    ///
+    /// Not a backdoor: bearer-authed institution JWTs cannot satisfy the
+    /// step-up gate (that lives under the cookie + TOTP surface) and
+    /// cannot set the institution-session middleware's per-request
+    /// <c>WebSession</c> context. Tests that want a full cookie session
+    /// should call <see cref="CreateSessionAsync"/> instead.
+    /// </summary>
+    public static HttpClient CreateBearerClient(
+        Infrastructure.HaliWebApplicationFactory factory,
+        Guid accountId,
+        string role,
+        Guid? institutionId = null)
+    {
+        string jwt = MintJwt(accountId, role, institutionId);
+        var client = factory.CreateClient();
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
+        return client;
+    }
+
+    /// <summary>
+    /// POSTs with the double-submit CSRF header required by every
+    /// cookie-scoped write endpoint. Mirrors the existing per-test
+    /// <c>PostWithCsrfAsync</c> helpers so call sites can switch without
+    /// changing behaviour.
+    /// </summary>
+    public static async Task<HttpResponseMessage> PostWithCsrfAsync(
+        InstitutionAuthSession session, string path, object? body = null,
+        CancellationToken ct = default)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Post, path);
+        req.Headers.Add("X-CSRF-Token", session.CsrfPlaintext);
+        req.Content = body is null
+            ? new StringContent(string.Empty, Encoding.UTF8, "application/json")
+            : JsonContent.Create(body, options: s_json);
+        return await session.Client.SendAsync(req, ct);
+    }
+
+    /// <summary>PUT with the double-submit CSRF header.</summary>
+    public static async Task<HttpResponseMessage> PutWithCsrfAsync(
+        InstitutionAuthSession session, string path, object body,
+        CancellationToken ct = default)
+    {
+        using var req = new HttpRequestMessage(HttpMethod.Put, path);
+        req.Headers.Add("X-CSRF-Token", session.CsrfPlaintext);
+        req.Content = JsonContent.Create(body, options: s_json);
+        return await session.Client.SendAsync(req, ct);
+    }
+
+    // ======================================================================
+    // Internals
+    // ======================================================================
+
+    private static async Task<Guid> CreateInstitutionAsync(CancellationToken ct)
+    {
+        await using var conn = new NpgsqlConnection(Infrastructure.TestConstants.ConnectionString);
+        await conn.OpenAsync(ct);
+        await using var cmd = new NpgsqlCommand(@"
+INSERT INTO institutions (id, name, type, is_verified, created_at)
+VALUES (gen_random_uuid(), @name, 'utility', true, now())
+RETURNING id", conn);
+        cmd.Parameters.AddWithValue("name", $"Helper Test Inst {Guid.NewGuid():N}");
+        return (Guid)(await cmd.ExecuteScalarAsync(ct))!;
+    }
+
+    private static async Task<Guid> CreateInstitutionAccountAsync(
+        Infrastructure.HaliWebApplicationFactory factory,
+        Guid institutionId,
+        bool isAdmin,
+        CancellationToken ct)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        // UUID-suffixed email guarantees uniqueness — the accounts table
+        // enforces uq_accounts_email, so a shared static email would fail
+        // on the second invocation within the same test (or across tests
+        // when CleanTablesAsync has not run).
+        string email = $"helper-{(isAdmin ? "admin" : "user")}-{Guid.NewGuid():N}@example.com";
+        var account = new Account
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            IsEmailVerified = true,
+            AccountType = AccountType.InstitutionUser,
+            InstitutionId = institutionId,
+            IsInstitutionAdmin = isAdmin,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Accounts.Add(account);
+        await db.SaveChangesAsync(ct);
+        return account.Id;
+    }
+
+    private static async Task<string> GetAccountEmailAsync(
+        Infrastructure.HaliWebApplicationFactory factory,
+        Guid accountId,
+        CancellationToken ct)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        Account account = await db.Accounts.FirstAsync(a => a.Id == accountId, ct);
+        return account.Email!;
+    }
+
+    private static async Task CompleteTotpStepUpAsync(
+        Infrastructure.HaliWebApplicationFactory factory,
+        HttpClient client,
+        string csrfPlaintext,
+        Guid accountId,
+        CancellationToken ct)
+    {
+        // Enroll TOTP. First-time enrollment returns the encoded secret
+        // via the otpauth URI, but the encrypted copy is also persisted
+        // to totp_secrets — we read it back from the DB rather than
+        // parsing the URI.
+        using (var enrollReq = new HttpRequestMessage(HttpMethod.Post,
+            "/v1/auth/institution/totp/enroll"))
+        {
+            enrollReq.Headers.Add("X-CSRF-Token", csrfPlaintext);
+            enrollReq.Content = new StringContent(string.Empty, Encoding.UTF8, "application/json");
+            var enroll = await client.SendAsync(enrollReq, ct);
+            enroll.EnsureSuccessStatusCode();
+        }
+
+        string currentCode = await ComputeCurrentTotpCodeAsync(factory, accountId, ct);
+
+        using var confirmReq = new HttpRequestMessage(HttpMethod.Post,
+            "/v1/auth/institution/totp/confirm");
+        confirmReq.Headers.Add("X-CSRF-Token", csrfPlaintext);
+        confirmReq.Content = JsonContent.Create(new { code = currentCode }, options: s_json);
+        var confirm = await client.SendAsync(confirmReq, ct);
+        confirm.EnsureSuccessStatusCode();
+    }
+
+    private static async Task<string> ComputeCurrentTotpCodeAsync(
+        Infrastructure.HaliWebApplicationFactory factory,
+        Guid accountId,
+        CancellationToken ct)
+    {
+        using var scope = factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+        TotpSecret secret = await db.TotpSecrets.FirstAsync(s => s.AccountId == accountId, ct);
+
+        // Purpose string must match TotpService.DataProtectionPurpose —
+        // duplicated deliberately because the const is private. If that
+        // purpose ever changes, this helper and TotpService must move
+        // together.
+        var protector = scope.ServiceProvider
+            .GetRequiredService<IDataProtectionProvider>()
+            .CreateProtector("hali-institution-totp-secrets");
+        string base32 = protector.Unprotect(secret.SecretEncrypted);
+        byte[] raw = TotpService.DecodeBase32(base32);
+        long step = TotpService.GetCurrentStep(DateTimeOffset.UtcNow);
+        return TotpService.ComputeCode(raw, step);
+    }
+
+    private static string? ExtractCookieValue(HttpResponseMessage response, string cookieName)
+    {
+        if (!response.Headers.TryGetValues("Set-Cookie", out var cookies))
+        {
+            return null;
+        }
+        string prefix = cookieName + "=";
+        foreach (var raw in cookies)
+        {
+            if (!raw.StartsWith(prefix, StringComparison.Ordinal)) continue;
+            int semicolon = raw.IndexOf(';');
+            return semicolon < 0 ? raw[prefix.Length..] : raw[prefix.Length..semicolon];
+        }
+        return null;
+    }
+
+    private static string MintJwt(Guid accountId, string role, Guid? institutionId)
+    {
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(Infrastructure.TestConstants.JwtSecret));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, accountId.ToString()),
+            new(ClaimTypes.Role, role),
+        };
+        if (institutionId.HasValue)
+        {
+            claims.Add(new Claim("institution_id", institutionId.Value.ToString()));
+        }
+        var token = new JwtSecurityToken(
+            issuer: Infrastructure.TestConstants.JwtIssuer,
+            audience: Infrastructure.TestConstants.JwtAudience,
+            claims: claims,
+            notBefore: DateTime.UtcNow,
+            expires: DateTime.UtcNow.AddMinutes(10),
+            signingCredentials: creds);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+}
+
+/// <summary>
+/// The authenticated state produced by
+/// <see cref="InstitutionAuthHelper.CreateSessionAsync"/>. Holds the
+/// HttpClient plus the plaintext CSRF token tests need to echo into the
+/// X-CSRF-Token header for every write verb.
+/// </summary>
+public sealed class InstitutionAuthSession
+{
+    public HttpClient Client { get; }
+    public Guid AccountId { get; }
+    public Guid InstitutionId { get; }
+    public string CsrfPlaintext { get; }
+    public string SessionPlaintext { get; }
+
+    internal InstitutionAuthSession(
+        HttpClient client,
+        Guid accountId,
+        Guid institutionId,
+        string csrfPlaintext,
+        string sessionPlaintext)
+    {
+        Client = client;
+        AccountId = accountId;
+        InstitutionId = institutionId;
+        CsrfPlaintext = csrfPlaintext;
+        SessionPlaintext = sessionPlaintext;
+    }
+}

--- a/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelperTests.cs
+++ b/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelperTests.cs
@@ -27,21 +27,23 @@ public sealed class InstitutionAuthHelperTests : IntegrationTestBase
         // Primary smoke test. Drives the full magic-link + verify path:
         // creates a fresh institution + institution account, issues a
         // magic link, POSTs to /v1/auth/institution/magic-link/verify,
-        // and returns a cookie-bearing HttpClient. A 200-class response
-        // from /v1/institution/overview proves:
+        // and returns a cookie-bearing HttpClient. A 200 OK from
+        // /v1/institution/overview proves:
         //   * The session cookie was set on the response
         //   * The InstitutionSessionMiddleware resolved it successfully
         //   * The claims principal the middleware built carries both
         //     role="institution" and the institution_id claim
-        // Any break in the helper's DB seeding, magic-link binding, or
-        // cookie capture surfaces here.
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        //   * The underlying read path works end-to-end
+        // Asserting an exact 200 (not just "not 401/403") catches the
+        // degenerate cases where the controller returns 404 / 500 due
+        // to a wiring break elsewhere — a weaker assertion would let
+        // those silently mask as "passes".
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution");
 
         var response = await session.Client.GetAsync("/v1/institution/overview");
 
-        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
-        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.False(string.IsNullOrEmpty(session.CsrfPlaintext),
             "Helper must surface the plaintext CSRF token for write-verb tests.");
         Assert.False(string.IsNullOrEmpty(session.SessionPlaintext),
@@ -60,7 +62,7 @@ public sealed class InstitutionAuthHelperTests : IntegrationTestBase
         // proves both. The check is narrow — we do not assert on the
         // invite-id body beyond "parseable guid" because the shape of
         // the response is owned by #196, not by #241.
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
 
         var response = await InstitutionAuthHelper.PostWithCsrfAsync(
@@ -77,16 +79,18 @@ public sealed class InstitutionAuthHelperTests : IntegrationTestBase
     public async Task InstitutionAuthHelper_BearerClient_AuthenticatesWithMintedJwt()
     {
         // Bearer-path smoke test. A minted institution JWT must reach
-        // InstitutionController.Overview without being rejected by the
-        // JwtBearer validator. 401 here would indicate a drift between
+        // InstitutionController.Overview and return 200 OK. Anything
+        // other than 200 indicates a drift between
         // TestConstants.JwtIssuer/JwtAudience/JwtSecret and the values
         // Program.cs binds — which is exactly the kind of regression
-        // a centralised helper is supposed to catch.
+        // a centralised helper is supposed to catch. (The bare
+        // institution has no jurisdiction, so /overview naturally
+        // returns an empty summary + zero-length areas, still 200.)
         using var client = InstitutionAuthHelper.CreateBearerClient(
             Factory, Guid.NewGuid(), role: "institution", institutionId: Guid.NewGuid());
 
         var response = await client.GetAsync("/v1/institution/overview");
 
-        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
     }
 }

--- a/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelperTests.cs
+++ b/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelperTests.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Net;
+using System.Threading.Tasks;
+using Hali.Tests.Integration.Infrastructure;
+using Xunit;
+
+namespace Hali.Tests.Integration.Helpers;
+
+/// <summary>
+/// Smoke tests for <see cref="InstitutionAuthHelper"/> itself (#241).
+///
+/// These tests exercise the helper end-to-end against the real API so
+/// a regression in the magic-link / TOTP flow or in the helper's cookie
+/// extraction fails loudly here rather than silently masking as a
+/// failure in one of the Phase 2 test classes that depend on it.
+/// </summary>
+[Collection("Integration")]
+[Trait("Category", "Integration")]
+public sealed class InstitutionAuthHelperTests : IntegrationTestBase
+{
+    public InstitutionAuthHelperTests(HaliWebApplicationFactory factory)
+        : base(factory) { }
+
+    [Fact]
+    public async Task InstitutionAuthHelper_ProducesValidSession_ThroughRealAuthFlow()
+    {
+        // Primary smoke test. Drives the full magic-link + verify path:
+        // creates a fresh institution + institution account, issues a
+        // magic link, POSTs to /v1/auth/institution/magic-link/verify,
+        // and returns a cookie-bearing HttpClient. A 200-class response
+        // from /v1/institution/overview proves:
+        //   * The session cookie was set on the response
+        //   * The InstitutionSessionMiddleware resolved it successfully
+        //   * The claims principal the middleware built carries both
+        //     role="institution" and the institution_id claim
+        // Any break in the helper's DB seeding, magic-link binding, or
+        // cookie capture surfaces here.
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution");
+
+        var response = await session.Client.GetAsync("/v1/institution/overview");
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+        Assert.NotEqual(HttpStatusCode.Forbidden, response.StatusCode);
+        Assert.False(string.IsNullOrEmpty(session.CsrfPlaintext),
+            "Helper must surface the plaintext CSRF token for write-verb tests.");
+        Assert.False(string.IsNullOrEmpty(session.SessionPlaintext),
+            "Helper must surface the plaintext session cookie value.");
+        Assert.NotEqual(Guid.Empty, session.AccountId);
+        Assert.NotEqual(Guid.Empty, session.InstitutionId);
+    }
+
+    [Fact]
+    public async Task InstitutionAuthHelper_WithStepUp_StampsStepUpOnSession()
+    {
+        // Session with step-up must satisfy the institution_admin write
+        // endpoints. /v1/institution-admin/users/invite is the narrowest
+        // write path: it requires (a) institution_admin role on the
+        // session, (b) a fresh step_up_verified_at. A 200 OK here
+        // proves both. The check is narrow — we do not assert on the
+        // invite-id body beyond "parseable guid" because the shape of
+        // the response is owned by #196, not by #241.
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", withStepUp: true);
+
+        var response = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/institution-admin/users/invite", new
+            {
+                email = $"smoke-invite-{Guid.NewGuid():N}@example.com",
+                role = "institution_user",
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task InstitutionAuthHelper_BearerClient_AuthenticatesWithMintedJwt()
+    {
+        // Bearer-path smoke test. A minted institution JWT must reach
+        // InstitutionController.Overview without being rejected by the
+        // JwtBearer validator. 401 here would indicate a drift between
+        // TestConstants.JwtIssuer/JwtAudience/JwtSecret and the values
+        // Program.cs binds — which is exactly the kind of regression
+        // a centralised helper is supposed to catch.
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "institution", institutionId: Guid.NewGuid());
+
+        var response = await client.GetAsync("/v1/institution/overview");
+
+        Assert.NotEqual(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+}

--- a/tests/Hali.Tests.Integration/InstitutionAdmin/InstitutionAdminIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/InstitutionAdmin/InstitutionAdminIntegrationTests.cs
@@ -281,11 +281,15 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     public async Task ChangeRole_CrossInstitutionTarget_Returns404()
     {
         // Helper logs the admin into institution A; member B lives in a
-        // separately seeded institution B.
+        // separately seeded institution B. SeedInstitutionWithMemberIdAsync
+        // (not SeedInstitutionWithMemberAsync) is used so memberB is the
+        // account Guid — the route has a `{userId:guid}` constraint and
+        // would reject a non-Guid segment with an empty-bodied 404 from
+        // the router, masking the controller's NotFoundException envelope.
         var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
-        var (_, memberB) = await SeedInstitutionWithMemberAsync(
-            institutionName: "Other", memberEmailPrefix: "b");
+        var (_, memberB, _) = await SeedInstitutionWithMemberIdAsync(
+            institutionName: "Other");
 
         var resp = await InstitutionAuthHelper.PutWithCsrfAsync(
             session, $"/v1/institution-admin/users/{memberB}/role", new

--- a/tests/Hali.Tests.Integration/InstitutionAdmin/InstitutionAdminIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/InstitutionAdmin/InstitutionAdminIntegrationTests.cs
@@ -158,7 +158,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     {
         // Helper creates the institution + admin; drives magic-link verify
         // and TOTP enroll + confirm so step_up_verified_at is fresh.
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
 
         var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
@@ -176,7 +176,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task InviteUser_ElevationAttempt_Returns403ElevationGuard()
     {
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
 
         var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
@@ -198,7 +198,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
         // then log in an admin in the same institution via the helper
         // and attempt to invite using that member's email.
         var (institutionId, memberEmail) = await SeedInstitutionWithMemberAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", institutionId: institutionId,
             withStepUp: true);
 
@@ -222,7 +222,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     public async Task ChangeRole_ElevationAttempt_Returns403()
     {
         var (institutionId, memberId, _) = await SeedInstitutionWithMemberIdAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", institutionId: institutionId,
             withStepUp: true);
 
@@ -242,7 +242,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     {
         // Helper creates the single admin in a fresh institution; trying
         // to demote that admin (self) must be blocked to prevent lockout.
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
 
         var resp = await InstitutionAuthHelper.PutWithCsrfAsync(
@@ -261,7 +261,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     {
         // Two admins in the institution: the helper's (session.AccountId)
         // + a seeded second admin (adminB). Demoting adminB is allowed.
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
         Guid adminB = await SeedSecondAdminAsync(session.InstitutionId);
 
@@ -286,7 +286,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
         // account Guid — the route has a `{userId:guid}` constraint and
         // would reject a non-Guid segment with an empty-bodied 404 from
         // the router, masking the controller's NotFoundException envelope.
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution_admin", withStepUp: true);
         var (_, memberB, _) = await SeedInstitutionWithMemberIdAsync(
             institutionName: "Other");

--- a/tests/Hali.Tests.Integration/InstitutionAdmin/InstitutionAdminIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/InstitutionAdmin/InstitutionAdminIntegrationTests.cs
@@ -1,23 +1,17 @@
 using System;
-using System.IdentityModel.Tokens.Jwt;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Security.Claims;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Hali.Application.Auth;
 using Hali.Domain.Entities.Auth;
 using Hali.Domain.Enums;
 using Hali.Infrastructure.Data.Auth;
+using Hali.Tests.Integration.Helpers;
 using Hali.Tests.Integration.Infrastructure;
-using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
-using Microsoft.IdentityModel.Tokens;
 using Npgsql;
 using Xunit;
 
@@ -29,6 +23,16 @@ namespace Hali.Tests.Integration.InstitutionAdmin;
 /// Covers happy paths, forbidden-path (institution-member + citizen),
 /// cross-institution isolation, step-up gating on writes, role
 /// elevation guard, and the last-admin-demote guard.
+///
+/// #241 — every auth setup goes through <see cref="InstitutionAuthHelper"/>.
+/// Tests that exercise the bearer boundary (read endpoints under
+/// [Authorize(Roles = "institution_admin")], citizen 403 checks, and
+/// the "bearer-JWT cannot satisfy step-up" assertion) keep the bearer
+/// path via <see cref="InstitutionAuthHelper.CreateBearerClient"/>
+/// because that boundary IS the thing under test. Tests that require
+/// a fresh step-up stamp use
+/// <see cref="InstitutionAuthHelper.CreateSessionAsync"/> which drives
+/// the real magic-link + TOTP-confirm flow.
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
@@ -40,14 +44,15 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
         : base(factory) { }
 
     // -----------------------------------------------------------------------
-    // GET /users
+    // GET /users — bearer-JWT auth (reads are not step-up gated)
     // -----------------------------------------------------------------------
 
     [Fact]
     public async Task ListUsers_InstitutionAdmin_ReturnsOwnInstitutionUsers()
     {
         var (institutionId, adminId, memberId) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = CreateBearerClient(adminId, "institution_admin", institutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, adminId, role: "institution_admin", institutionId: institutionId);
 
         var resp = await client.GetAsync("/v1/institution-admin/users");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
@@ -63,7 +68,8 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     public async Task ListUsers_InstitutionMember_Returns403()
     {
         var (institutionId, _, memberId) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = CreateBearerClient(memberId, "institution", institutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, memberId, role: "institution", institutionId: institutionId);
 
         var resp = await client.GetAsync("/v1/institution-admin/users");
         Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
@@ -72,7 +78,8 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task ListUsers_Citizen_Returns403()
     {
-        using var client = CreateBearerClient(Guid.NewGuid(), "citizen", institutionId: null);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "citizen", institutionId: null);
         var resp = await client.GetAsync("/v1/institution-admin/users");
         Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
     }
@@ -85,14 +92,15 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     }
 
     // -----------------------------------------------------------------------
-    // GET /users/{id}
+    // GET /users/{id} — bearer-JWT auth
     // -----------------------------------------------------------------------
 
     [Fact]
     public async Task GetUser_InSameInstitution_ReturnsDetail()
     {
         var (institutionId, adminId, memberId) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = CreateBearerClient(adminId, "institution_admin", institutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, adminId, role: "institution_admin", institutionId: institutionId);
 
         var resp = await client.GetAsync($"/v1/institution-admin/users/{memberId}");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
@@ -108,7 +116,8 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
         var (_, _, memberB) = await SeedInstitutionWithAdminAndMemberAsync(
             institutionName: "Other Institution", emailPrefix: "other");
 
-        using var adminAClient = CreateBearerClient(adminA, "institution_admin", institutionA);
+        using var adminAClient = InstitutionAuthHelper.CreateBearerClient(
+            Factory, adminA, role: "institution_admin", institutionId: institutionA);
         var resp = await adminAClient.GetAsync($"/v1/institution-admin/users/{memberB}");
 
         // 404 (not 403) so admin A cannot probe user IDs from institution B.
@@ -119,7 +128,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     }
 
     // -----------------------------------------------------------------------
-    // POST /users/invite (step-up required)
+    // POST /users/invite — bearer asserts step-up boundary; session drives happy path
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -127,9 +136,11 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     {
         // Bearer-JWT flows cannot satisfy step-up (it lives under the
         // cookie session + TOTP surface). Even an institution_admin
-        // bearer token is rejected on the write endpoint.
+        // bearer token is rejected on the write endpoint. This assertion
+        // IS the thing under test — keep the bearer path.
         var (institutionId, adminId, _) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = CreateBearerClient(adminId, "institution_admin", institutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, adminId, role: "institution_admin", institutionId: institutionId);
 
         var resp = await client.PostAsJsonAsync("/v1/institution-admin/users/invite", new
         {
@@ -145,14 +156,17 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task InviteUser_WithStepUpSession_HappyPath_ReturnsInvite()
     {
-        var (institutionId, adminId, _) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = await LogInAdminWithStepUpAsync(adminId, institutionId);
+        // Helper creates the institution + admin; drives magic-link verify
+        // and TOTP enroll + confirm so step_up_verified_at is fresh.
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", withStepUp: true);
 
-        var resp = await PostWithCsrfAsync(client, "/v1/institution-admin/users/invite", new
-        {
-            email = "newcomer@example.com",
-            role = "institution_user",
-        });
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/institution-admin/users/invite", new
+            {
+                email = $"newcomer-{Guid.NewGuid():N}@example.com",
+                role = "institution_user",
+            });
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.True(Guid.TryParse(body.GetProperty("inviteId").GetString(), out _));
@@ -162,14 +176,15 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task InviteUser_ElevationAttempt_Returns403ElevationGuard()
     {
-        var (institutionId, adminId, _) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = await LogInAdminWithStepUpAsync(adminId, institutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", withStepUp: true);
 
-        var resp = await PostWithCsrfAsync(client, "/v1/institution-admin/users/invite", new
-        {
-            email = "elevated@example.com",
-            role = "institution_admin",
-        });
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/institution-admin/users/invite", new
+            {
+                email = $"elevated-{Guid.NewGuid():N}@example.com",
+                role = "institution_admin",
+            });
         Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal("institution_admin.elevation_requires_approval",
@@ -179,15 +194,20 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task InviteUser_EmailAlreadyInUse_Returns409()
     {
-        var (institutionId, adminId, memberId) = await SeedInstitutionWithAdminAndMemberAsync();
-        string existingEmail = await GetEmailAsync(memberId);
+        // Create institution + a member first so its email is reserved,
+        // then log in an admin in the same institution via the helper
+        // and attempt to invite using that member's email.
+        var (institutionId, memberEmail) = await SeedInstitutionWithMemberAsync();
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", institutionId: institutionId,
+            withStepUp: true);
 
-        using var client = await LogInAdminWithStepUpAsync(adminId, institutionId);
-        var resp = await PostWithCsrfAsync(client, "/v1/institution-admin/users/invite", new
-        {
-            email = existingEmail,
-            role = "institution_user",
-        });
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/institution-admin/users/invite", new
+            {
+                email = memberEmail,
+                role = "institution_user",
+            });
         Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal("institution_admin.email_already_in_use",
@@ -195,19 +215,22 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     }
 
     // -----------------------------------------------------------------------
-    // PUT /users/{id}/role
+    // PUT /users/{id}/role — session + step-up required
     // -----------------------------------------------------------------------
 
     [Fact]
     public async Task ChangeRole_ElevationAttempt_Returns403()
     {
-        var (institutionId, adminId, memberId) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = await LogInAdminWithStepUpAsync(adminId, institutionId);
+        var (institutionId, memberId, _) = await SeedInstitutionWithMemberIdAsync();
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", institutionId: institutionId,
+            withStepUp: true);
 
-        var resp = await PutWithCsrfAsync(client, $"/v1/institution-admin/users/{memberId}/role", new
-        {
-            role = "institution_admin",
-        });
+        var resp = await InstitutionAuthHelper.PutWithCsrfAsync(
+            session, $"/v1/institution-admin/users/{memberId}/role", new
+            {
+                role = "institution_admin",
+            });
         Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal("institution_admin.elevation_requires_approval",
@@ -217,15 +240,16 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task ChangeRole_DemoteLastAdmin_Returns409()
     {
-        // Seed an institution with exactly ONE admin — demoting that
-        // admin (even self) must be blocked to prevent a lockout.
-        var (institutionId, adminId, _) = await SeedInstitutionWithAdminAndMemberAsync();
-        using var client = await LogInAdminWithStepUpAsync(adminId, institutionId);
+        // Helper creates the single admin in a fresh institution; trying
+        // to demote that admin (self) must be blocked to prevent lockout.
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", withStepUp: true);
 
-        var resp = await PutWithCsrfAsync(client, $"/v1/institution-admin/users/{adminId}/role", new
-        {
-            role = "institution_user",
-        });
+        var resp = await InstitutionAuthHelper.PutWithCsrfAsync(
+            session, $"/v1/institution-admin/users/{session.AccountId}/role", new
+            {
+                role = "institution_user",
+            });
         Assert.Equal(HttpStatusCode.Conflict, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal("institution_admin.last_admin_cannot_demote",
@@ -235,15 +259,17 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task ChangeRole_DemoteAdmin_WithTwoAdmins_Succeeds()
     {
-        // With 2 admins present, demoting one is allowed.
-        var (institutionId, adminA, _) = await SeedInstitutionWithAdminAndMemberAsync();
-        var adminB = await SeedSecondAdminAsync(institutionId, "adminB@example.com");
+        // Two admins in the institution: the helper's (session.AccountId)
+        // + a seeded second admin (adminB). Demoting adminB is allowed.
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", withStepUp: true);
+        Guid adminB = await SeedSecondAdminAsync(session.InstitutionId);
 
-        using var client = await LogInAdminWithStepUpAsync(adminA, institutionId);
-        var resp = await PutWithCsrfAsync(client, $"/v1/institution-admin/users/{adminB}/role", new
-        {
-            role = "institution_user",
-        });
+        var resp = await InstitutionAuthHelper.PutWithCsrfAsync(
+            session, $"/v1/institution-admin/users/{adminB}/role", new
+            {
+                role = "institution_user",
+            });
         Assert.Equal(HttpStatusCode.NoContent, resp.StatusCode);
 
         // Confirm the flag was actually flipped.
@@ -254,15 +280,18 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task ChangeRole_CrossInstitutionTarget_Returns404()
     {
-        var (institutionA, adminA, _) = await SeedInstitutionWithAdminAndMemberAsync();
-        var (_, _, memberB) = await SeedInstitutionWithAdminAndMemberAsync(
-            institutionName: "Other", emailPrefix: "b");
+        // Helper logs the admin into institution A; member B lives in a
+        // separately seeded institution B.
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution_admin", withStepUp: true);
+        var (_, memberB) = await SeedInstitutionWithMemberAsync(
+            institutionName: "Other", memberEmailPrefix: "b");
 
-        using var client = await LogInAdminWithStepUpAsync(adminA, institutionA);
-        var resp = await PutWithCsrfAsync(client, $"/v1/institution-admin/users/{memberB}/role", new
-        {
-            role = "institution_user",
-        });
+        var resp = await InstitutionAuthHelper.PutWithCsrfAsync(
+            session, $"/v1/institution-admin/users/{memberB}/role", new
+            {
+                role = "institution_user",
+            });
         Assert.Equal(HttpStatusCode.NotFound, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal("institution_admin.user_not_found",
@@ -270,7 +299,7 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     }
 
     // -----------------------------------------------------------------------
-    // GET /scope
+    // GET /scope — bearer-JWT auth
     // -----------------------------------------------------------------------
 
     [Fact]
@@ -279,7 +308,8 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
         var (institutionId, adminId, _) = await SeedInstitutionWithAdminAndMemberAsync();
         await SeedJurisdictionAsync(institutionId, FakeLocalityLookupRepository.TestLocalityId);
 
-        using var client = CreateBearerClient(adminId, "institution_admin", institutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, adminId, role: "institution_admin", institutionId: institutionId);
         var resp = await client.GetAsync("/v1/institution-admin/scope");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
@@ -289,125 +319,21 @@ public sealed class InstitutionAdminIntegrationTests : IntegrationTestBase
     }
 
     // =======================================================================
-    // Test helpers
+    // Seed helpers
     // =======================================================================
 
-    private string? _csrfPlaintext;
-
-    private async Task<HttpClient> LogInAdminWithStepUpAsync(Guid adminId, Guid institutionId)
-    {
-        // Mint a magic-link + verify + TOTP enroll + TOTP confirm
-        // directly via the services. The end state: an institution-web
-        // session cookie with step_up_verified_at stamped.
-        await EnsureAdminEmailNormalisedAsync(adminId);
-        string email = await GetEmailAsync(adminId);
-
-        using var scope = Factory.Services.CreateScope();
-        var magic = scope.ServiceProvider.GetRequiredService<IMagicLinkService>();
-        MagicLinkIssued issued = await magic.IssueAsync(email, default);
-
-        // Bind the magic link row to the admin's account id via direct
-        // UPDATE — the real flow does this at IssueAsync time via the
-        // email-to-account join, but the test wants a deterministic tie.
-        await using (var conn = new NpgsqlConnection(TestConstants.ConnectionString))
-        {
-            await conn.OpenAsync();
-            await using var cmd = new NpgsqlCommand(
-                "UPDATE magic_link_tokens SET account_id = @aid WHERE token_hash = @hash", conn);
-            cmd.Parameters.AddWithValue("aid", adminId);
-            cmd.Parameters.AddWithValue("hash", magic.HashToken(issued.PlaintextToken));
-            await cmd.ExecuteNonQueryAsync();
-        }
-
-        var client = Factory.CreateClient();
-        var verify = await client.PostAsJsonAsync("/v1/auth/institution/magic-link/verify", new
-        {
-            token = issued.PlaintextToken,
-        });
-        verify.EnsureSuccessStatusCode();
-        _csrfPlaintext = ExtractCookieValue(verify, "hali_institution_csrf");
-
-        // Enroll TOTP and confirm with the current code so the session
-        // carries a fresh step_up_verified_at.
-        var enroll = await PostWithCsrfAsync(client, "/v1/auth/institution/totp/enroll");
-        enroll.EnsureSuccessStatusCode();
-
-        string currentCode = await ComputeCurrentCodeAsync(adminId);
-        var confirm = await PostWithCsrfAsync(client, "/v1/auth/institution/totp/confirm", new
-        {
-            code = currentCode,
-        });
-        confirm.EnsureSuccessStatusCode();
-
-        // The session row was created with role snapshotted from Account.
-        // The seed flagged adminId as IsInstitutionAdmin=true, so role=
-        // "institution_admin" on the session row.
-        return client;
-    }
-
-    private async Task<HttpResponseMessage> PostWithCsrfAsync(HttpClient client, string path, object? body = null)
-    {
-        using var req = new HttpRequestMessage(HttpMethod.Post, path);
-        if (_csrfPlaintext is not null) req.Headers.Add("X-CSRF-Token", _csrfPlaintext);
-        req.Content = body is null
-            ? new StringContent("", Encoding.UTF8, "application/json")
-            : JsonContent.Create(body);
-        return await client.SendAsync(req);
-    }
-
-    private async Task<HttpResponseMessage> PutWithCsrfAsync(HttpClient client, string path, object body)
-    {
-        using var req = new HttpRequestMessage(HttpMethod.Put, path);
-        if (_csrfPlaintext is not null) req.Headers.Add("X-CSRF-Token", _csrfPlaintext);
-        req.Content = JsonContent.Create(body);
-        return await client.SendAsync(req);
-    }
-
-    private static string? ExtractCookieValue(HttpResponseMessage response, string cookieName)
-    {
-        if (!response.Headers.TryGetValues("Set-Cookie", out var cookies)) return null;
-        string prefix = cookieName + "=";
-        foreach (var raw in cookies)
-        {
-            if (!raw.StartsWith(prefix, StringComparison.Ordinal)) continue;
-            int semicolon = raw.IndexOf(';');
-            return semicolon < 0 ? raw[prefix.Length..] : raw[prefix.Length..semicolon];
-        }
-        return null;
-    }
-
-    private async Task<string> ComputeCurrentCodeAsync(Guid accountId)
-    {
-        using var scope = Factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
-        var secret = await db.TotpSecrets.FirstAsync(s => s.AccountId == accountId);
-        var protector = scope.ServiceProvider
-            .GetRequiredService<IDataProtectionProvider>()
-            .CreateProtector("hali-institution-totp-secrets");
-        string base32 = protector.Unprotect(secret.SecretEncrypted);
-        byte[] raw = TotpService.DecodeBase32(base32);
-        long step = TotpService.GetCurrentStep(DateTimeOffset.UtcNow);
-        return TotpService.ComputeCode(raw, step);
-    }
-
-    // ---- Seeding ------------------------------------------------------
-
+    /// <summary>
+    /// Seeds a fresh institution + an admin account + a member account.
+    /// Returned ids are used by tests that authenticate via bearer JWT
+    /// and therefore need control over the account identities on either
+    /// side of the auth boundary.
+    /// </summary>
     private async Task<(Guid institutionId, Guid adminId, Guid memberId)>
         SeedInstitutionWithAdminAndMemberAsync(
             string institutionName = "Test Institution",
             string emailPrefix = "a")
     {
-        Guid institutionId;
-        await using (var conn = new NpgsqlConnection(TestConstants.ConnectionString))
-        {
-            await conn.OpenAsync();
-            await using var cmd = new NpgsqlCommand(@"
-INSERT INTO institutions (id, name, type, is_verified, created_at)
-VALUES (gen_random_uuid(), @name, 'utility', true, now())
-RETURNING id", conn);
-            cmd.Parameters.AddWithValue("name", institutionName);
-            institutionId = (Guid)(await cmd.ExecuteScalarAsync())!;
-        }
+        Guid institutionId = await InsertInstitutionAsync(institutionName);
 
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
@@ -441,14 +367,83 @@ RETURNING id", conn);
         return (institutionId, admin.Id, member.Id);
     }
 
-    private async Task<Guid> SeedSecondAdminAsync(Guid institutionId, string email)
+    /// <summary>
+    /// Seeds an institution + a single member account (no admin — the
+    /// admin comes from <see cref="InstitutionAuthHelper.CreateSessionAsync"/>
+    /// in tests that need a fresh step-up session). Returns both the
+    /// institution id AND the member's email so callers testing the
+    /// "email already in use" path don't need a second DB round-trip.
+    /// </summary>
+    private async Task<(Guid institutionId, string memberEmail)>
+        SeedInstitutionWithMemberAsync(
+            string institutionName = "Test Institution",
+            string memberEmailPrefix = "member")
+    {
+        Guid institutionId = await InsertInstitutionAsync(institutionName);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        var member = new Account
+        {
+            Id = Guid.NewGuid(),
+            Email = $"{memberEmailPrefix}-{Guid.NewGuid():N}@example.com",
+            IsEmailVerified = true,
+            AccountType = AccountType.InstitutionUser,
+            InstitutionId = institutionId,
+            IsInstitutionAdmin = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Accounts.Add(member);
+        await db.SaveChangesAsync();
+
+        return (institutionId, member.Email!);
+    }
+
+    /// <summary>
+    /// Variant of <see cref="SeedInstitutionWithMemberAsync"/> that also
+    /// returns the member account id — callers that need the id to
+    /// construct a role-change URL, not just the email.
+    /// </summary>
+    private async Task<(Guid institutionId, Guid memberId, string memberEmail)>
+        SeedInstitutionWithMemberIdAsync(string institutionName = "Test Institution")
+    {
+        Guid institutionId = await InsertInstitutionAsync(institutionName);
+
+        using var scope = Factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
+
+        var member = new Account
+        {
+            Id = Guid.NewGuid(),
+            Email = $"member-{Guid.NewGuid():N}@example.com",
+            IsEmailVerified = true,
+            AccountType = AccountType.InstitutionUser,
+            InstitutionId = institutionId,
+            IsInstitutionAdmin = false,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+        };
+        db.Accounts.Add(member);
+        await db.SaveChangesAsync();
+
+        return (institutionId, member.Id, member.Email!);
+    }
+
+    /// <summary>
+    /// Seeds an additional admin account in an existing institution so
+    /// the "two admins present, demoting one succeeds" scenario has a
+    /// demotion target that isn't the self-demote last-admin guard.
+    /// </summary>
+    private async Task<Guid> SeedSecondAdminAsync(Guid institutionId)
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
         var account = new Account
         {
             Id = Guid.NewGuid(),
-            Email = $"{Guid.NewGuid():N}-{email}".ToLowerInvariant(),
+            Email = $"admin2-{Guid.NewGuid():N}@example.com",
             IsEmailVerified = true,
             AccountType = AccountType.InstitutionUser,
             InstitutionId = institutionId,
@@ -459,6 +454,18 @@ RETURNING id", conn);
         db.Accounts.Add(account);
         await db.SaveChangesAsync();
         return account.Id;
+    }
+
+    private static async Task<Guid> InsertInstitutionAsync(string name)
+    {
+        await using var conn = new NpgsqlConnection(TestConstants.ConnectionString);
+        await conn.OpenAsync();
+        await using var cmd = new NpgsqlCommand(@"
+INSERT INTO institutions (id, name, type, is_verified, created_at)
+VALUES (gen_random_uuid(), @name, 'utility', true, now())
+RETURNING id", conn);
+        cmd.Parameters.AddWithValue("name", name);
+        return (Guid)(await cmd.ExecuteScalarAsync())!;
     }
 
     private static async Task SeedJurisdictionAsync(Guid institutionId, Guid localityId)
@@ -473,64 +480,11 @@ VALUES (gen_random_uuid(), @instId, @locId, now())", conn);
         await cmd.ExecuteNonQueryAsync();
     }
 
-    private async Task<string> GetEmailAsync(Guid accountId)
-    {
-        using var scope = Factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
-        var account = await db.Accounts.FirstAsync(a => a.Id == accountId);
-        return account.Email!;
-    }
-
     private async Task<string> GetAccountRoleAsync(Guid accountId)
     {
         using var scope = Factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
         var account = await db.Accounts.FirstAsync(a => a.Id == accountId);
         return account.IsInstitutionAdmin ? "institution_admin" : "institution_user";
-    }
-
-    private async Task EnsureAdminEmailNormalisedAsync(Guid accountId)
-    {
-        using var scope = Factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<AuthDbContext>();
-        var account = await db.Accounts.FirstAsync(a => a.Id == accountId);
-        if (account.Email is not null)
-        {
-            account.Email = account.Email.ToLowerInvariant();
-            await db.SaveChangesAsync();
-        }
-    }
-
-    // ---- JWT minting for bearer-auth tests ---------------------------
-
-    private HttpClient CreateBearerClient(Guid accountId, string role, Guid? institutionId)
-    {
-        var jwt = MintJwt(accountId, role, institutionId);
-        var client = Factory.CreateClient();
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", jwt);
-        return client;
-    }
-
-    private static string MintJwt(Guid accountId, string role, Guid? institutionId)
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestConstants.JwtSecret));
-        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var claims = new System.Collections.Generic.List<Claim>
-        {
-            new Claim(JwtRegisteredClaimNames.Sub, accountId.ToString()),
-            new Claim(ClaimTypes.Role, role),
-        };
-        if (institutionId.HasValue)
-        {
-            claims.Add(new Claim("institution_id", institutionId.Value.ToString()));
-        }
-        var token = new JwtSecurityToken(
-            issuer: TestConstants.JwtIssuer,
-            audience: TestConstants.JwtAudience,
-            claims: claims,
-            notBefore: DateTime.UtcNow,
-            expires: DateTime.UtcNow.AddMinutes(10),
-            signingCredentials: creds);
-        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 }

--- a/tests/Hali.Tests.Integration/Institutions/InstitutionReadIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Institutions/InstitutionReadIntegrationTests.cs
@@ -40,7 +40,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Overview_InstitutionRole_ReturnsScopedSummary()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         var resp = await session.Client.GetAsync("/v1/institution/overview");
@@ -81,7 +81,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
         var seedA = await SeedInstitutionWithActiveClusterAsync();
         var seedB = await SeedEmptyInstitutionAsync();
 
-        var sessionB = await InstitutionAuthHelper.CreateSessionAsync(
+        using var sessionB = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seedB.InstitutionId);
         var resp = await sessionB.Client.GetAsync("/v1/institution/signals");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
@@ -95,7 +95,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Signals_List_HappyPath_ReturnsOwnedCluster()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         var resp = await session.Client.GetAsync("/v1/institution/signals");
@@ -111,7 +111,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Signals_InvalidStateFilter_Returns400()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         var resp = await session.Client.GetAsync("/v1/institution/signals?state=not_a_real_state");
@@ -127,7 +127,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Signals_ListPagination_EmitsNextCursorAndHonoursIt()
     {
         var seed = await SeedInstitutionWithClustersAsync(clusterCount: 3);
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         // limit=2 with 3 clusters → expect a next cursor
@@ -154,7 +154,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task SignalDetail_InScope_ReturnsCluster()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         var resp = await session.Client.GetAsync($"/v1/institution/signals/{seed.ClusterId}");
@@ -170,7 +170,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
         var seedA = await SeedInstitutionWithActiveClusterAsync();
         var seedB = await SeedEmptyInstitutionAsync();
 
-        var sessionB = await InstitutionAuthHelper.CreateSessionAsync(
+        using var sessionB = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seedB.InstitutionId);
         var resp = await sessionB.Client.GetAsync($"/v1/institution/signals/{seedA.ClusterId}");
 
@@ -191,7 +191,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Areas_ReturnsInstitutionJurisdictions()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         var resp = await session.Client.GetAsync("/v1/institution/areas");
@@ -212,7 +212,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
         await SeedOfficialPostAsync(seed.InstitutionId, seed.LocalityId, seed.ClusterId, type: "live_update");
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
+        using var session = await InstitutionAuthHelper.CreateSessionAsync(
             Factory, role: "institution", institutionId: seed.InstitutionId);
 
         var resp = await session.Client.GetAsync("/v1/institution/activity");

--- a/tests/Hali.Tests.Integration/Institutions/InstitutionReadIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Institutions/InstitutionReadIntegrationTests.cs
@@ -1,15 +1,11 @@
 using System;
-using System.IdentityModel.Tokens.Jwt;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Http.Json;
-using System.Security.Claims;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Hali.Tests.Integration.Helpers;
 using Hali.Tests.Integration.Infrastructure;
-using Microsoft.IdentityModel.Tokens;
 using Npgsql;
 using Xunit;
 
@@ -20,6 +16,12 @@ namespace Hali.Tests.Integration.Institutions;
 /// endpoints introduced by #195. Each endpoint is exercised on the happy
 /// path AND on the forbidden / cross-institution paths — a deliberate
 /// symmetry the PR quality gates mandate (G4.b).
+///
+/// #241 — auth setup for every institution-scoped call now goes through
+/// <see cref="InstitutionAuthHelper"/> so the tests exercise the real
+/// magic-link + session flow (role="institution") rather than minted
+/// JWTs. Citizen 403 checks keep the bearer path via the helper because
+/// citizens never use magic link.
 /// </summary>
 [Collection("Integration")]
 [Trait("Category", "Integration")]
@@ -38,9 +40,10 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Overview_InstitutionRole_ReturnsScopedSummary()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.GetAsync("/v1/institution/overview");
+        var resp = await session.Client.GetAsync("/v1/institution/overview");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -53,7 +56,8 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     [Fact]
     public async Task Overview_CitizenRole_Returns403()
     {
-        using var citizen = CreateCitizenClient();
+        using var citizen = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "citizen", institutionId: null);
         var resp = await citizen.GetAsync("/v1/institution/overview");
         Assert.Equal(HttpStatusCode.Forbidden, resp.StatusCode);
     }
@@ -77,8 +81,9 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
         var seedA = await SeedInstitutionWithActiveClusterAsync();
         var seedB = await SeedEmptyInstitutionAsync();
 
-        using var clientB = CreateInstitutionClient(seedB.InstitutionId);
-        var resp = await clientB.GetAsync("/v1/institution/signals");
+        var sessionB = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seedB.InstitutionId);
+        var resp = await sessionB.Client.GetAsync("/v1/institution/signals");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -90,9 +95,10 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Signals_List_HappyPath_ReturnsOwnedCluster()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.GetAsync("/v1/institution/signals");
+        var resp = await session.Client.GetAsync("/v1/institution/signals");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -105,9 +111,10 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Signals_InvalidStateFilter_Returns400()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.GetAsync("/v1/institution/signals?state=not_a_real_state");
+        var resp = await session.Client.GetAsync("/v1/institution/signals?state=not_a_real_state");
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -120,10 +127,11 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Signals_ListPagination_EmitsNextCursorAndHonoursIt()
     {
         var seed = await SeedInstitutionWithClustersAsync(clusterCount: 3);
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
         // limit=2 with 3 clusters → expect a next cursor
-        var first = await client.GetAsync("/v1/institution/signals?limit=2");
+        var first = await session.Client.GetAsync("/v1/institution/signals?limit=2");
         Assert.Equal(HttpStatusCode.OK, first.StatusCode);
         var firstBody = await first.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal(2, firstBody.GetProperty("items").GetArrayLength());
@@ -131,7 +139,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
         Assert.False(string.IsNullOrEmpty(cursor));
 
         // Next page returns the third cluster and nulls the cursor
-        var second = await client.GetAsync($"/v1/institution/signals?limit=2&cursor={Uri.EscapeDataString(cursor!)}");
+        var second = await session.Client.GetAsync($"/v1/institution/signals?limit=2&cursor={Uri.EscapeDataString(cursor!)}");
         Assert.Equal(HttpStatusCode.OK, second.StatusCode);
         var secondBody = await second.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal(1, secondBody.GetProperty("items").GetArrayLength());
@@ -146,9 +154,10 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task SignalDetail_InScope_ReturnsCluster()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.GetAsync($"/v1/institution/signals/{seed.ClusterId}");
+        var resp = await session.Client.GetAsync($"/v1/institution/signals/{seed.ClusterId}");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -161,8 +170,9 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
         var seedA = await SeedInstitutionWithActiveClusterAsync();
         var seedB = await SeedEmptyInstitutionAsync();
 
-        using var clientB = CreateInstitutionClient(seedB.InstitutionId);
-        var resp = await clientB.GetAsync($"/v1/institution/signals/{seedA.ClusterId}");
+        var sessionB = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seedB.InstitutionId);
+        var resp = await sessionB.Client.GetAsync($"/v1/institution/signals/{seedA.ClusterId}");
 
         // 404 (not 403) — an institution can never confirm the existence of
         // another institution's cluster via this route.
@@ -181,9 +191,10 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task Areas_ReturnsInstitutionJurisdictions()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.GetAsync("/v1/institution/areas");
+        var resp = await session.Client.GetAsync("/v1/institution/areas");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -201,9 +212,10 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
         await SeedOfficialPostAsync(seed.InstitutionId, seed.LocalityId, seed.ClusterId, type: "live_update");
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.GetAsync("/v1/institution/activity");
+        var resp = await session.Client.GetAsync("/v1/institution/activity");
         Assert.Equal(HttpStatusCode.OK, resp.StatusCode);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -220,18 +232,22 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_LiveUpdate_WithResponseStatus_Persists()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
-        {
-            type = "live_update",
-            category = "electricity",
-            title = "Teams on site",
-            body = "Technicians arrived at the substation.",
-            localityId = seed.LocalityId,
-            relatedClusterId = seed.ClusterId,
-            responseStatus = "teams_on_site",
-        });
+        // The session flow triggers the CSRF middleware on write verbs;
+        // PostWithCsrfAsync echoes the plaintext CSRF into X-CSRF-Token.
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/official-posts", new
+            {
+                type = "live_update",
+                category = "electricity",
+                title = "Teams on site",
+                body = "Technicians arrived at the substation.",
+                localityId = seed.LocalityId,
+                relatedClusterId = seed.ClusterId,
+                responseStatus = "teams_on_site",
+            });
         await AssertCreatedAsync(resp);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -242,18 +258,20 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_NonLiveUpdate_WithResponseStatus_Returns400()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
-        {
-            type = "advisory_public_notice",
-            category = "electricity",
-            title = "Planned upgrade",
-            body = "Informational notice.",
-            localityId = seed.LocalityId,
-            // Invalid: response_status on a non-live_update post
-            responseStatus = "teams_on_site",
-        });
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/official-posts", new
+            {
+                type = "advisory_public_notice",
+                category = "electricity",
+                title = "Planned upgrade",
+                body = "Informational notice.",
+                localityId = seed.LocalityId,
+                // Invalid: response_status on a non-live_update post
+                responseStatus = "teams_on_site",
+            });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal(
@@ -265,17 +283,19 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_ScheduledDisruption_WithSeverity_Persists()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
-        {
-            type = "scheduled_disruption",
-            category = "electricity",
-            title = "Scheduled maintenance",
-            body = "Power off 08:00–12:00.",
-            localityId = seed.LocalityId,
-            severity = "moderate",
-        });
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/official-posts", new
+            {
+                type = "scheduled_disruption",
+                category = "electricity",
+                title = "Scheduled maintenance",
+                body = "Power off 08:00–12:00.",
+                localityId = seed.LocalityId,
+                severity = "moderate",
+            });
         await AssertCreatedAsync(resp);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -286,17 +306,19 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_WithInvalidSeverity_Returns400()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var client = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
-        {
-            type = "scheduled_disruption",
-            category = "electricity",
-            title = "Scheduled maintenance",
-            body = "Power off 08:00–12:00.",
-            localityId = seed.LocalityId,
-            severity = "catastrophic",
-        });
+        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/official-posts", new
+            {
+                type = "scheduled_disruption",
+                category = "electricity",
+                title = "Scheduled maintenance",
+                body = "Power off 08:00–12:00.",
+                localityId = seed.LocalityId,
+                severity = "catastrophic",
+            });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal(
@@ -312,19 +334,21 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task PublicCluster_AfterLiveUpdate_ExposesResponseStatus()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        using var institutionClient = CreateInstitutionClient(seed.InstitutionId);
+        var session = await InstitutionAuthHelper.CreateSessionAsync(
+            Factory, role: "institution", institutionId: seed.InstitutionId);
 
         // Post a live_update carrying a response status
-        var post = await institutionClient.PostAsJsonAsync("/v1/official-posts", new
-        {
-            type = "live_update",
-            category = "electricity",
-            title = "Restoration in progress",
-            body = "Work crews are on site.",
-            localityId = seed.LocalityId,
-            relatedClusterId = seed.ClusterId,
-            responseStatus = "restoration_in_progress",
-        });
+        var post = await InstitutionAuthHelper.PostWithCsrfAsync(
+            session, "/v1/official-posts", new
+            {
+                type = "live_update",
+                category = "electricity",
+                title = "Restoration in progress",
+                body = "Work crews are on site.",
+                localityId = seed.LocalityId,
+                relatedClusterId = seed.ClusterId,
+                responseStatus = "restoration_in_progress",
+            });
         await AssertCreatedAsync(post);
 
         // Public cluster endpoint now exposes the derived responseStatus
@@ -335,7 +359,7 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     }
 
     // -----------------------------------------------------------------------
-    // Seed + auth helpers
+    // Seed helpers (unchanged from pre-#241)
     // -----------------------------------------------------------------------
 
     private sealed record InstitutionSeed(
@@ -464,40 +488,5 @@ VALUES
         }
         var body = await resp.Content.ReadAsStringAsync();
         Assert.Fail($"Expected 201 Created but got {(int)resp.StatusCode} {resp.StatusCode}. Body: {body}");
-    }
-
-    private HttpClient CreateInstitutionClient(Guid institutionId)
-    {
-        var jwt = MintJwt(Guid.NewGuid(), role: "institution", institutionId: institutionId);
-        return CreateAuthenticatedClient(jwt);
-    }
-
-    private HttpClient CreateCitizenClient()
-    {
-        var jwt = MintJwt(Guid.NewGuid(), role: "citizen", institutionId: null);
-        return CreateAuthenticatedClient(jwt);
-    }
-
-    private static string MintJwt(Guid accountId, string role, Guid? institutionId)
-    {
-        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(TestConstants.JwtSecret));
-        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var claims = new System.Collections.Generic.List<Claim>
-        {
-            new Claim(JwtRegisteredClaimNames.Sub, accountId.ToString()),
-            new Claim(ClaimTypes.Role, role),
-        };
-        if (institutionId.HasValue)
-        {
-            claims.Add(new Claim("institution_id", institutionId.Value.ToString()));
-        }
-        var token = new JwtSecurityToken(
-            issuer: TestConstants.JwtIssuer,
-            audience: TestConstants.JwtAudience,
-            claims: claims,
-            notBefore: DateTime.UtcNow,
-            expires: DateTime.UtcNow.AddMinutes(10),
-            signingCredentials: creds);
-        return new JwtSecurityTokenHandler().WriteToken(token);
     }
 }

--- a/tests/Hali.Tests.Integration/Institutions/InstitutionReadIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/Institutions/InstitutionReadIntegrationTests.cs
@@ -228,26 +228,34 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     // /v1/official-posts additions: responseStatus + severity validation
     // -----------------------------------------------------------------------
 
+    // -----------------------------------------------------------------------
+    // /v1/official-posts is NOT covered by InstitutionSessionMiddleware's
+    // path list (see src/Hali.Api/Middleware/InstitutionSessionMiddleware.cs,
+    // which only resolves the institution session cookie on
+    // /v1/institution*, /v1/institution-admin*, and specific auth sub-paths).
+    // It authorises solely via JwtBearer. These tests therefore keep the
+    // bearer path via the helper — switching to session would produce a
+    // 401 even though the helper minted a valid session, because the
+    // middleware never gets a chance to attach the principal.
+    // -----------------------------------------------------------------------
+
     [Fact]
     public async Task OfficialPost_LiveUpdate_WithResponseStatus_Persists()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
-            Factory, role: "institution", institutionId: seed.InstitutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "institution", institutionId: seed.InstitutionId);
 
-        // The session flow triggers the CSRF middleware on write verbs;
-        // PostWithCsrfAsync echoes the plaintext CSRF into X-CSRF-Token.
-        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
-            session, "/v1/official-posts", new
-            {
-                type = "live_update",
-                category = "electricity",
-                title = "Teams on site",
-                body = "Technicians arrived at the substation.",
-                localityId = seed.LocalityId,
-                relatedClusterId = seed.ClusterId,
-                responseStatus = "teams_on_site",
-            });
+        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
+        {
+            type = "live_update",
+            category = "electricity",
+            title = "Teams on site",
+            body = "Technicians arrived at the substation.",
+            localityId = seed.LocalityId,
+            relatedClusterId = seed.ClusterId,
+            responseStatus = "teams_on_site",
+        });
         await AssertCreatedAsync(resp);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -258,20 +266,19 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_NonLiveUpdate_WithResponseStatus_Returns400()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
-            Factory, role: "institution", institutionId: seed.InstitutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
-            session, "/v1/official-posts", new
-            {
-                type = "advisory_public_notice",
-                category = "electricity",
-                title = "Planned upgrade",
-                body = "Informational notice.",
-                localityId = seed.LocalityId,
-                // Invalid: response_status on a non-live_update post
-                responseStatus = "teams_on_site",
-            });
+        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
+        {
+            type = "advisory_public_notice",
+            category = "electricity",
+            title = "Planned upgrade",
+            body = "Informational notice.",
+            localityId = seed.LocalityId,
+            // Invalid: response_status on a non-live_update post
+            responseStatus = "teams_on_site",
+        });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal(
@@ -283,19 +290,18 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_ScheduledDisruption_WithSeverity_Persists()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
-            Factory, role: "institution", institutionId: seed.InstitutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
-            session, "/v1/official-posts", new
-            {
-                type = "scheduled_disruption",
-                category = "electricity",
-                title = "Scheduled maintenance",
-                body = "Power off 08:00–12:00.",
-                localityId = seed.LocalityId,
-                severity = "moderate",
-            });
+        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
+        {
+            type = "scheduled_disruption",
+            category = "electricity",
+            title = "Scheduled maintenance",
+            body = "Power off 08:00–12:00.",
+            localityId = seed.LocalityId,
+            severity = "moderate",
+        });
         await AssertCreatedAsync(resp);
 
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
@@ -306,19 +312,18 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task OfficialPost_WithInvalidSeverity_Returns400()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
-            Factory, role: "institution", institutionId: seed.InstitutionId);
+        using var client = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "institution", institutionId: seed.InstitutionId);
 
-        var resp = await InstitutionAuthHelper.PostWithCsrfAsync(
-            session, "/v1/official-posts", new
-            {
-                type = "scheduled_disruption",
-                category = "electricity",
-                title = "Scheduled maintenance",
-                body = "Power off 08:00–12:00.",
-                localityId = seed.LocalityId,
-                severity = "catastrophic",
-            });
+        var resp = await client.PostAsJsonAsync("/v1/official-posts", new
+        {
+            type = "scheduled_disruption",
+            category = "electricity",
+            title = "Scheduled maintenance",
+            body = "Power off 08:00–12:00.",
+            localityId = seed.LocalityId,
+            severity = "catastrophic",
+        });
         Assert.Equal(HttpStatusCode.BadRequest, resp.StatusCode);
         var body = await resp.Content.ReadFromJsonAsync<JsonElement>(_json);
         Assert.Equal(
@@ -334,21 +339,20 @@ public sealed class InstitutionReadIntegrationTests : IntegrationTestBase
     public async Task PublicCluster_AfterLiveUpdate_ExposesResponseStatus()
     {
         var seed = await SeedInstitutionWithActiveClusterAsync();
-        var session = await InstitutionAuthHelper.CreateSessionAsync(
-            Factory, role: "institution", institutionId: seed.InstitutionId);
+        using var institutionClient = InstitutionAuthHelper.CreateBearerClient(
+            Factory, Guid.NewGuid(), role: "institution", institutionId: seed.InstitutionId);
 
         // Post a live_update carrying a response status
-        var post = await InstitutionAuthHelper.PostWithCsrfAsync(
-            session, "/v1/official-posts", new
-            {
-                type = "live_update",
-                category = "electricity",
-                title = "Restoration in progress",
-                body = "Work crews are on site.",
-                localityId = seed.LocalityId,
-                relatedClusterId = seed.ClusterId,
-                responseStatus = "restoration_in_progress",
-            });
+        var post = await institutionClient.PostAsJsonAsync("/v1/official-posts", new
+        {
+            type = "live_update",
+            category = "electricity",
+            title = "Restoration in progress",
+            body = "Work crews are on site.",
+            localityId = seed.LocalityId,
+            relatedClusterId = seed.ClusterId,
+            responseStatus = "restoration_in_progress",
+        });
         await AssertCreatedAsync(post);
 
         // Public cluster endpoint now exposes the derived responseStatus


### PR DESCRIPTION
## Summary
Closes #241.

Replaces direct JWT minting in the Phase 2 integration tests with `InstitutionAuthHelper`, which authenticates through the real application auth flow. Tests now exercise the actual auth middleware behaviour end-to-end. JWT minting code for Phase 2 test classes lives in exactly one place.

## Auth flow used
**Option C — both paths.** The helper exposes two entry points, matching the two real production auth paths institution surfaces actually serve:

- **`CreateSessionAsync` (primary)** — drives the real magic-link + optional TOTP-step-up flow end-to-end: seeds an institution + institution account, calls `IMagicLinkService.IssueAsync`, POSTs to `/v1/auth/institution/magic-link/verify`, captures session + CSRF cookies, and when `withStepUp: true` runs TOTP enroll + confirm so `step_up_verified_at` is fresh. Used for every cookie-flow test.
- **`CreateBearerClient` (secondary)** — mints a JWT against `TestConstants` for tests that specifically exercise the bearer path. Not a backdoor: `InstitutionSessionMiddleware` intentionally short-circuits requests carrying `Authorization: Bearer` (see its comment at line 70–77 in `src/Hali.Api/Middleware/InstitutionSessionMiddleware.cs`). The bearer path is a production path (citizen mobile, programmatic clients), and the "bearer JWT cannot satisfy step-up" assertion IS what some tests are proving — those tests must remain on bearer. `/v1/official-posts` is also bearer-only because `InstitutionSessionMiddleware`'s path list doesn't cover it.

## Test isolation
Every account / institution / invite email created by the helper uses a UUID suffix (`helper-admin-{Guid.NewGuid():N}@example.com`). The project's existing serial `Collection("Integration")` + `CleanTablesAsync()` TRUNCATE pattern is preserved unchanged — the helper writes no state that needs additional cleanup. `InstitutionAuthSession` implements `IDisposable` so test call sites use `using var session = ...` and the underlying `HttpClient` is disposed with the test's scope.

## Changes
- [x] Created `tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs` (+ `InstitutionAuthSession`, now `IDisposable`)
- [x] Refactored 2 Phase 2 test files — all JWT-minting sites for Phase 2 removed
  - `InstitutionReadIntegrationTests.cs`: 13 tests. Institution-role reads now use `CreateSessionAsync`; citizen 403 uses `CreateBearerClient`. `/v1/official-posts` writes stay on bearer because the session middleware doesn't cover that path (documented inline).
  - `InstitutionAdminIntegrationTests.cs`: 14 tests. 7 bearer via helper (where the bearer boundary is under test); 7 session+step-up via helper.
- [x] Helper smoke tests added (3 tests) — exercise the real path, step-up path, and bearer path. Assertions tightened to exact `HttpStatusCode.OK` so degenerate 404/500 responses cannot silently pass.

## Tests corrected during refactor
None. Every assertion is preserved verbatim. The prior JWT-minting path validated against the SAME `TokenValidationParameters` the helper's `CreateBearerClient` uses, so no hidden test was silently passing on an invalid token shape.

## Test count
- Unit tests:        518 → 518 (unchanged — none added)
- Integration tests: existing suite + 3 new smoke tests for the helper

## Findings outside scope
- The purpose string `"hali-institution-totp-secrets"` is duplicated between `TotpService` (private const) and `InstitutionAuthHelper.ComputeCurrentTotpCodeAsync`. A comment in the helper notes this. Promoting it to a public const on `TotpService` would be a trivial follow-up but sits outside #241's refactor scope.
- `InstitutionAuthIntegrationTests.cs` still has its own `LogInViaMagicLinkAsync` / `LogInAdminWithStepUpAsync` helpers — deliberately left in place because that file is the PRIMARY test of the magic-link + TOTP flow itself, so it needs inline control of the flow rather than depending on the helper it's also supposed to validate.
- **Phase 1 test files still mint their own JWTs.** `ForbiddenRoleEnvelopeTests.cs`, `StandardizedErrorEnvelopeTests.cs`, `FeatureFlagsEndpointTests.cs`, and `HomeIntegrationTests.cs` each have a local `MintJwt`. These are citizen-auth tests under the Phase 1 surface, not institution-auth tests — folding them into `InstitutionAuthHelper` would be a misnomer. A separate `CitizenJwtFactory` (or a rename of the existing helper) would be the right follow-up.

## Copilot Review Resolution
| # | Summary | Category | Action taken |
|---|---------|----------|--------------|
| 1 | Smoke-test assertions too loose — `!= 401 && != 403` could silently pass on 404 / 500 | VALID AND ALIGNED | Tightened to exact `HttpStatusCode.OK`. Docstring updated to match. (`4e9575c`) |
| 2 | `InstitutionAuthSession` wraps an `HttpClient` but is not disposable — callers leak | VALID AND ALIGNED | `InstitutionAuthSession` now implements `IDisposable`, disposes the underlying client. All call sites in the two refactored test files + smoke tests use `using var session = ...`. (`4e9575c`) |
| 3 | XML doc `cref` targets for `TestConstants` / `HaliWebApplicationFactory` don't resolve — file doesn't `using` their namespace | VALID AND ALIGNED | Fully qualified to `Infrastructure.TestConstants` and `Infrastructure.HaliWebApplicationFactory`. (`4e9575c`) |
| 4 | PR description claim "JWT minting in exactly one place" overclaims — Phase 1 test files still have local `MintJwt` | VALID AND ALIGNED | PR description now scopes the claim explicitly to Phase 2 and lists the Phase 1 sites under "Findings outside scope" as follow-up, since folding citizen-auth tests into `InstitutionAuthHelper` would be a misnomer. |
| 5 | Same disposal concern as #2, flagged on `InstitutionReadIntegrationTests` | VALID AND ALIGNED | Same fix — `using var session = ...` across every call site. (`4e9575c`) |
| 6 | `ChangeRole_CrossInstitutionTarget_Returns404` — tuple destructured as `(_, memberB)` but `memberB` was the member's email (string) not a Guid; route constraint rejected the segment with an empty-bodied 404 and `ReadFromJson` failed | VALID AND ALIGNED (self-caught during CI) | Switched to `SeedInstitutionWithMemberIdAsync` which returns the member id as a Guid so the route constraint passes and the controller's `NotFoundException` envelope is the one asserted. (`60b017f`) |

## Checklist
- [x] CI green — all checks passing
- [x] Zero open Copilot threads
- [x] Helper smoke test covers real auth path and would fail if helper were broken
- [x] No TODOs or placeholders in shipped code
- [x] OpenAPI spec unchanged
- [x] No product logic changed
- [x] No schema changes
- [x] All pre-existing assertions unchanged or corrected with documented reason
- [x] Tests are parallel-safe and do not share mutable state
