### PR TITLE
fix(arch): website spec — 3 Copilot review corrections from PR #256

### DIFF
--- a/docs/arch/website_spec_v1.1.md
+++ b/docs/arch/website_spec_v1.1.md
@@ -11,7 +11,8 @@
 
 ### Campaign domain
 **`https://whatsthehali.com`** — social, word-of-mouth, curiosity entry point
-- Redirects to `gethali.app` (301 permanent)
+- Redirects to `gethali.app` with a temporary redirect initially (302/307)
+- Switch to 301 only once the campaign URL + destination are fully locked and expected to remain stable
 - No content served from this domain directly
 
 ### Usage principle
@@ -25,7 +26,7 @@ The `whatsthehali.com` redirect is a Vercel domain redirect — one config line,
 
 ## 1. Purpose and Scope
 
-The Hali website (`apps/hali-web`) is a **public marketing and conversion site**. Its job is not to explain everything — it is to trigger a behavior: open or download the app.
+The Hali website (planned new workspace `apps/hali-web`, to be created in Phase A) is a **public marketing and conversion site**. Its job is not to explain everything — it is to trigger a behavior: open or download the app.
 
 > This site is a behavior trigger, not an explanation platform.
 > Goal: the visitor thinks "let me check Hali."
@@ -185,7 +186,7 @@ The site must feel real, grounded, and immediately useful. Nothing invented for 
 | Pre-launch | "Get notified at launch" | Email capture modal |
 | Live | "Open Hali" | App Store / Play Store links |
 
-Switch: `NEXT_PUBLIC_APP_LAUNCH_STATE=prelaunch` or `live`. No code change required to flip.
+Switch: `NEXT_PUBLIC_APP_LAUNCH_STATE=prelaunch` or `live`. No code changes are required to flip this, but for a static/SSG Next.js site a rebuild/redeploy on Vercel is required for the change to take effect.
 
 ---
 

--- a/docs/arch/website_spec_v1.1.md
+++ b/docs/arch/website_spec_v1.1.md
@@ -11,8 +11,8 @@
 
 ### Campaign domain
 **`https://whatsthehali.com`** — social, word-of-mouth, curiosity entry point
-- Redirects to `gethali.app` with a temporary redirect initially (302/307)
-- Switch to 301 only once the campaign URL + destination are fully locked and expected to remain stable
+- Redirects to `gethali.app` with a temporary redirect initially (307 via Vercel `permanent: false`)
+- Switch to 308 (`permanent: true`) only once the campaign URL + destination are fully locked and expected to remain stable
 - No content served from this domain directly
 
 ### Usage principle
@@ -26,7 +26,7 @@ The `whatsthehali.com` redirect is a Vercel domain redirect — one config line,
 
 ## 1. Purpose and Scope
 
-The Hali website (planned new workspace `apps/hali-web`, to be created in Phase A) is a **public marketing and conversion site**. Its job is not to explain everything — it is to trigger a behavior: open or download the app.
+The Hali website lives in `apps/hali-web` (created in Phase A) and is a **public marketing and conversion site**. Its job is not to explain everything — it is to trigger a behavior: open or download the app.
 
 > This site is a behavior trigger, not an explanation platform.
 > Goal: the visitor thinks "let me check Hali."


### PR DESCRIPTION
## Summary
Applies Copilot review suggestions missed on PR #256, plus follow-up Copilot suggestions on this PR itself.

## Relates to
Closes Copilot review threads on PR #256; Copilot threads on this PR resolved below.

## Changes applied

### 1. Redirect type (VALID AND ALIGNED)
Initial Copilot note (from #256) asked to switch from 301 (permanent) to 302/307 (temporary). Follow-up Copilot note on this PR correctly flagged that the spec should reference Vercel's native `permanent` boolean (307/308) rather than HTTP's 301/302, since `apps/hali-web/vercel.json` uses `permanent: true/false`. Applied Vercel-semantic wording: **307 via `permanent: false` initially → switch to 308 (`permanent: true`) once stable**.

### 2. SSG redeploy required (VALID AND ALIGNED)
Clarified that flipping `NEXT_PUBLIC_APP_LAUNCH_STATE` requires a Vercel rebuild/redeploy, not just an env var change — `NEXT_PUBLIC_*` vars are baked at build time for SSG sites.

### 3. apps/hali-web phrasing (VALID AND ALIGNED)
Follow-up Copilot note flagged that "planned new workspace… to be created in Phase A" was outdated because PR #257 (Phase A) merged before this PR's review. Rephrased to timeless language: **"The Hali website lives in `apps/hali-web` (created in Phase A) …"**.

## Copilot Review Resolution (this PR)

| Thread | Category | Action |
|---|---|---|
| Redirect codes should use Vercel `permanent` semantics (307/308), not 301/302 | VALID AND ALIGNED | Applied verbatim in commit a751f91. Thread resolved. |
| `apps/hali-web` phrasing was outdated post Phase A | VALID AND ALIGNED | Applied timeless rephrasing in commit a751f91. Thread resolved. |

All threads resolved: yes
PR description updated: yes

## Checklist
- [x] All 3 Copilot suggestions from PR #256 applied
- [x] Both follow-up Copilot suggestions on this PR applied
- [x] All Copilot threads on this PR resolved
- [x] grep verification passed for spec changes
- [x] Docs only — no code changes
