### PR TITLE
feat(institution-web): post official update modal on cluster detail (#203)

### DIFF
--- a/apps/institution-web/e2e/smoke.spec.ts
+++ b/apps/institution-web/e2e/smoke.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import type { ClusterDetailResponse, OfficialPostResponse } from "../src/api/types";
 
 // Shell + dashboard smoke. Asserts the Vite dev server boots, the
 // router mounts the institution shell, every primary nav target
@@ -120,27 +121,7 @@ test.describe("institution-web dashboard", () => {
   });
 
   test("opens cluster detail from the signals list and posts a live update", async ({ page }) => {
-    const clusterPayload = {
-      id: "cluster-1",
-      state: "active",
-      category: "electricity",
-      subcategorySlug: "outage",
-      title: "Power outage on Ngong Road",
-      summary: "Several blocks along Ngong Road report no power.",
-      affectedCount: 18,
-      observingCount: 6,
-      createdAt: "2026-04-18T03:00:00Z",
-      updatedAt: "2026-04-18T05:00:00Z",
-      activatedAt: "2026-04-18T03:30:00Z",
-      possibleRestorationAt: null,
-      resolvedAt: null,
-      locationLabel: "Ngong Road near Adams Arcade, Kilimani",
-      responseStatus: "teams_dispatched",
-      officialPosts: [] as unknown[],
-    };
-
-    let postRequests = 0;
-    const createdPost = {
+    const createdPost: OfficialPostResponse = {
       id: "post-1",
       institutionId: "inst-1",
       type: "live_update",
@@ -156,6 +137,27 @@ test.describe("institution-web dashboard", () => {
       responseStatus: "teams_dispatched",
       severity: null,
     };
+
+    const clusterPayload: ClusterDetailResponse = {
+      id: "cluster-1",
+      state: "active",
+      category: "electricity",
+      subcategorySlug: "outage",
+      title: "Power outage on Ngong Road",
+      summary: "Several blocks along Ngong Road report no power.",
+      affectedCount: 18,
+      observingCount: 6,
+      createdAt: "2026-04-18T03:00:00Z",
+      updatedAt: "2026-04-18T05:00:00Z",
+      activatedAt: "2026-04-18T03:30:00Z",
+      possibleRestorationAt: null,
+      resolvedAt: null,
+      locationLabel: "Ngong Road near Adams Arcade, Kilimani",
+      responseStatus: "teams_dispatched",
+      officialPosts: [],
+    };
+
+    let postRequests = 0;
 
     await page.route("**/v1/institution/signals/cluster-1", (route) =>
       route.fulfill({

--- a/apps/institution-web/e2e/smoke.spec.ts
+++ b/apps/institution-web/e2e/smoke.spec.ts
@@ -119,30 +119,62 @@ test.describe("institution-web dashboard", () => {
     expect(errors, "no runtime errors across shell navigation").toEqual([]);
   });
 
-  test("opens cluster detail from the signals list", async ({ page }) => {
+  test("opens cluster detail from the signals list and posts a live update", async ({ page }) => {
+    const clusterPayload = {
+      id: "cluster-1",
+      state: "active",
+      category: "electricity",
+      subcategorySlug: "outage",
+      title: "Power outage on Ngong Road",
+      summary: "Several blocks along Ngong Road report no power.",
+      affectedCount: 18,
+      observingCount: 6,
+      createdAt: "2026-04-18T03:00:00Z",
+      updatedAt: "2026-04-18T05:00:00Z",
+      activatedAt: "2026-04-18T03:30:00Z",
+      possibleRestorationAt: null,
+      resolvedAt: null,
+      locationLabel: "Ngong Road near Adams Arcade, Kilimani",
+      responseStatus: "teams_dispatched",
+      officialPosts: [] as unknown[],
+    };
+
+    let postRequests = 0;
+    const createdPost = {
+      id: "post-1",
+      institutionId: "inst-1",
+      type: "live_update",
+      category: "electricity",
+      title: "Teams dispatched to Ngong Road substation",
+      body: "Crews are en route. ETA 30 minutes.",
+      startsAt: null,
+      endsAt: null,
+      status: "published",
+      relatedClusterId: "cluster-1",
+      isRestorationClaim: false,
+      createdAt: "2026-04-18T04:00:00Z",
+      responseStatus: "teams_dispatched",
+      severity: null,
+    };
+
     await page.route("**/v1/institution/signals/cluster-1", (route) =>
       route.fulfill({
         status: 200,
         contentType: "application/json",
-        body: JSON.stringify({
-          id: "cluster-1",
-          state: "active",
-          category: "electricity",
-          subcategorySlug: "outage",
-          title: "Power outage on Ngong Road",
-          summary: "Several blocks along Ngong Road report no power.",
-          affectedCount: 18,
-          observingCount: 6,
-          createdAt: "2026-04-18T03:00:00Z",
-          updatedAt: "2026-04-18T05:00:00Z",
-          activatedAt: "2026-04-18T03:30:00Z",
-          possibleRestorationAt: null,
-          resolvedAt: null,
-          locationLabel: "Ngong Road near Adams Arcade, Kilimani",
-          responseStatus: "teams_dispatched",
-        }),
+        body: JSON.stringify(
+          postRequests > 0 ? { ...clusterPayload, officialPosts: [createdPost] } : clusterPayload,
+        ),
       }),
     );
+
+    await page.route("**/v1/official-posts", (route) => {
+      postRequests += 1;
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify(createdPost),
+      });
+    });
 
     await page.goto("/signals");
     await page.getByRole("link", { name: /power outage on ngong road/i }).click();
@@ -150,6 +182,18 @@ test.describe("institution-web dashboard", () => {
       page.getByRole("heading", { level: 2, name: /power outage on ngong road/i }),
     ).toBeVisible();
     await expect(page.getByText(/ngong road near adams arcade/i)).toBeVisible();
+
+    await page.getByRole("button", { name: /post an update/i }).click();
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/^title$/i).fill("Teams dispatched to Ngong Road substation");
+    await dialog.getByLabel(/^body$/i).fill("Crews are en route. ETA 30 minutes.");
+    await dialog.getByLabel(/response status/i).selectOption("teams_dispatched");
+    await dialog.getByRole("button", { name: /post update/i }).click();
+
+    await expect(page.getByTestId("official-post-card")).toContainText(
+      /teams dispatched to ngong road substation/i,
+    );
   });
 
   test("renders a recovery surface for unknown routes", async ({ page }) => {

--- a/apps/institution-web/src/api/officialPosts.ts
+++ b/apps/institution-web/src/api/officialPosts.ts
@@ -1,0 +1,18 @@
+import { apiFetch } from "./client";
+import type { OfficialPostCreateRequest, OfficialPostResponse } from "./types";
+
+// Typed accessors for POST /v1/official-posts. The backend derives
+// institution_id from the JWT claim, so the UI never sends it. The
+// caller attaches `relatedClusterId` when posting from a cluster
+// detail; otherwise the post is cluster-less and is scoped by
+// `localityId` / `corridorName` (handled in later PRs).
+
+export function createOfficialPost(
+  request: OfficialPostCreateRequest,
+): Promise<OfficialPostResponse> {
+  return apiFetch<OfficialPostResponse>("/v1/official-posts", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(request),
+  });
+}

--- a/apps/institution-web/src/api/types.ts
+++ b/apps/institution-web/src/api/types.ts
@@ -6,7 +6,6 @@
 //
 // Deliberate omissions from `ClusterDetailResponse` vs the server's
 // `ClusterResponse` schema:
-// - `officialPosts` — rendered by the post-update card landing in #203
 // - `myParticipation` — gating for the restoration CTA landing in #204
 // - `restorationRatio` / `restorationYesVotes` / `restorationTotalVotes`
 //   — consumed alongside the restoration CTA in #204
@@ -66,6 +65,60 @@ export interface InstitutionSignalsResponse {
   readonly nextCursor: string | null;
 }
 
+export type OfficialPostType = "live_update" | "scheduled_disruption" | "advisory_public_notice";
+
+export type OfficialPostResponseStatus =
+  | "acknowledged"
+  | "teams_dispatched"
+  | "teams_on_site"
+  | "work_ongoing"
+  | "restoration_in_progress"
+  | "service_restored";
+
+export type OfficialPostSeverity = "minor" | "moderate" | "major";
+
+export type CivicCategorySlug =
+  | "roads"
+  | "transport"
+  | "electricity"
+  | "water"
+  | "environment"
+  | "safety"
+  | "governance"
+  | "infrastructure";
+
+export interface OfficialPostResponse {
+  readonly id: string;
+  readonly institutionId: string;
+  readonly type: OfficialPostType | string;
+  readonly category: CivicCategorySlug | string;
+  readonly title: string;
+  readonly body: string;
+  readonly startsAt: string | null;
+  readonly endsAt: string | null;
+  readonly status: string;
+  readonly relatedClusterId: string | null;
+  readonly isRestorationClaim: boolean;
+  readonly createdAt: string;
+  readonly responseStatus: OfficialPostResponseStatus | null;
+  readonly severity: OfficialPostSeverity | null;
+}
+
+export interface OfficialPostCreateRequest {
+  readonly type: OfficialPostType;
+  readonly category: CivicCategorySlug | string;
+  readonly title: string;
+  readonly body: string;
+  readonly startsAt?: string | null;
+  readonly endsAt?: string | null;
+  readonly relatedClusterId?: string | null;
+  readonly isRestorationClaim?: boolean;
+  readonly localityId?: string | null;
+  readonly corridorName?: string | null;
+  readonly responseStatus?: OfficialPostResponseStatus | null;
+  readonly severity?: OfficialPostSeverity | null;
+}
+
 export interface ClusterDetailResponse {
   readonly id: string;
   readonly state: string;
@@ -82,4 +135,5 @@ export interface ClusterDetailResponse {
   readonly resolvedAt: string | null;
   readonly locationLabel: string | null;
   readonly responseStatus: string | null;
+  readonly officialPosts: ReadonlyArray<OfficialPostResponse>;
 }

--- a/apps/institution-web/src/screens/ClusterDetailScreen.test.tsx
+++ b/apps/institution-web/src/screens/ClusterDetailScreen.test.tsx
@@ -1,4 +1,5 @@
 import { screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ClusterDetailResponse } from "../api/types";
 import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../test/mockFetch";
@@ -22,6 +23,24 @@ const sampleCluster: ClusterDetailResponse = {
   resolvedAt: null,
   locationLabel: "Ngong Road near Adams Arcade, Kilimani",
   responseStatus: "teams_dispatched",
+  officialPosts: [
+    {
+      id: "post-1",
+      institutionId: "inst-1",
+      type: "live_update",
+      category: "electricity",
+      title: "Teams dispatched to Ngong Road substation",
+      body: "Crews are en route to the substation. ETA 30 minutes.",
+      startsAt: null,
+      endsAt: null,
+      status: "published",
+      relatedClusterId: clusterId,
+      isRestorationClaim: false,
+      createdAt: "2026-04-18T04:00:00Z",
+      responseStatus: "teams_dispatched",
+      severity: null,
+    },
+  ],
 };
 
 describe("ClusterDetailScreen", () => {
@@ -40,9 +59,47 @@ describe("ClusterDetailScreen", () => {
       await screen.findByRole("heading", { level: 2, name: /power outage on ngong road/i }),
     ).toBeInTheDocument();
     expect(screen.getByText(/ngong road near adams arcade/i)).toBeInTheDocument();
-    expect(screen.getByText(/teams_dispatched/)).toBeInTheDocument();
+    expect(screen.getAllByText(/teams_dispatched/).length).toBeGreaterThan(0);
     expect(screen.getByText("18")).toBeInTheDocument();
     expect(screen.getByText("6")).toBeInTheDocument();
+  });
+
+  it("renders existing official updates for this cluster", async () => {
+    mockFetch({
+      [`/v1/institution/signals/${clusterId}`]: () => jsonResponse(sampleCluster),
+    });
+
+    renderWithProviders({ pathname: `/signals/${clusterId}` });
+
+    const card = await screen.findByTestId("official-post-card");
+    expect(card).toHaveTextContent(/teams dispatched to ngong road substation/i);
+    expect(card).toHaveTextContent(/live update/i);
+  });
+
+  it("shows an empty-state hint when the cluster has no official posts yet", async () => {
+    mockFetch({
+      [`/v1/institution/signals/${clusterId}`]: () =>
+        jsonResponse({ ...sampleCluster, officialPosts: [] }),
+    });
+
+    renderWithProviders({ pathname: `/signals/${clusterId}` });
+
+    expect(
+      await screen.findByText(/no official updates posted yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("opens the post-update modal when the Post an update button is clicked", async () => {
+    mockFetch({
+      [`/v1/institution/signals/${clusterId}`]: () => jsonResponse(sampleCluster),
+    });
+
+    renderWithProviders({ pathname: `/signals/${clusterId}` });
+
+    const trigger = await screen.findByRole("button", { name: /post an update/i });
+    await userEvent.click(trigger);
+
+    expect(screen.getByRole("dialog")).toHaveTextContent(/post an official update/i);
   });
 
   it("renders the error state when the cluster is out of scope or missing", async () => {

--- a/apps/institution-web/src/screens/ClusterDetailScreen.tsx
+++ b/apps/institution-web/src/screens/ClusterDetailScreen.tsx
@@ -1,9 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { getInstitutionSignal } from "../api/institution";
+import type { OfficialPostResponse } from "../api/types";
 import { ErrorState } from "../components/ErrorState";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { institutionKeys } from "../query/keys";
+import { PostUpdateModal } from "./cluster/PostUpdateModal";
 import { formatDurationSeconds } from "./signalFormatting";
 
 // Institution-scoped cluster detail. Pulls from
@@ -13,11 +16,13 @@ import { formatDurationSeconds } from "./signalFormatting";
 // as a transport failure (we deliberately don't leak the distinction
 // between "forbidden" and "missing").
 //
-// Post-update (#203) and restoration-response (#204) actions slot in
-// as peer cards on this screen; they read the same cluster query and
-// invalidate it on success.
+// Post-update (#203) is wired here as a peer card: the button opens
+// `PostUpdateModal`, which invalidates this cluster's query on
+// success so the new post surfaces in the list without an explicit
+// refetch. The restoration CTA (#204) slots in next to it.
 export function ClusterDetailScreen() {
   const { clusterId } = useParams<{ clusterId: string }>();
+  const [postModalOpen, setPostModalOpen] = useState(false);
 
   const cluster = useQuery({
     queryKey: institutionKeys.signalDetail(clusterId ?? ""),
@@ -54,16 +59,26 @@ export function ClusterDetailScreen() {
   const timeActiveSeconds = signal.activatedAt
     ? Math.max(0, Math.floor((Date.now() - new Date(signal.activatedAt).getTime()) / 1000))
     : 0;
+  const officialPosts = signal.officialPosts ?? [];
 
   return (
     <article className="max-w-3xl space-y-6">
-      <header className="space-y-1">
-        <h2 className="text-xl font-semibold text-foreground">
-          {signal.title ?? "Untitled signal"}
-        </h2>
-        {signal.locationLabel ? (
-          <p className="text-sm text-muted-foreground">{signal.locationLabel}</p>
-        ) : null}
+      <header className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <h2 className="text-xl font-semibold text-foreground">
+            {signal.title ?? "Untitled signal"}
+          </h2>
+          {signal.locationLabel ? (
+            <p className="text-sm text-muted-foreground">{signal.locationLabel}</p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={() => setPostModalOpen(true)}
+          className="shrink-0 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+        >
+          Post an update
+        </button>
       </header>
 
       {signal.summary ? (
@@ -84,12 +99,36 @@ export function ClusterDetailScreen() {
         ) : null}
       </dl>
 
+      <section aria-label="Official updates" className="space-y-3">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Official updates
+        </h3>
+        {officialPosts.length === 0 ? (
+          <p className="text-sm text-muted-foreground">
+            No official updates posted yet. Use the button above to publish one.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {officialPosts.map((post) => (
+              <OfficialPostCard key={post.id} post={post} />
+            ))}
+          </ul>
+        )}
+      </section>
+
       <Link
         to="/signals"
         className="inline-block text-sm font-medium text-foreground underline underline-offset-2"
       >
         Back to signals
       </Link>
+
+      <PostUpdateModal
+        clusterId={signal.id}
+        clusterCategory={signal.category}
+        open={postModalOpen}
+        onClose={() => setPostModalOpen(false)}
+      />
     </article>
   );
 }
@@ -100,5 +139,27 @@ function DetailField({ label, value }: { readonly label: string; readonly value:
       <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
       <dd className="text-sm font-medium text-foreground">{value}</dd>
     </div>
+  );
+}
+
+function OfficialPostCard({ post }: { readonly post: OfficialPostResponse }) {
+  return (
+    <li
+      data-testid="official-post-card"
+      className="rounded-md border border-border bg-card p-3 text-sm"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <span className="font-medium text-foreground">{post.title}</span>
+        <span className="text-xs uppercase tracking-wide text-muted-foreground">
+          {post.type.replace(/_/g, " ")}
+        </span>
+      </div>
+      <p className="mt-1 whitespace-pre-wrap text-muted-foreground">{post.body}</p>
+      <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-muted-foreground">
+        <span>Status: {post.status}</span>
+        {post.responseStatus ? <span>Response: {post.responseStatus}</span> : null}
+        {post.severity ? <span>Severity: {post.severity}</span> : null}
+      </div>
+    </li>
   );
 }

--- a/apps/institution-web/src/screens/cluster/PostUpdateModal.test.tsx
+++ b/apps/institution-web/src/screens/cluster/PostUpdateModal.test.tsx
@@ -1,0 +1,226 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../../test/mockFetch";
+import { PostUpdateModal } from "./PostUpdateModal";
+
+function renderModal(overrides?: Partial<ComponentProps<typeof PostUpdateModal>>) {
+  const onClose = overrides?.onClose ?? vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <PostUpdateModal
+        clusterId={overrides?.clusterId ?? "cluster-1"}
+        clusterCategory={overrides?.clusterCategory ?? "electricity"}
+        open={overrides?.open ?? true}
+        onClose={onClose}
+      />
+    </QueryClientProvider>,
+  );
+  return { ...result, onClose, queryClient };
+}
+
+describe("PostUpdateModal", () => {
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("is hidden when open is false", () => {
+    renderModal({ open: false });
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("submits a live_update request with the chosen response status", async () => {
+    const captured: { url?: string; init?: RequestInit } = {};
+    mockFetch({
+      "/v1/official-posts": (url, init) => {
+        captured.url = url;
+        captured.init = init;
+        return jsonResponse(
+          {
+            id: "post-1",
+            institutionId: "inst-1",
+            type: "live_update",
+            category: "electricity",
+            title: "Teams dispatched",
+            body: "Crews are en route.",
+            startsAt: null,
+            endsAt: null,
+            status: "published",
+            relatedClusterId: "cluster-1",
+            isRestorationClaim: false,
+            createdAt: "2026-04-18T04:00:00Z",
+            responseStatus: "teams_dispatched",
+            severity: null,
+          },
+          201,
+        );
+      },
+    });
+
+    const { onClose } = renderModal();
+
+    await userEvent.type(screen.getByLabelText(/^title$/i), "Teams dispatched");
+    await userEvent.type(screen.getByLabelText(/^body$/i), "Crews are en route.");
+    await userEvent.selectOptions(
+      screen.getByLabelText(/response status/i),
+      "teams_dispatched",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /post update/i }));
+
+    await waitFor(() => expect(onClose).toHaveBeenCalledTimes(1));
+
+    expect(captured.init?.method).toBe("POST");
+    const body = JSON.parse(String(captured.init?.body));
+    expect(body).toMatchObject({
+      type: "live_update",
+      category: "electricity",
+      title: "Teams dispatched",
+      body: "Crews are en route.",
+      relatedClusterId: "cluster-1",
+      responseStatus: "teams_dispatched",
+    });
+    expect(body).not.toHaveProperty("severity");
+  });
+
+  it("reveals severity + schedule fields when scheduled_disruption is picked", async () => {
+    const captured: { init?: RequestInit } = {};
+    mockFetch({
+      "/v1/official-posts": (_url, init) => {
+        captured.init = init;
+        return jsonResponse(
+          {
+            id: "post-2",
+            institutionId: "inst-1",
+            type: "scheduled_disruption",
+            category: "water",
+            title: "Scheduled water maintenance",
+            body: "Water supply will be paused for maintenance.",
+            startsAt: "2026-04-19T09:00:00.000Z",
+            endsAt: "2026-04-19T11:00:00.000Z",
+            status: "published",
+            relatedClusterId: "cluster-1",
+            isRestorationClaim: false,
+            createdAt: "2026-04-18T04:00:00Z",
+            responseStatus: null,
+            severity: "moderate",
+          },
+          201,
+        );
+      },
+    });
+
+    renderModal({ clusterCategory: "water" });
+
+    await userEvent.click(screen.getByRole("radio", { name: /scheduled disruption/i }));
+    await userEvent.type(screen.getByLabelText(/^title$/i), "Scheduled water maintenance");
+    await userEvent.type(
+      screen.getByLabelText(/^body$/i),
+      "Water supply will be paused for maintenance.",
+    );
+    await userEvent.selectOptions(screen.getByLabelText(/severity/i), "moderate");
+    // datetime-local values use the local timezone; we just assert they serialize as ISO.
+    fireInputEvent(screen.getByLabelText(/^starts$/i), "2026-04-19T09:00");
+    fireInputEvent(screen.getByLabelText(/^ends$/i), "2026-04-19T11:00");
+
+    await userEvent.click(screen.getByRole("button", { name: /post update/i }));
+
+    await waitFor(() => expect(captured.init?.body).toBeTruthy());
+    const body = JSON.parse(String(captured.init?.body));
+    expect(body).toMatchObject({
+      type: "scheduled_disruption",
+      category: "water",
+      severity: "moderate",
+    });
+    expect(body.startsAt).toMatch(/^2026-04-19T/);
+    expect(body.endsAt).toMatch(/^2026-04-19T/);
+    expect(body).not.toHaveProperty("responseStatus");
+  });
+
+  it("omits response status and severity for an advisory post", async () => {
+    const captured: { init?: RequestInit } = {};
+    mockFetch({
+      "/v1/official-posts": (_url, init) => {
+        captured.init = init;
+        return jsonResponse(
+          {
+            id: "post-3",
+            institutionId: "inst-1",
+            type: "advisory_public_notice",
+            category: "environment",
+            title: "Advisory notice",
+            body: "General public notice.",
+            startsAt: null,
+            endsAt: null,
+            status: "published",
+            relatedClusterId: "cluster-1",
+            isRestorationClaim: false,
+            createdAt: "2026-04-18T04:00:00Z",
+            responseStatus: null,
+            severity: null,
+          },
+          201,
+        );
+      },
+    });
+
+    renderModal({ clusterCategory: "environment" });
+
+    await userEvent.click(
+      screen.getByRole("radio", { name: /advisory \/ public notice/i }),
+    );
+    await userEvent.type(screen.getByLabelText(/^title$/i), "Advisory notice");
+    await userEvent.type(screen.getByLabelText(/^body$/i), "General public notice.");
+
+    expect(screen.queryByLabelText(/response status/i)).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/severity/i)).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /post update/i }));
+
+    await waitFor(() => expect(captured.init?.body).toBeTruthy());
+    const body = JSON.parse(String(captured.init?.body));
+    expect(body).not.toHaveProperty("responseStatus");
+    expect(body).not.toHaveProperty("severity");
+    expect(body).not.toHaveProperty("startsAt");
+  });
+
+  it("surfaces a server error without closing the modal", async () => {
+    mockFetch({
+      "/v1/official-posts": () => errorResponse(400, "invalid_category"),
+    });
+
+    const { onClose } = renderModal();
+
+    await userEvent.type(screen.getByLabelText(/^title$/i), "Teams dispatched");
+    await userEvent.type(screen.getByLabelText(/^body$/i), "Crews are en route.");
+    await userEvent.click(screen.getByRole("button", { name: /post update/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/backend rejected this update/i);
+    });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("blocks submit when title or body are blank", async () => {
+    renderModal();
+
+    await userEvent.click(screen.getByRole("button", { name: /post update/i }));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});
+
+// React Testing Library's userEvent doesn't reliably fire input events
+// for the datetime-local control in jsdom — we emit a native input event
+// so React's controlled component picks up the value.
+function fireInputEvent(element: HTMLElement, value: string): void {
+  const input = element as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, "value")?.set;
+  setter?.call(input, value);
+  input.dispatchEvent(new Event("input", { bubbles: true }));
+}

--- a/apps/institution-web/src/screens/cluster/PostUpdateModal.tsx
+++ b/apps/institution-web/src/screens/cluster/PostUpdateModal.tsx
@@ -1,0 +1,381 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { FormEvent } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+import { ApiError } from "../../api/client";
+import { createOfficialPost } from "../../api/officialPosts";
+import type {
+  CivicCategorySlug,
+  OfficialPostCreateRequest,
+  OfficialPostResponse,
+  OfficialPostResponseStatus,
+  OfficialPostSeverity,
+  OfficialPostType,
+} from "../../api/types";
+import { institutionKeys } from "../../query/keys";
+
+// Modal-driven composer for the three official-update kinds defined by
+// `POST /v1/official-posts`:
+//
+//  - `live_update` — optional `responseStatus` from the canonical 6-value
+//    set; other type-specific fields rejected by the backend.
+//  - `scheduled_disruption` — optional `severity` (minor/moderate/major)
+//    plus `startsAt` / `endsAt` datetimes.
+//  - `advisory_public_notice` — title + body only.
+//
+// The server derives `institutionId` from the JWT. The caller supplies
+// `relatedClusterId` and the cluster's own `category` so the post
+// anchors to the signal we're viewing. Post-save we invalidate the
+// cluster detail query so the freshly-authored post surfaces in the
+// list without an explicit refetch.
+//
+// Field caps mirror `OfficialPostCreateRequest` (title 220, body 5000)
+// so validation bites before the network round-trip.
+
+const TITLE_MAX = 220;
+const BODY_MAX = 5000;
+
+const RESPONSE_STATUS_OPTIONS: ReadonlyArray<{ value: OfficialPostResponseStatus; label: string }> = [
+  { value: "acknowledged", label: "Acknowledged" },
+  { value: "teams_dispatched", label: "Teams dispatched" },
+  { value: "teams_on_site", label: "Teams on site" },
+  { value: "work_ongoing", label: "Work ongoing" },
+  { value: "restoration_in_progress", label: "Restoration in progress" },
+  { value: "service_restored", label: "Service restored" },
+];
+
+const SEVERITY_OPTIONS: ReadonlyArray<{ value: OfficialPostSeverity; label: string }> = [
+  { value: "minor", label: "Minor" },
+  { value: "moderate", label: "Moderate" },
+  { value: "major", label: "Major" },
+];
+
+const TYPE_OPTIONS: ReadonlyArray<{ value: OfficialPostType; label: string; hint: string }> = [
+  {
+    value: "live_update",
+    label: "Live update",
+    hint: "Status change on an active incident — teams dispatched, restored, etc.",
+  },
+  {
+    value: "scheduled_disruption",
+    label: "Scheduled disruption",
+    hint: "Planned outage or maintenance window with a known start/end.",
+  },
+  {
+    value: "advisory_public_notice",
+    label: "Advisory / public notice",
+    hint: "General notice with no live status or planned window.",
+  },
+];
+
+export interface PostUpdateModalProps {
+  readonly clusterId: string;
+  readonly clusterCategory: CivicCategorySlug | string;
+  readonly open: boolean;
+  readonly onClose: () => void;
+}
+
+export function PostUpdateModal({ clusterId, clusterCategory, open, onClose }: PostUpdateModalProps) {
+  const titleInputId = useId();
+  const bodyInputId = useId();
+  const startsAtId = useId();
+  const endsAtId = useId();
+  const responseStatusId = useId();
+  const severityId = useId();
+
+  const queryClient = useQueryClient();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  const [type, setType] = useState<OfficialPostType>("live_update");
+  const [title, setTitle] = useState("");
+  const [body, setBody] = useState("");
+  const [startsAt, setStartsAt] = useState("");
+  const [endsAt, setEndsAt] = useState("");
+  const [responseStatus, setResponseStatus] = useState<OfficialPostResponseStatus | "">("");
+  const [severity, setSeverity] = useState<OfficialPostSeverity | "">("");
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const resetForm = () => {
+    setType("live_update");
+    setTitle("");
+    setBody("");
+    setStartsAt("");
+    setEndsAt("");
+    setResponseStatus("");
+    setSeverity("");
+    setLocalError(null);
+  };
+
+  const mutation = useMutation<OfficialPostResponse, Error, OfficialPostCreateRequest>({
+    mutationFn: (request) => createOfficialPost(request),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: institutionKeys.signalDetail(clusterId) });
+      onClose();
+    },
+  });
+
+  useEffect(() => {
+    if (open) {
+      firstFieldRef.current?.focus();
+    } else {
+      resetForm();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !mutation.isPending) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, mutation.isPending, onClose]);
+
+  if (!open) return null;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    const trimmedTitle = title.trim();
+    const trimmedBody = body.trim();
+    if (!trimmedTitle || !trimmedBody) {
+      setLocalError("Title and body are required.");
+      return;
+    }
+
+    const request: OfficialPostCreateRequest = {
+      type,
+      category: clusterCategory,
+      title: trimmedTitle,
+      body: trimmedBody,
+      relatedClusterId: clusterId,
+      ...(type === "live_update" && responseStatus ? { responseStatus } : {}),
+      ...(type === "scheduled_disruption" && startsAt
+        ? { startsAt: new Date(startsAt).toISOString() }
+        : {}),
+      ...(type === "scheduled_disruption" && endsAt
+        ? { endsAt: new Date(endsAt).toISOString() }
+        : {}),
+      ...(type === "scheduled_disruption" && severity ? { severity } : {}),
+    };
+
+    mutation.mutate(request);
+  };
+
+  const serverError = mutation.error instanceof ApiError
+    ? `The backend rejected this update (${mutation.error.status}). Check the fields and retry.`
+    : mutation.error
+      ? "Something went wrong posting this update. Please retry."
+      : null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`${titleInputId}-heading`}
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto px-4 py-8"
+    >
+      <button
+        type="button"
+        aria-label="Close dialog"
+        onClick={() => {
+          if (!mutation.isPending) onClose();
+        }}
+        className="fixed inset-0 -z-0 cursor-default bg-black/40"
+        tabIndex={-1}
+      />
+      <div className="relative w-full max-w-xl rounded-lg border border-border bg-card p-6 shadow-lg">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 id={`${titleInputId}-heading`} className="text-lg font-semibold text-foreground">
+              Post an official update
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              Citizens within this cluster&apos;s scope will see this update next to the signal.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={mutation.isPending}
+            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted disabled:opacity-60"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <fieldset className="space-y-2">
+            <legend className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Update kind
+            </legend>
+            <div className="space-y-2">
+              {TYPE_OPTIONS.map((option) => {
+                const radioId = `${titleInputId}-type-${option.value}`;
+                return (
+                  <label
+                    key={option.value}
+                    htmlFor={radioId}
+                    aria-label={option.label}
+                    className="flex cursor-pointer items-start gap-2 rounded-md border border-border bg-background p-2 text-sm hover:bg-muted has-[:checked]:border-foreground"
+                  >
+                    <input
+                      id={radioId}
+                      type="radio"
+                      name="post-type"
+                      value={option.value}
+                      checked={type === option.value}
+                      onChange={() => setType(option.value)}
+                      className="mt-1"
+                    />
+                    <span className="flex flex-col">
+                      <span className="font-medium text-foreground">{option.label}</span>
+                      <span className="text-xs text-muted-foreground">{option.hint}</span>
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          </fieldset>
+
+          <div className="space-y-1">
+            <label htmlFor={titleInputId} className="block text-xs font-medium text-foreground">
+              Title
+            </label>
+            <input
+              id={titleInputId}
+              ref={firstFieldRef}
+              type="text"
+              required
+              maxLength={TITLE_MAX}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+            />
+            <p className="text-xs text-muted-foreground">
+              {title.length}/{TITLE_MAX}
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor={bodyInputId} className="block text-xs font-medium text-foreground">
+              Body
+            </label>
+            <textarea
+              id={bodyInputId}
+              required
+              maxLength={BODY_MAX}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              rows={5}
+              className="w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+            />
+            <p className="text-xs text-muted-foreground">
+              {body.length}/{BODY_MAX}
+            </p>
+          </div>
+
+          {type === "live_update" ? (
+            <div className="space-y-1">
+              <label htmlFor={responseStatusId} className="block text-xs font-medium text-foreground">
+                Response status (optional)
+              </label>
+              <select
+                id={responseStatusId}
+                value={responseStatus}
+                onChange={(event) => setResponseStatus(event.target.value as OfficialPostResponseStatus | "")}
+                className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+              >
+                <option value="">No status change</option>
+                {RESPONSE_STATUS_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+
+          {type === "scheduled_disruption" ? (
+            <div className="grid gap-3 sm:grid-cols-2">
+              <div className="space-y-1">
+                <label htmlFor={startsAtId} className="block text-xs font-medium text-foreground">
+                  Starts
+                </label>
+                <input
+                  id={startsAtId}
+                  type="datetime-local"
+                  value={startsAt}
+                  onChange={(event) => setStartsAt(event.target.value)}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+                />
+              </div>
+              <div className="space-y-1">
+                <label htmlFor={endsAtId} className="block text-xs font-medium text-foreground">
+                  Ends
+                </label>
+                <input
+                  id={endsAtId}
+                  type="datetime-local"
+                  value={endsAt}
+                  onChange={(event) => setEndsAt(event.target.value)}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+                />
+              </div>
+              <div className="space-y-1 sm:col-span-2">
+                <label htmlFor={severityId} className="block text-xs font-medium text-foreground">
+                  Severity (optional)
+                </label>
+                <select
+                  id={severityId}
+                  value={severity}
+                  onChange={(event) => setSeverity(event.target.value as OfficialPostSeverity | "")}
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+                >
+                  <option value="">Not specified</option>
+                  {SEVERITY_OPTIONS.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+          ) : null}
+
+          {localError ? (
+            <p role="alert" className="text-sm text-red-600">
+              {localError}
+            </p>
+          ) : null}
+          {serverError ? (
+            <p role="alert" className="text-sm text-red-600">
+              {serverError}
+            </p>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={mutation.isPending}
+              className="rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
+            >
+              {mutation.isPending ? "Posting…" : "Post update"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/institution-web/src/screens/cluster/PostUpdateModal.tsx
+++ b/apps/institution-web/src/screens/cluster/PostUpdateModal.tsx
@@ -145,6 +145,16 @@ export function PostUpdateModal({ clusterId, clusterCategory, open, onClose }: P
       return;
     }
 
+    // The wire contract makes startsAt/endsAt nullable (the backend
+    // accepts a scheduled_disruption with no window) but the UX intent
+    // for this kind is a planned, time-bound disruption — without a
+    // schedule the operator should be picking advisory_public_notice
+    // instead. Enforce here so the form guides the choice.
+    if (type === "scheduled_disruption" && (!startsAt || !endsAt)) {
+      setLocalError("Scheduled disruptions need both a start and end time.");
+      return;
+    }
+
     const request: OfficialPostCreateRequest = {
       type,
       category: clusterCategory,
@@ -152,13 +162,13 @@ export function PostUpdateModal({ clusterId, clusterCategory, open, onClose }: P
       body: trimmedBody,
       relatedClusterId: clusterId,
       ...(type === "live_update" && responseStatus ? { responseStatus } : {}),
-      ...(type === "scheduled_disruption" && startsAt
-        ? { startsAt: new Date(startsAt).toISOString() }
+      ...(type === "scheduled_disruption"
+        ? {
+            startsAt: new Date(startsAt).toISOString(),
+            endsAt: new Date(endsAt).toISOString(),
+            ...(severity ? { severity } : {}),
+          }
         : {}),
-      ...(type === "scheduled_disruption" && endsAt
-        ? { endsAt: new Date(endsAt).toISOString() }
-        : {}),
-      ...(type === "scheduled_disruption" && severity ? { severity } : {}),
     };
 
     mutation.mutate(request);
@@ -175,17 +185,14 @@ export function PostUpdateModal({ clusterId, clusterCategory, open, onClose }: P
       role="dialog"
       aria-modal="true"
       aria-labelledby={`${titleInputId}-heading`}
-      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto px-4 py-8"
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 px-4 py-8"
     >
-      <button
-        type="button"
-        aria-label="Close dialog"
-        onClick={() => {
-          if (!mutation.isPending) onClose();
-        }}
-        className="fixed inset-0 -z-0 cursor-default bg-black/40"
-        tabIndex={-1}
-      />
+      {/*
+        Backdrop is decorative — Escape + the explicit ✕ button drive
+        close, so we do not wire a click-to-close on the backdrop. Doing
+        so previously required a focusable <button> wrapper that some
+        assistive tech surfaced as an interactive control.
+      */}
       <div className="relative w-full max-w-xl rounded-lg border border-border bg-card p-6 shadow-lg">
         <div className="mb-4 flex items-start justify-between gap-4">
           <div>
@@ -308,6 +315,7 @@ export function PostUpdateModal({ clusterId, clusterCategory, open, onClose }: P
                 <input
                   id={startsAtId}
                   type="datetime-local"
+                  required
                   value={startsAt}
                   onChange={(event) => setStartsAt(event.target.value)}
                   className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
@@ -320,6 +328,7 @@ export function PostUpdateModal({ clusterId, clusterCategory, open, onClose }: P
                 <input
                   id={endsAtId}
                   type="datetime-local"
+                  required
                   value={endsAt}
                   onChange={(event) => setEndsAt(event.target.value)}
                   className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"


### PR DESCRIPTION
## Summary

Implements #203 — institution-web UI for creating official updates (live updates, scheduled disruptions, advisory/public notices) via `POST /v1/official-posts`.

- New `PostUpdateModal` (apps/institution-web/src/screens/cluster/PostUpdateModal.tsx) composes the three post kinds with type-aware fields:
  - `live_update` — optional `responseStatus` from the canonical 6-value set.
  - `scheduled_disruption` — `startsAt` / `endsAt` datetime-local + optional severity (minor/moderate/major).
  - `advisory_public_notice` — title + body only.
- Trigger is wired into `ClusterDetailScreen`; the cluster's category and id are forwarded to scope the post. On success the cluster detail query is invalidated so the new card surfaces without a refetch.
- Existing official posts now render beneath the detail grid; `officialPosts` is removed from the deliberate-omission comment in `api/types.ts` since this PR adds the render path.
- New `createOfficialPost` accessor in `api/officialPosts.ts` plus `OfficialPostCreateRequest` / `OfficialPostResponse` / type-narrowing enums in `api/types.ts`.

## Why this shape

- Backend derives `institutionId` from the JWT — UI never sends it.
- `relatedClusterId` is set from the active cluster; geo-scope (`localityId` / `corridorName`) is left null since the cluster is the scope anchor.
- Title/body caps mirror the OpenAPI contract (220 / 5000) so validation bites before the network round-trip.
- Type-specific fields are stripped from the request when the active type doesn't claim them — backend rejects extras with `official_post.invalid_response_status` / `official_post.invalid_severity`.

## Test plan

- [x] `pnpm test` — 38 tests pass (10 files), including 6 new modal tests + 3 new cluster-detail tests.
- [x] `pnpm lint` — clean.
- [x] `pnpm typecheck` — clean.
- [x] `pnpm exec turbo run typecheck lint test build --filter=@hali/institution-web` — 7/7 tasks green.
- [x] Playwright smoke (`apps/institution-web/e2e/smoke.spec.ts`) extended to exercise open → fill → submit → render-card flow against page.route stubs.

## Next up

- #204 Restoration action UI — adds the restoration CTA card alongside the post-update card (will read `myParticipation` + `restorationRatio/yesVotes/totalVotes`, which are still in the deliberate-omission comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)