### PR TITLE
fix(ci): replace || true with continue-on-error on optional steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,12 +227,15 @@ jobs:
           done
           curl -f http://localhost:8080/health
       - name: Run Dredd contract tests
+        # Declared non-blocking: contract drift surfaces as a failed step
+        # (visible in GitHub UI) without failing the job. Exit code propagates
+        # correctly — no `|| true`, which would mask real failures as green.
+        continue-on-error: true
         run: |
           dredd 02_openapi.yaml http://localhost:8080 \
             --hookfiles=tests/dredd-hooks.js \
             --reporter=junit \
-            --output=./test-results/dredd/contract-results.xml \
-            || true  # Don't fail CI while hooks are being developed
+            --output=./test-results/dredd/contract-results.xml
       - uses: actions/upload-artifact@v7
         if: always()
         with: { name: contract-test-results, path: ./test-results/dredd/ }

--- a/.github/workflows/spec_verifier.yml
+++ b/.github/workflows/spec_verifier.yml
@@ -59,8 +59,13 @@ jobs:
           python3 scripts/spec_verifier.py
 
       - name: Commit updated lessons if changed
+        # Push is best-effort: non-fast-forward against a moving branch is
+        # acceptable (next run picks it up). Declared non-blocking at the
+        # step level so failures stay visible in the UI instead of being
+        # masked by `|| true`.
+        continue-on-error: true
         run: |
           git add agent_prompts/agent_a_lessons.md
           git diff --staged --quiet || \
             git commit -m "lessons: post-CI spec verification update [skip ci]"
-          git push origin HEAD || true
+          git push origin HEAD


### PR DESCRIPTION
## Summary

Removes both `|| true` instances from `.github/workflows/`. This was the CI hazard flagged on PR #245 — `|| true` on a test/CI step swallows the exit code entirely, so a genuine failure inside the step is masked as a silent green. Replaced with step-level `continue-on-error: true`, which keeps the team's prior non-blocking intent but surfaces real failures in the GitHub UI as a ❌ step while the job still proceeds.

## Instances found and resolution

| File | Line | Purpose | Resolution |
|---|---|---|---|
| `.github/workflows/ci.yml` | 235 (prev.) | `dredd ... \|\| true` on "Run Dredd contract tests" — historical comment: *"Don't fail CI while hooks are being developed"* | Removed `\|\| true`; added `continue-on-error: true` at step level |
| `.github/workflows/spec_verifier.yml` | 66 (prev.) | `git push origin HEAD \|\| true` — best-effort lessons-update push that may hit non-fast-forward against a moving branch | Removed `\|\| true`; added `continue-on-error: true` at step level |

No other `\|\| true` instances in `.github/workflows/`.

## Why `continue-on-error` rather than pure removal

- **Dredd contract tests** — the hooks in `tests/dredd-hooks.js` are substantively built out (127 lines, real auth setup, skip list for stateful endpoints), but CI hasn't been hardened to make the step strictly pass across every transaction. Making it block CI in this PR would be a scope-expansion that risks a cascade of Dredd noise. The right next step is a follow-up that drives the Dredd run to a reliable green and then drops `continue-on-error` entirely. Captured as information for now, not as a regression.
- **spec_verifier push** — genuinely best-effort: if the lessons branch has moved ahead between checkout and push, the push loses the race and next run picks up the diff. `continue-on-error: true` is the correct idiom for this shape.

## Previously silent failures

Neither change surfaces a known regression. The Dredd step will now render as ❌ on any PR where Dredd reports a contract drift — that is the desired signal. The spec_verifier push step will render as ❌ on the post-merge workflow if the push loses a race, which is observational only.

## Copilot Review Resolution
| Classification | Count |
|---|---:|
| VALID AND ALIGNED | 0 |
| VALID BUT OUT OF SCOPE | 0 |
| VALID AND ALIGNED BUT DEFERRED | 0 |
| VALID BUT MISALIGNED WITH DOCTRINE | 0 |
| NOT VALID | 0 |

**Fixes applied:** none — Copilot generated 0 comments on this PR.
**Follow-up issues created:** none required by this PR.

## Checklist
- [x] Removed every `\|\| true` from `.github/workflows/`
- [x] Replaced with `continue-on-error: true` where the team's prior intent was "step is non-blocking"
- [x] No behavioural change for the happy path — passing steps still pass the job
- [x] Documented commit messages and comments explain why each step is declared non-blocking
- [x] All 16 CI checks green
- [x] Zero open Copilot threads

🤖 Generated with [Claude Code](https://claude.com/claude-code)
