### PR TITLE
feat(institution-web): #204 restoration action UI

### DIFF
--- a/apps/institution-web/e2e/smoke.spec.ts
+++ b/apps/institution-web/e2e/smoke.spec.ts
@@ -154,6 +154,9 @@ test.describe("institution-web dashboard", () => {
       resolvedAt: null,
       locationLabel: "Ngong Road near Adams Arcade, Kilimani",
       responseStatus: "teams_dispatched",
+      restorationRatio: null,
+      restorationYesVotes: null,
+      restorationTotalVotes: null,
       officialPosts: [],
     };
 
@@ -196,6 +199,93 @@ test.describe("institution-web dashboard", () => {
     await expect(page.getByTestId("official-post-card")).toContainText(
       /teams dispatched to ngong road substation/i,
     );
+  });
+
+  test("submits a restoration claim and flips the cluster into awaiting-citizen-confirmation", async ({
+    page,
+  }) => {
+    const baseCluster: ClusterDetailResponse = {
+      id: "cluster-1",
+      state: "active",
+      category: "electricity",
+      subcategorySlug: "outage",
+      title: "Power outage on Ngong Road",
+      summary: "Several blocks along Ngong Road report no power.",
+      affectedCount: 18,
+      observingCount: 6,
+      createdAt: "2026-04-18T03:00:00Z",
+      updatedAt: "2026-04-18T05:00:00Z",
+      activatedAt: "2026-04-18T03:30:00Z",
+      possibleRestorationAt: null,
+      resolvedAt: null,
+      locationLabel: "Ngong Road near Adams Arcade, Kilimani",
+      responseStatus: "teams_dispatched",
+      restorationRatio: null,
+      restorationYesVotes: null,
+      restorationTotalVotes: null,
+      officialPosts: [],
+    };
+
+    const restorationPost: OfficialPostResponse = {
+      id: "post-restoration",
+      institutionId: "inst-1",
+      type: "live_update",
+      category: "electricity",
+      title: "Service restored",
+      body: "Power is back across the affected blocks.",
+      startsAt: null,
+      endsAt: null,
+      status: "published",
+      relatedClusterId: "cluster-1",
+      isRestorationClaim: true,
+      createdAt: "2026-04-18T09:00:00Z",
+      responseStatus: "restoration_in_progress",
+      severity: null,
+    };
+
+    let postRequests = 0;
+
+    await page.route("**/v1/institution/signals/cluster-1", (route) => {
+      const payload =
+        postRequests > 0
+          ? {
+              ...baseCluster,
+              state: "possible_restoration",
+              possibleRestorationAt: "2026-04-18T09:00:00Z",
+              restorationRatio: 0,
+              restorationYesVotes: 0,
+              restorationTotalVotes: 0,
+              officialPosts: [restorationPost],
+            }
+          : baseCluster;
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(payload),
+      });
+    });
+
+    await page.route("**/v1/official-posts", (route) => {
+      postRequests += 1;
+      return route.fulfill({
+        status: 201,
+        contentType: "application/json",
+        body: JSON.stringify(restorationPost),
+      });
+    });
+
+    await page.goto("/signals/cluster-1");
+    await expect(
+      page.getByRole("heading", { level: 2, name: /power outage on ngong road/i }),
+    ).toBeVisible();
+
+    await page.getByRole("button", { name: /mark as restored/i }).click();
+    const dialog = page.getByRole("dialog", { name: /claim restoration/i });
+    await expect(dialog).toBeVisible();
+    await dialog.getByLabel(/^body$/i).fill("Power is back across the affected blocks.");
+    await dialog.getByRole("button", { name: /confirm restoration claim/i }).click();
+
+    await expect(page.getByText(/awaiting citizen confirmation/i)).toBeVisible();
   });
 
   test("renders a recovery surface for unknown routes", async ({ page }) => {

--- a/apps/institution-web/src/api/types.ts
+++ b/apps/institution-web/src/api/types.ts
@@ -6,11 +6,10 @@
 //
 // Deliberate omissions from `ClusterDetailResponse` vs the server's
 // `ClusterResponse` schema:
-// - `myParticipation` — gating for the restoration CTA landing in #204
-// - `restorationRatio` / `restorationYesVotes` / `restorationTotalVotes`
-//   — consumed alongside the restoration CTA in #204
-// Adding them now would bloat the type without a render path; they
-// slot in when those PRs wire the corresponding UI.
+// - `myParticipation` — citizen-scoped participation gating; the
+//   institution dashboard never acts as a citizen so this field is
+//   surplus to requirements.
+// Adding unused fields bloats the type without a render path.
 //
 // When the OpenAPI → TypeScript codegen pipeline lands, this file
 // deletes in favour of generated types re-exported from
@@ -119,9 +118,16 @@ export interface OfficialPostCreateRequest {
   readonly severity?: OfficialPostSeverity | null;
 }
 
+// `unconfirmed` is emitted by the server for clusters below the MACF
+// gate. The institution dashboard filters those out upstream and never
+// renders an unconfirmed detail page, so the restoration card only
+// branches across the remaining three states. Leaving the string wider
+// than the enum keeps the type tolerant of new server-side states.
+export type ClusterState = "unconfirmed" | "active" | "possible_restoration" | "resolved";
+
 export interface ClusterDetailResponse {
   readonly id: string;
-  readonly state: string;
+  readonly state: ClusterState | string;
   readonly category: string;
   readonly subcategorySlug: string | null;
   readonly title: string | null;
@@ -136,4 +142,7 @@ export interface ClusterDetailResponse {
   readonly locationLabel: string | null;
   readonly responseStatus: string | null;
   readonly officialPosts: ReadonlyArray<OfficialPostResponse>;
+  readonly restorationRatio: number | null;
+  readonly restorationYesVotes: number | null;
+  readonly restorationTotalVotes: number | null;
 }

--- a/apps/institution-web/src/screens/ClusterDetailScreen.test.tsx
+++ b/apps/institution-web/src/screens/ClusterDetailScreen.test.tsx
@@ -23,6 +23,9 @@ const sampleCluster: ClusterDetailResponse = {
   resolvedAt: null,
   locationLabel: "Ngong Road near Adams Arcade, Kilimani",
   responseStatus: "teams_dispatched",
+  restorationRatio: null,
+  restorationYesVotes: null,
+  restorationTotalVotes: null,
   officialPosts: [
     {
       id: "post-1",

--- a/apps/institution-web/src/screens/ClusterDetailScreen.tsx
+++ b/apps/institution-web/src/screens/ClusterDetailScreen.tsx
@@ -7,6 +7,7 @@ import { ErrorState } from "../components/ErrorState";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { institutionKeys } from "../query/keys";
 import { PostUpdateModal } from "./cluster/PostUpdateModal";
+import { RestorationActionCard } from "./cluster/RestorationActionCard";
 import { formatDurationSeconds } from "./signalFormatting";
 
 // Institution-scoped cluster detail. Pulls from
@@ -19,7 +20,9 @@ import { formatDurationSeconds } from "./signalFormatting";
 // Post-update (#203) is wired here as a peer card: the button opens
 // `PostUpdateModal`, which invalidates this cluster's query on
 // success so the new post surfaces in the list without an explicit
-// refetch. The restoration CTA (#204) slots in next to it.
+// refetch. Restoration (#204) sits below it as a state-aware card
+// (`RestorationActionCard`) so the composer and citizen-confirmation
+// banner share the same slot.
 export function ClusterDetailScreen() {
   const { clusterId } = useParams<{ clusterId: string }>();
   const [postModalOpen, setPostModalOpen] = useState(false);
@@ -98,6 +101,16 @@ export function ClusterDetailScreen() {
           <DetailField label="Active for" value={formatDurationSeconds(timeActiveSeconds)} />
         ) : null}
       </dl>
+
+      <RestorationActionCard
+        clusterId={signal.id}
+        clusterState={signal.state}
+        clusterCategory={signal.category}
+        restorationRatio={signal.restorationRatio}
+        restorationYesVotes={signal.restorationYesVotes}
+        restorationTotalVotes={signal.restorationTotalVotes}
+        resolvedAt={signal.resolvedAt}
+      />
 
       <section aria-label="Official updates" className="space-y-3">
         <h3 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">

--- a/apps/institution-web/src/screens/cluster/RestorationActionCard.test.tsx
+++ b/apps/institution-web/src/screens/cluster/RestorationActionCard.test.tsx
@@ -1,0 +1,157 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ComponentProps } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../../test/mockFetch";
+import { RestorationActionCard } from "./RestorationActionCard";
+
+function renderCard(overrides?: Partial<ComponentProps<typeof RestorationActionCard>>) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  const result = render(
+    <QueryClientProvider client={queryClient}>
+      <RestorationActionCard
+        clusterId={overrides?.clusterId ?? "cluster-1"}
+        clusterState={overrides?.clusterState ?? "active"}
+        clusterCategory={overrides?.clusterCategory ?? "electricity"}
+        restorationRatio={overrides?.restorationRatio ?? null}
+        restorationYesVotes={overrides?.restorationYesVotes ?? null}
+        restorationTotalVotes={overrides?.restorationTotalVotes ?? null}
+        resolvedAt={overrides?.resolvedAt ?? null}
+      />
+    </QueryClientProvider>,
+  );
+  return { ...result, queryClient };
+}
+
+describe("RestorationActionCard", () => {
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("renders nothing for an unconfirmed cluster", () => {
+    const { container } = renderCard({ clusterState: "unconfirmed" });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a 'Mark as restored' CTA when the cluster is active", () => {
+    renderCard({ clusterState: "active" });
+    expect(screen.getByRole("button", { name: /mark as restored/i })).toBeInTheDocument();
+  });
+
+  it("renders the awaiting-confirmation banner with ratio and votes for possible_restoration", () => {
+    renderCard({
+      clusterState: "possible_restoration",
+      restorationRatio: 0.67,
+      restorationYesVotes: 4,
+      restorationTotalVotes: 6,
+    });
+    expect(screen.getByText(/awaiting citizen confirmation/i)).toBeInTheDocument();
+    expect(screen.getByText("67%")).toBeInTheDocument();
+    // Yes votes = 4, total = 6.
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("6")).toBeInTheDocument();
+  });
+
+  it("falls back to em-dashes when restoration counts have not been populated yet", () => {
+    renderCard({ clusterState: "possible_restoration" });
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(3);
+    expect(screen.getByText(/no citizen responses yet/i)).toBeInTheDocument();
+  });
+
+  it("renders the resolved banner when the cluster is resolved", () => {
+    renderCard({
+      clusterState: "resolved",
+      resolvedAt: "2026-04-18T09:00:00Z",
+    });
+    expect(screen.getByText(/service restored/i)).toBeInTheDocument();
+    expect(screen.getByText(/citizen confirmations reached the threshold/i)).toBeInTheDocument();
+  });
+
+  it("submits a restoration claim via POST /v1/official-posts with isRestorationClaim true", async () => {
+    const captured: { url?: string; init?: RequestInit } = {};
+    mockFetch({
+      "/v1/official-posts": (url, init) => {
+        captured.url = url;
+        captured.init = init;
+        return jsonResponse(
+          {
+            id: "post-1",
+            institutionId: "inst-1",
+            type: "live_update",
+            category: "electricity",
+            title: "Service restored",
+            body: "Power is back on the affected blocks.",
+            startsAt: null,
+            endsAt: null,
+            status: "published",
+            relatedClusterId: "cluster-1",
+            isRestorationClaim: true,
+            createdAt: "2026-04-18T09:00:00Z",
+            responseStatus: "restoration_in_progress",
+            severity: null,
+          },
+          201,
+        );
+      },
+    });
+
+    renderCard({ clusterState: "active" });
+
+    await userEvent.click(screen.getByRole("button", { name: /mark as restored/i }));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(dialog).toHaveTextContent(/claim restoration/i);
+
+    await userEvent.type(screen.getByLabelText(/^body$/i), "Power is back on the affected blocks.");
+
+    await userEvent.click(screen.getByRole("button", { name: /confirm restoration claim/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+
+    expect(captured.init?.method).toBe("POST");
+    const body = JSON.parse(String(captured.init?.body));
+    expect(body).toMatchObject({
+      type: "live_update",
+      category: "electricity",
+      title: "Service restored",
+      body: "Power is back on the affected blocks.",
+      relatedClusterId: "cluster-1",
+      isRestorationClaim: true,
+      responseStatus: "restoration_in_progress",
+    });
+  });
+
+  it("surfaces a server error without closing the dialog", async () => {
+    mockFetch({
+      "/v1/official-posts": () => errorResponse(409, "cluster_not_active"),
+    });
+
+    renderCard({ clusterState: "active" });
+
+    await userEvent.click(screen.getByRole("button", { name: /mark as restored/i }));
+    await userEvent.type(screen.getByLabelText(/^body$/i), "Power is back.");
+    await userEvent.click(screen.getByRole("button", { name: /confirm restoration claim/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/backend rejected this restoration claim/i);
+    });
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("keeps the dialog open when the body is blank", async () => {
+    renderCard({ clusterState: "active" });
+
+    await userEvent.click(screen.getByRole("button", { name: /mark as restored/i }));
+    await userEvent.click(screen.getByRole("button", { name: /confirm restoration claim/i }));
+
+    // `required` on the textarea makes the browser block submission
+    // before handleSubmit runs — the dialog staying open is the
+    // affordance the user sees.
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+});

--- a/apps/institution-web/src/screens/cluster/RestorationActionCard.tsx
+++ b/apps/institution-web/src/screens/cluster/RestorationActionCard.tsx
@@ -1,0 +1,370 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type { FormEvent } from "react";
+import { useEffect, useId, useRef, useState } from "react";
+import { ApiError } from "../../api/client";
+import { createOfficialPost } from "../../api/officialPosts";
+import type {
+  CivicCategorySlug,
+  ClusterState,
+  OfficialPostCreateRequest,
+  OfficialPostResponse,
+} from "../../api/types";
+import { institutionKeys } from "../../query/keys";
+
+// Institution restoration action per Hali doctrine:
+//
+//   - Institutions can only *claim* restoration — the cluster moves to
+//     `possible_restoration`, not `resolved`.
+//   - Final resolution requires citizen confirmation (≥60% of
+//     restoration votes and ≥2 affected voters, enforced server-side).
+//   - A restoration claim is a `live_update` post with
+//     `isRestorationClaim: true`; the server handles the state
+//     transition and emits the outbox event.
+//
+// The card is state-aware:
+//   - `active`                 → "Mark as restored" CTA opens a
+//                                confirmation composer.
+//   - `possible_restoration`   → awaiting-citizen-confirmation banner
+//                                with live ratio + vote counts.
+//   - `resolved`               → static "Service restored" banner.
+//   - anything else            → renders nothing.
+
+const TITLE_MAX = 220;
+const BODY_MAX = 5000;
+
+export interface RestorationActionCardProps {
+  readonly clusterId: string;
+  readonly clusterState: ClusterState | string;
+  readonly clusterCategory: CivicCategorySlug | string;
+  readonly restorationRatio: number | null;
+  readonly restorationYesVotes: number | null;
+  readonly restorationTotalVotes: number | null;
+  readonly resolvedAt: string | null;
+}
+
+export function RestorationActionCard({
+  clusterId,
+  clusterState,
+  clusterCategory,
+  restorationRatio,
+  restorationYesVotes,
+  restorationTotalVotes,
+  resolvedAt,
+}: RestorationActionCardProps) {
+  const [composerOpen, setComposerOpen] = useState(false);
+
+  if (clusterState === "resolved") {
+    return <ResolvedBanner resolvedAt={resolvedAt} />;
+  }
+
+  if (clusterState === "possible_restoration") {
+    return (
+      <AwaitingBanner
+        ratio={restorationRatio}
+        yesVotes={restorationYesVotes}
+        totalVotes={restorationTotalVotes}
+      />
+    );
+  }
+
+  if (clusterState !== "active") {
+    return null;
+  }
+
+  return (
+    <section
+      aria-labelledby={`${clusterId}-restoration-heading`}
+      className="rounded-md border border-border bg-card p-4"
+    >
+      <h3
+        id={`${clusterId}-restoration-heading`}
+        className="text-sm font-semibold text-foreground"
+      >
+        Claim restoration
+      </h3>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Move this signal into citizen confirmation. Citizens within the cluster will be prompted
+        to confirm service is restored — the signal stays open until enough confirm.
+      </p>
+      <button
+        type="button"
+        onClick={() => setComposerOpen(true)}
+        className="mt-3 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+      >
+        Mark as restored
+      </button>
+      <RestorationClaimModal
+        clusterId={clusterId}
+        clusterCategory={clusterCategory}
+        open={composerOpen}
+        onClose={() => setComposerOpen(false)}
+      />
+    </section>
+  );
+}
+
+function ResolvedBanner({ resolvedAt }: { readonly resolvedAt: string | null }) {
+  const resolvedLabel = resolvedAt ? new Date(resolvedAt).toLocaleString() : null;
+  return (
+    <section
+      aria-label="Restoration status"
+      className="rounded-md border border-border bg-muted/40 p-4 text-sm text-foreground"
+    >
+      <p className="font-semibold">Service restored</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        Citizen confirmations reached the threshold and this signal is resolved.
+        {resolvedLabel ? ` Closed ${resolvedLabel}.` : null}
+      </p>
+    </section>
+  );
+}
+
+function AwaitingBanner({
+  ratio,
+  yesVotes,
+  totalVotes,
+}: {
+  readonly ratio: number | null;
+  readonly yesVotes: number | null;
+  readonly totalVotes: number | null;
+}) {
+  const percent = ratio !== null ? Math.round(ratio * 100) : null;
+  const countsKnown = yesVotes !== null && totalVotes !== null;
+  return (
+    <section
+      aria-label="Restoration status"
+      className="rounded-md border border-amber-300/60 bg-amber-50/60 p-4 text-sm text-foreground dark:border-amber-300/30 dark:bg-amber-900/20"
+    >
+      <p className="font-semibold">Awaiting citizen confirmation</p>
+      <p className="mt-1 text-xs text-muted-foreground">
+        You&apos;ve claimed restoration on this signal. It resolves once enough affected citizens
+        confirm (≥60% of restoration votes and at least 2 affected voters).
+      </p>
+      <dl className="mt-3 grid gap-2 sm:grid-cols-3">
+        <Stat
+          label="Confirmation ratio"
+          value={percent !== null ? `${percent}%` : "—"}
+          hint={percent !== null ? null : "No citizen responses yet."}
+        />
+        <Stat
+          label="Yes votes"
+          value={countsKnown ? String(yesVotes) : "—"}
+        />
+        <Stat
+          label="Total responses"
+          value={countsKnown ? String(totalVotes) : "—"}
+        />
+      </dl>
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  hint,
+}: {
+  readonly label: string;
+  readonly value: string;
+  readonly hint?: string | null;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">{label}</dt>
+      <dd className="text-sm font-medium text-foreground">{value}</dd>
+      {hint ? <p className="text-xs text-muted-foreground">{hint}</p> : null}
+    </div>
+  );
+}
+
+interface RestorationClaimModalProps {
+  readonly clusterId: string;
+  readonly clusterCategory: CivicCategorySlug | string;
+  readonly open: boolean;
+  readonly onClose: () => void;
+}
+
+function RestorationClaimModal({
+  clusterId,
+  clusterCategory,
+  open,
+  onClose,
+}: RestorationClaimModalProps) {
+  const titleInputId = useId();
+  const bodyInputId = useId();
+  const queryClient = useQueryClient();
+  const firstFieldRef = useRef<HTMLInputElement>(null);
+
+  const [title, setTitle] = useState("Service restored");
+  const [body, setBody] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+
+  const mutation = useMutation<OfficialPostResponse, Error, OfficialPostCreateRequest>({
+    mutationFn: (request) => createOfficialPost(request),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: institutionKeys.signalDetail(clusterId) });
+      onClose();
+    },
+  });
+
+  // Reset the form + mutation status when the modal closes so a
+  // reopened composer is blank and any stale server error is gone.
+  // `mutation.reset` is stable per the TanStack Query v5 useMutation
+  // contract, but not known-stable to React's dep checker — hence the
+  // ref wrapper instead of listing `mutation` (which is a new object
+  // every render and causes an infinite update loop).
+  const resetMutationRef = useRef(mutation.reset);
+  resetMutationRef.current = mutation.reset;
+  useEffect(() => {
+    if (open) {
+      firstFieldRef.current?.focus();
+    } else {
+      setTitle("Service restored");
+      setBody("");
+      setLocalError(null);
+      resetMutationRef.current();
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !mutation.isPending) {
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [open, mutation.isPending, onClose]);
+
+  if (!open) return null;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setLocalError(null);
+
+    const trimmedTitle = title.trim();
+    const trimmedBody = body.trim();
+    if (!trimmedTitle || !trimmedBody) {
+      setLocalError("Title and body are required.");
+      return;
+    }
+
+    mutation.mutate({
+      type: "live_update",
+      category: clusterCategory,
+      title: trimmedTitle,
+      body: trimmedBody,
+      relatedClusterId: clusterId,
+      isRestorationClaim: true,
+      responseStatus: "restoration_in_progress",
+    });
+  };
+
+  const serverError = mutation.error instanceof ApiError
+    ? `The backend rejected this restoration claim (${mutation.error.status}). Check the fields and retry.`
+    : mutation.error
+      ? "Something went wrong posting this restoration claim. Please retry."
+      : null;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`${titleInputId}-heading`}
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 px-4 py-8"
+    >
+      <div className="relative w-full max-w-xl rounded-lg border border-border bg-card p-6 shadow-lg">
+        <div className="mb-4 flex items-start justify-between gap-4">
+          <div>
+            <h2 id={`${titleInputId}-heading`} className="text-lg font-semibold text-foreground">
+              Claim restoration
+            </h2>
+            <p className="text-xs text-muted-foreground">
+              Citizens will see this update and be asked to confirm whether service is actually
+              restored. The signal only closes once enough of them confirm.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={mutation.isPending}
+            className="rounded-md px-2 py-1 text-sm text-muted-foreground hover:bg-muted disabled:opacity-60"
+            aria-label="Close"
+          >
+            ✕
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-1">
+            <label htmlFor={titleInputId} className="block text-xs font-medium text-foreground">
+              Title
+            </label>
+            <input
+              id={titleInputId}
+              ref={firstFieldRef}
+              type="text"
+              required
+              maxLength={TITLE_MAX}
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+            />
+            <p className="text-xs text-muted-foreground">
+              {title.length}/{TITLE_MAX}
+            </p>
+          </div>
+
+          <div className="space-y-1">
+            <label htmlFor={bodyInputId} className="block text-xs font-medium text-foreground">
+              Body
+            </label>
+            <textarea
+              id={bodyInputId}
+              required
+              maxLength={BODY_MAX}
+              value={body}
+              onChange={(event) => setBody(event.target.value)}
+              rows={5}
+              placeholder="Summarise what was restored and when. Citizens will see this verbatim."
+              className="w-full resize-y rounded-md border border-border bg-background px-3 py-2 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-foreground/20"
+            />
+            <p className="text-xs text-muted-foreground">
+              {body.length}/{BODY_MAX}
+            </p>
+          </div>
+
+          {localError ? (
+            <p role="alert" className="text-sm text-red-600">
+              {localError}
+            </p>
+          ) : null}
+          {serverError ? (
+            <p role="alert" className="text-sm text-red-600">
+              {serverError}
+            </p>
+          ) : null}
+
+          <div className="flex items-center justify-end gap-3 pt-2">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={mutation.isPending}
+              className="rounded-md border border-border bg-background px-4 py-2 text-sm font-medium text-foreground hover:bg-muted disabled:cursor-wait disabled:opacity-60"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={mutation.isPending}
+              className="rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90 disabled:cursor-wait disabled:opacity-60"
+            >
+              {mutation.isPending ? "Submitting…" : "Confirm restoration claim"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Implements #204 — institution restoration action UI on the cluster detail screen.

- **State-aware `RestorationActionCard`** replaces a plain CTA with three branches:
  - `active` → **Mark as restored** opens a confirmation composer that posts a `live_update` official post with `isRestorationClaim: true` and `responseStatus: restoration_in_progress`. The backend's existing Phase-11 trigger (`OfficialPostsService`) transitions the cluster to `possible_restoration`, writes the CIVIS decision, and emits the outbox event — we don't touch that path here.
  - `possible_restoration` → **Awaiting citizen confirmation** banner that surfaces the server-computed `restorationRatio` / `restorationYesVotes` / `restorationTotalVotes`.
  - `resolved` → static **Service restored** banner.
- Final resolution stays citizen-gated (≥60% + ≥2 affected voters, server-side). Institutions can only *claim* restoration per doctrine; they never close the signal directly.

## Contract
Adds `restorationRatio` / `restorationYesVotes` / `restorationTotalVotes` to `ClusterDetailResponse` so the three server-populated counts flow through the typed payload. Adds the `ClusterState` union to make the state-branching readable without widening the public surface. Removes the now-landed "consumed in #204" marker from the deliberate-omissions block.

## Doctrine filter
- **VALID AND ALIGNED** with the Hali restoration lifecycle (`docs/arch/05_civis_engine.md`, `02_openapi.yaml` `ClusterResponse`).
- Reuses the existing `POST /v1/official-posts` endpoint — no new route, no schema churn.
- No CIVIS internals exposed (ratio/yes/total are already public fields per OpenAPI).
- No citizen identity leakage.

## Test plan
- [x] 8 unit tests on `RestorationActionCard` (state branches, submit happy path, server error, blank-body guard).
- [x] Extended `ClusterDetailScreen.test.tsx` fixture with the new fields.
- [x] Extended Playwright smoke spec with a restoration-claim → awaiting-confirmation flow.
- [x] `npx tsc --noEmit` clean.
- [x] `npx eslint . --max-warnings=0` clean.
- [x] `npx vitest run` — 46/46 passing.

Closes #204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)