### PR TITLE
feat(institution-web): feature-flag gating for shell + per-feature CTAs (#205)

### DIFF
--- a/apps/institution-web/src/App.tsx
+++ b/apps/institution-web/src/App.tsx
@@ -1,17 +1,27 @@
 import { QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
+import { DashboardGate } from "./featureFlags/DashboardGate";
+import { FeatureFlagsProvider } from "./featureFlags/FeatureFlagsProvider";
 import { queryClient } from "./query/client";
 import { router } from "./router";
 
 // Application entrypoint. Mounts the TanStack Query cache provider so
-// every screen shares one client, then the router that renders the
-// institution shell and its screens. Auth gates (redirect to /login,
-// step-up prompts) land in #254 as a wrapper inside each route
-// element.
+// every screen shares one client, then the feature-flags provider
+// and master dashboard gate around the router. The gate resolves
+// `institution_web.enabled` before anything authenticated renders,
+// so a rollback-flipped flag blanks the shell without a redeploy.
+//
+// Auth gates (redirect to /login, step-up prompts) land in #254 as a
+// wrapper inside each route element, sitting below the flag gate so
+// login screens are also subject to the master rollout.
 export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <FeatureFlagsProvider>
+        <DashboardGate>
+          <RouterProvider router={router} />
+        </DashboardGate>
+      </FeatureFlagsProvider>
     </QueryClientProvider>
   );
 }

--- a/apps/institution-web/src/api/featureFlags.ts
+++ b/apps/institution-web/src/api/featureFlags.ts
@@ -1,0 +1,35 @@
+import { apiFetch } from "./client";
+
+// Client-visible feature flags resolved for the current request
+// context. The backend endpoint (`GET /v1/feature-flags`, see
+// `FeatureFlagsController`) returns a flat string→bool map containing
+// only flags declared as `ClientVisible`; server-only flags
+// (including the workers push dispatcher kill switch) never leak.
+//
+// The endpoint accepts `Accept: application/json`, is anonymous-safe
+// (falls back to `actor_type = "anonymous"`), and optionally takes a
+// `localityId` query string for locality-targeted rollouts. The
+// institution shell doesn't know a locality yet (no locality switcher
+// in this PR), so the default call is unscoped.
+
+export interface ResolvedFeatureFlags {
+  readonly flags: Readonly<Record<string, boolean>>;
+}
+
+export function getResolvedFeatureFlags(): Promise<ResolvedFeatureFlags> {
+  return apiFetch<ResolvedFeatureFlags>("/v1/feature-flags");
+}
+
+// Typed accessors for the institution dashboard's known flag keys.
+// Keeping them in one place means adding a new institution flag is
+// one spot in this file plus the Rust backend catalog — never a raw
+// string spread across screens. Mirrors the "typed-not-stringly"
+// rule in docs/arch/FEATURE_FLIGHTING_MODEL.md §1.
+export const InstitutionWebFlagKeys = {
+  enabled: "institution_web.enabled",
+  postUpdateEnabled: "institution_web.post_update.enabled",
+  restorationClaimEnabled: "institution_web.restoration_claim.enabled",
+} as const;
+
+export type InstitutionWebFlagKey =
+  (typeof InstitutionWebFlagKeys)[keyof typeof InstitutionWebFlagKeys];

--- a/apps/institution-web/src/featureFlags/DashboardGate.test.tsx
+++ b/apps/institution-web/src/featureFlags/DashboardGate.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { FeatureFlagsTestProvider } from "../test/featureFlagsTestProvider";
+import { DashboardGate } from "./DashboardGate";
+import { InstitutionWebFlagKeys } from "./FeatureFlagsProvider";
+
+// The gate consumes `useFeatureFlag` + `useFeatureFlagsStatus`; we
+// drive each state deterministically via `FeatureFlagsTestProvider`
+// so the assertions don't hinge on async fetch timing (the wire
+// behaviour is covered in FeatureFlagsProvider.test.tsx).
+
+describe("DashboardGate", () => {
+  it("renders the loading surface while flags resolve", () => {
+    render(
+      <FeatureFlagsTestProvider isLoading>
+        <DashboardGate>
+          <span>shell</span>
+        </DashboardGate>
+      </FeatureFlagsTestProvider>,
+    );
+    const status = screen.getByTestId("dashboard-gate-status");
+    expect(status).toHaveAttribute("data-state", "loading");
+    expect(status).toHaveTextContent(/resolving dashboard access/i);
+    expect(screen.queryByText("shell")).not.toBeInTheDocument();
+  });
+
+  it("renders the disabled surface when the master flag is off", () => {
+    render(
+      <FeatureFlagsTestProvider
+        override={{ [InstitutionWebFlagKeys.enabled]: false }}
+      >
+        <DashboardGate>
+          <span>shell</span>
+        </DashboardGate>
+      </FeatureFlagsTestProvider>,
+    );
+    const status = screen.getByTestId("dashboard-gate-status");
+    expect(status).toHaveAttribute("data-state", "disabled");
+    expect(status).toHaveTextContent(/currently unavailable/i);
+    expect(screen.queryByText("shell")).not.toBeInTheDocument();
+  });
+
+  it("renders its children when the master flag is enabled", () => {
+    render(
+      <FeatureFlagsTestProvider
+        override={{ [InstitutionWebFlagKeys.enabled]: true }}
+      >
+        <DashboardGate>
+          <span>shell</span>
+        </DashboardGate>
+      </FeatureFlagsTestProvider>,
+    );
+    expect(screen.getByText("shell")).toBeInTheDocument();
+    expect(screen.queryByTestId("dashboard-gate-status")).not.toBeInTheDocument();
+  });
+});

--- a/apps/institution-web/src/featureFlags/DashboardGate.tsx
+++ b/apps/institution-web/src/featureFlags/DashboardGate.tsx
@@ -1,0 +1,75 @@
+import type { ReactNode } from "react";
+import {
+  InstitutionWebFlagKeys,
+  useFeatureFlag,
+  useFeatureFlagsStatus,
+} from "./FeatureFlagsProvider";
+
+// Master shell gate driven by `institution_web.enabled`. Wraps the
+// whole router so a flipped flag blanks every authenticated surface
+// — including the topbar, sidebar, and screens — without requiring
+// a redeploy.
+//
+// While the flag fetch is in flight we render a minimal loading
+// surface; rendering the real shell and then pulling it back would
+// let a user click into a feature that's about to vanish. If the
+// fetch fails we fall through to the "disabled" surface, matching
+// the conservative default in `FeatureFlagsProvider`.
+//
+// The "dashboard-gate-status" data attribute is the integration
+// hook used by tests and observability probes to distinguish the
+// three states without colour-matching the copy.
+
+export interface DashboardGateProps {
+  readonly children: ReactNode;
+}
+
+export function DashboardGate({ children }: DashboardGateProps) {
+  const { isLoading } = useFeatureFlagsStatus();
+  const enabled = useFeatureFlag(InstitutionWebFlagKeys.enabled);
+
+  if (isLoading) {
+    return <GateLoading />;
+  }
+
+  if (!enabled) {
+    return <GateDisabled />;
+  }
+
+  return <>{children}</>;
+}
+
+function GateLoading() {
+  return (
+    <div
+      data-testid="dashboard-gate-status"
+      data-state="loading"
+      className="flex min-h-screen items-center justify-center bg-background text-sm text-muted-foreground"
+      role="status"
+      aria-live="polite"
+    >
+      Resolving dashboard access…
+    </div>
+  );
+}
+
+function GateDisabled() {
+  return (
+    <div
+      data-testid="dashboard-gate-status"
+      data-state="disabled"
+      className="flex min-h-screen items-center justify-center bg-background px-6"
+      role="alert"
+    >
+      <div className="max-w-md space-y-3 text-center">
+        <h1 className="text-xl font-semibold text-foreground">
+          The institution dashboard is currently unavailable.
+        </h1>
+        <p className="text-sm text-muted-foreground">
+          Access to this surface is controlled by a rollout flag. If you believe you should have
+          access, contact your Hali Ops partner — no action is required from your side.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/institution-web/src/featureFlags/FeatureFlagsProvider.test.tsx
+++ b/apps/institution-web/src/featureFlags/FeatureFlagsProvider.test.tsx
@@ -1,0 +1,92 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen, waitFor } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../test/mockFetch";
+import {
+  FeatureFlagsProvider,
+  InstitutionWebFlagKeys,
+  useFeatureFlag,
+  useFeatureFlagsStatus,
+} from "./FeatureFlagsProvider";
+
+function renderWithClient(children: ReactNode) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, staleTime: 0 } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FeatureFlagsProvider>{children}</FeatureFlagsProvider>
+    </QueryClientProvider>,
+  );
+}
+
+function FlagProbe({ flagKey }: { readonly flagKey: string }) {
+  const enabled = useFeatureFlag(flagKey as never);
+  const { isLoading, isError } = useFeatureFlagsStatus();
+  return (
+    <div>
+      <span data-testid="loading">{isLoading ? "yes" : "no"}</span>
+      <span data-testid="error">{isError ? "yes" : "no"}</span>
+      <span data-testid="flag">{enabled ? "on" : "off"}</span>
+    </div>
+  );
+}
+
+describe("FeatureFlagsProvider", () => {
+  afterEach(() => {
+    restoreFetch();
+  });
+
+  it("exposes resolved flags from /v1/feature-flags", async () => {
+    mockFetch({
+      "/v1/feature-flags": () =>
+        jsonResponse({
+          flags: {
+            [InstitutionWebFlagKeys.enabled]: true,
+            [InstitutionWebFlagKeys.postUpdateEnabled]: false,
+          },
+        }),
+    });
+
+    renderWithClient(<FlagProbe flagKey={InstitutionWebFlagKeys.enabled} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("no");
+    });
+    expect(screen.getByTestId("flag")).toHaveTextContent("on");
+    expect(screen.getByTestId("error")).toHaveTextContent("no");
+  });
+
+  it("returns false for keys missing from the resolved payload", async () => {
+    mockFetch({
+      "/v1/feature-flags": () => jsonResponse({ flags: {} }),
+    });
+
+    renderWithClient(<FlagProbe flagKey={InstitutionWebFlagKeys.postUpdateEnabled} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("loading")).toHaveTextContent("no");
+    });
+    expect(screen.getByTestId("flag")).toHaveTextContent("off");
+  });
+
+  it("safe-disables every flag when the fetch fails", async () => {
+    mockFetch({
+      "/v1/feature-flags": () => errorResponse(500),
+    });
+
+    renderWithClient(<FlagProbe flagKey={InstitutionWebFlagKeys.enabled} />);
+
+    // The provider retries once before surfacing an error — allow
+    // enough time for the retry + error-state settle. The per-test
+    // timeout is the default 5s, so 4s gives comfortable headroom.
+    await waitFor(
+      () => {
+        expect(screen.getByTestId("error")).toHaveTextContent("yes");
+      },
+      { timeout: 4_000 },
+    );
+    expect(screen.getByTestId("flag")).toHaveTextContent("off");
+  });
+});

--- a/apps/institution-web/src/featureFlags/FeatureFlagsProvider.tsx
+++ b/apps/institution-web/src/featureFlags/FeatureFlagsProvider.tsx
@@ -1,0 +1,85 @@
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { createContext, useContext, useMemo } from "react";
+import {
+  getResolvedFeatureFlags,
+  InstitutionWebFlagKeys,
+  type InstitutionWebFlagKey,
+} from "../api/featureFlags";
+
+// Feature-flag context for the institution dashboard.
+//
+// The provider wraps the router and issues a single `/v1/feature-flags`
+// request at mount, caching the result in TanStack Query. A loading
+// fallback blanks the shell while flags resolve — a flash of enabled-
+// UI would undermine the master gate (users could click into a
+// disabled feature during the window before the flags arrive).
+//
+// On error we fall back to "all off" rather than "all on": the master
+// gate (`institution_web.enabled`) being off surfaces the locked
+// screen, which is the correct conservative behaviour when the flag
+// service is unreachable. This matches the "safe disablement" line
+// in #205's acceptance criteria.
+//
+// Flag lookups always go through the typed `useFeatureFlag(key)` hook
+// so consumers can't accidentally depend on a bare string key; adding
+// a new flag is one spot in `api/featureFlags.ts` plus the backend
+// catalog.
+
+export interface FeatureFlagsContextValue {
+  readonly isLoading: boolean;
+  readonly isError: boolean;
+  readonly isFlagEnabled: (key: InstitutionWebFlagKey) => boolean;
+}
+
+const defaultContext: FeatureFlagsContextValue = {
+  isLoading: true,
+  isError: false,
+  isFlagEnabled: () => false,
+};
+
+export const FeatureFlagsContext = createContext<FeatureFlagsContextValue>(defaultContext);
+
+export interface FeatureFlagsProviderProps {
+  readonly children: ReactNode;
+}
+
+export function FeatureFlagsProvider({ children }: FeatureFlagsProviderProps) {
+  const query = useQuery({
+    queryKey: ["feature-flags", "institution"] as const,
+    queryFn: getResolvedFeatureFlags,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  const value = useMemo<FeatureFlagsContextValue>(() => {
+    const flagMap = query.data?.flags ?? {};
+    return {
+      isLoading: query.isLoading,
+      isError: query.isError,
+      isFlagEnabled: (key) => flagMap[key] === true,
+    };
+  }, [query.data, query.isLoading, query.isError]);
+
+  return (
+    <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>
+  );
+}
+
+export function useFeatureFlag(key: InstitutionWebFlagKey): boolean {
+  const { isFlagEnabled } = useContext(FeatureFlagsContext);
+  return isFlagEnabled(key);
+}
+
+export function useFeatureFlagsStatus(): Pick<
+  FeatureFlagsContextValue,
+  "isLoading" | "isError"
+> {
+  const { isLoading, isError } = useContext(FeatureFlagsContext);
+  return { isLoading, isError };
+}
+
+// Re-export the flag-key constants so call sites only import from one
+// place.
+export { InstitutionWebFlagKeys };

--- a/apps/institution-web/src/screens/ClusterDetailScreen.test.tsx
+++ b/apps/institution-web/src/screens/ClusterDetailScreen.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it } from "vitest";
 import type { ClusterDetailResponse } from "../api/types";
+import { InstitutionWebFlagKeys } from "../featureFlags/FeatureFlagsProvider";
 import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../test/mockFetch";
 import { renderWithProviders } from "../test/renderWithProviders";
 
@@ -115,5 +116,33 @@ describe("ClusterDetailScreen", () => {
     await waitFor(() => {
       expect(screen.getByRole("alert")).toHaveTextContent(/couldn't load this signal/i);
     });
+  });
+
+  it("hides the Post an update trigger when the post-update kill switch is off", async () => {
+    mockFetch({
+      [`/v1/institution/signals/${clusterId}`]: () => jsonResponse(sampleCluster),
+    });
+
+    renderWithProviders({
+      pathname: `/signals/${clusterId}`,
+      flagOverride: { [InstitutionWebFlagKeys.postUpdateEnabled]: false },
+    });
+
+    await screen.findByRole("heading", { level: 2, name: /power outage on ngong road/i });
+    expect(screen.queryByRole("button", { name: /post an update/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the Mark as restored trigger when the restoration kill switch is off", async () => {
+    mockFetch({
+      [`/v1/institution/signals/${clusterId}`]: () => jsonResponse(sampleCluster),
+    });
+
+    renderWithProviders({
+      pathname: `/signals/${clusterId}`,
+      flagOverride: { [InstitutionWebFlagKeys.restorationClaimEnabled]: false },
+    });
+
+    await screen.findByRole("heading", { level: 2, name: /power outage on ngong road/i });
+    expect(screen.queryByRole("button", { name: /mark as restored/i })).not.toBeInTheDocument();
   });
 });

--- a/apps/institution-web/src/screens/ClusterDetailScreen.tsx
+++ b/apps/institution-web/src/screens/ClusterDetailScreen.tsx
@@ -6,6 +6,10 @@ import type { OfficialPostResponse } from "../api/types";
 import { ErrorState } from "../components/ErrorState";
 import { LoadingSkeleton } from "../components/LoadingSkeleton";
 import { institutionKeys } from "../query/keys";
+import {
+  InstitutionWebFlagKeys,
+  useFeatureFlag,
+} from "../featureFlags/FeatureFlagsProvider";
 import { PostUpdateModal } from "./cluster/PostUpdateModal";
 import { RestorationActionCard } from "./cluster/RestorationActionCard";
 import { formatDurationSeconds } from "./signalFormatting";
@@ -26,6 +30,7 @@ import { formatDurationSeconds } from "./signalFormatting";
 export function ClusterDetailScreen() {
   const { clusterId } = useParams<{ clusterId: string }>();
   const [postModalOpen, setPostModalOpen] = useState(false);
+  const postUpdateEnabled = useFeatureFlag(InstitutionWebFlagKeys.postUpdateEnabled);
 
   const cluster = useQuery({
     queryKey: institutionKeys.signalDetail(clusterId ?? ""),
@@ -75,13 +80,15 @@ export function ClusterDetailScreen() {
             <p className="text-sm text-muted-foreground">{signal.locationLabel}</p>
           ) : null}
         </div>
-        <button
-          type="button"
-          onClick={() => setPostModalOpen(true)}
-          className="shrink-0 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
-        >
-          Post an update
-        </button>
+        {postUpdateEnabled ? (
+          <button
+            type="button"
+            onClick={() => setPostModalOpen(true)}
+            className="shrink-0 rounded-md bg-foreground px-4 py-2 text-sm font-medium text-background hover:opacity-90"
+          >
+            Post an update
+          </button>
+        ) : null}
       </header>
 
       {signal.summary ? (
@@ -136,12 +143,14 @@ export function ClusterDetailScreen() {
         Back to signals
       </Link>
 
-      <PostUpdateModal
-        clusterId={signal.id}
-        clusterCategory={signal.category}
-        open={postModalOpen}
-        onClose={() => setPostModalOpen(false)}
-      />
+      {postUpdateEnabled ? (
+        <PostUpdateModal
+          clusterId={signal.id}
+          clusterCategory={signal.category}
+          open={postModalOpen}
+          onClose={() => setPostModalOpen(false)}
+        />
+      ) : null}
     </article>
   );
 }

--- a/apps/institution-web/src/screens/cluster/PostUpdateModal.test.tsx
+++ b/apps/institution-web/src/screens/cluster/PostUpdateModal.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { FeatureFlagsTestProvider } from "../../test/featureFlagsTestProvider";
 import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../../test/mockFetch";
 import { PostUpdateModal } from "./PostUpdateModal";
 
@@ -13,12 +14,14 @@ function renderModal(overrides?: Partial<ComponentProps<typeof PostUpdateModal>>
   });
   const result = render(
     <QueryClientProvider client={queryClient}>
-      <PostUpdateModal
-        clusterId={overrides?.clusterId ?? "cluster-1"}
-        clusterCategory={overrides?.clusterCategory ?? "electricity"}
-        open={overrides?.open ?? true}
-        onClose={onClose}
-      />
+      <FeatureFlagsTestProvider>
+        <PostUpdateModal
+          clusterId={overrides?.clusterId ?? "cluster-1"}
+          clusterCategory={overrides?.clusterCategory ?? "electricity"}
+          open={overrides?.open ?? true}
+          onClose={onClose}
+        />
+      </FeatureFlagsTestProvider>
     </QueryClientProvider>,
   );
   return { ...result, onClose, queryClient };

--- a/apps/institution-web/src/screens/cluster/RestorationActionCard.test.tsx
+++ b/apps/institution-web/src/screens/cluster/RestorationActionCard.test.tsx
@@ -3,24 +3,32 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { ComponentProps } from "react";
 import { afterEach, describe, expect, it } from "vitest";
+import { InstitutionWebFlagKeys } from "../../featureFlags/FeatureFlagsProvider";
+import { FeatureFlagsTestProvider } from "../../test/featureFlagsTestProvider";
 import { errorResponse, jsonResponse, mockFetch, restoreFetch } from "../../test/mockFetch";
 import { RestorationActionCard } from "./RestorationActionCard";
 
-function renderCard(overrides?: Partial<ComponentProps<typeof RestorationActionCard>>) {
+interface RenderCardOptions extends Partial<ComponentProps<typeof RestorationActionCard>> {
+  readonly flagOverride?: Readonly<Record<string, boolean>>;
+}
+
+function renderCard(overrides?: RenderCardOptions) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
   const result = render(
     <QueryClientProvider client={queryClient}>
-      <RestorationActionCard
-        clusterId={overrides?.clusterId ?? "cluster-1"}
-        clusterState={overrides?.clusterState ?? "active"}
-        clusterCategory={overrides?.clusterCategory ?? "electricity"}
-        restorationRatio={overrides?.restorationRatio ?? null}
-        restorationYesVotes={overrides?.restorationYesVotes ?? null}
-        restorationTotalVotes={overrides?.restorationTotalVotes ?? null}
-        resolvedAt={overrides?.resolvedAt ?? null}
-      />
+      <FeatureFlagsTestProvider override={overrides?.flagOverride}>
+        <RestorationActionCard
+          clusterId={overrides?.clusterId ?? "cluster-1"}
+          clusterState={overrides?.clusterState ?? "active"}
+          clusterCategory={overrides?.clusterCategory ?? "electricity"}
+          restorationRatio={overrides?.restorationRatio ?? null}
+          restorationYesVotes={overrides?.restorationYesVotes ?? null}
+          restorationTotalVotes={overrides?.restorationTotalVotes ?? null}
+          resolvedAt={overrides?.resolvedAt ?? null}
+        />
+      </FeatureFlagsTestProvider>
     </QueryClientProvider>,
   );
   return { ...result, queryClient };
@@ -153,5 +161,24 @@ describe("RestorationActionCard", () => {
     // before handleSubmit runs — the dialog staying open is the
     // affordance the user sees.
     expect(screen.getByRole("dialog")).toBeInTheDocument();
+  });
+
+  it("hides the active-state CTA when the restoration kill switch is off", () => {
+    const { container } = renderCard({
+      clusterState: "active",
+      flagOverride: { [InstitutionWebFlagKeys.restorationClaimEnabled]: false },
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("still renders the awaiting banner when the kill switch is off", () => {
+    renderCard({
+      clusterState: "possible_restoration",
+      restorationRatio: 0.5,
+      restorationYesVotes: 3,
+      restorationTotalVotes: 6,
+      flagOverride: { [InstitutionWebFlagKeys.restorationClaimEnabled]: false },
+    });
+    expect(screen.getByText(/awaiting citizen confirmation/i)).toBeInTheDocument();
   });
 });

--- a/apps/institution-web/src/screens/cluster/RestorationActionCard.tsx
+++ b/apps/institution-web/src/screens/cluster/RestorationActionCard.tsx
@@ -9,6 +9,10 @@ import type {
   OfficialPostCreateRequest,
   OfficialPostResponse,
 } from "../../api/types";
+import {
+  InstitutionWebFlagKeys,
+  useFeatureFlag,
+} from "../../featureFlags/FeatureFlagsProvider";
 import { institutionKeys } from "../../query/keys";
 
 // Institution restoration action per Hali doctrine:
@@ -52,6 +56,7 @@ export function RestorationActionCard({
   resolvedAt,
 }: RestorationActionCardProps) {
   const [composerOpen, setComposerOpen] = useState(false);
+  const restorationEnabled = useFeatureFlag(InstitutionWebFlagKeys.restorationClaimEnabled);
 
   if (clusterState === "resolved") {
     return <ResolvedBanner resolvedAt={resolvedAt} />;
@@ -68,6 +73,14 @@ export function RestorationActionCard({
   }
 
   if (clusterState !== "active") {
+    return null;
+  }
+
+  // Read-only screens remain under the master gate; only the
+  // mutation CTA is hidden when the kill switch flips. The composer
+  // modal is not mounted so a user deep-linking to a stale tab
+  // can't re-use a cached modal render.
+  if (!restorationEnabled) {
     return null;
   }
 

--- a/apps/institution-web/src/test/featureFlagsTestProvider.tsx
+++ b/apps/institution-web/src/test/featureFlagsTestProvider.tsx
@@ -1,0 +1,38 @@
+import type { ReactNode } from "react";
+import {
+  FeatureFlagsContext,
+  type FeatureFlagsContextValue,
+} from "../featureFlags/FeatureFlagsProvider";
+
+// Test-only provider that short-circuits the `/v1/feature-flags`
+// fetch. Shell and screen tests care about the rendered surface, not
+// the flag-resolution wire; mounting the real provider would force
+// every test to stub the endpoint before arranging its own fixture.
+//
+// Default is "every flag enabled" so tests written before #205 keep
+// passing without change; a test that needs the opposite can pass an
+// `override` with the specific keys it wants to flip off. The
+// dedicated DashboardGate / FeatureFlagsProvider tests still mount
+// the real provider against a mocked fetch so the wire behaviour is
+// covered.
+
+export interface FeatureFlagsTestProviderProps {
+  readonly children: ReactNode;
+  readonly override?: Readonly<Record<string, boolean>>;
+  readonly isLoading?: boolean;
+  readonly isError?: boolean;
+}
+
+export function FeatureFlagsTestProvider({
+  children,
+  override,
+  isLoading = false,
+  isError = false,
+}: FeatureFlagsTestProviderProps) {
+  const value: FeatureFlagsContextValue = {
+    isLoading,
+    isError,
+    isFlagEnabled: (key) => (override && key in override ? override[key] === true : true),
+  };
+  return <FeatureFlagsContext.Provider value={value}>{children}</FeatureFlagsContext.Provider>;
+}

--- a/apps/institution-web/src/test/renderWithProviders.tsx
+++ b/apps/institution-web/src/test/renderWithProviders.tsx
@@ -3,21 +3,31 @@ import { render, type RenderResult } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import { institutionRoutes } from "../router";
+import { FeatureFlagsTestProvider } from "./featureFlagsTestProvider";
 
 // Test utility that mirrors App.tsx — QueryClientProvider wrapping
 // the institution router — but with memory-based routing and a fresh
 // QueryClient so test state never leaks. Every call creates its own
 // client so retries and error caches don't bleed between cases.
+//
+// Flags are stubbed-enabled by default via `FeatureFlagsTestProvider`
+// so screen tests written before #205 keep working without pulling
+// in the `/v1/feature-flags` endpoint; the real provider is exercised
+// by its own tests.
 
 export interface RenderOptions {
   readonly pathname: string;
+  readonly flagOverride?: Readonly<Record<string, boolean>>;
 }
 
 export interface RenderResultWithClient extends RenderResult {
   readonly queryClient: QueryClient;
 }
 
-export function renderWithProviders({ pathname }: RenderOptions): RenderResultWithClient {
+export function renderWithProviders({
+  pathname,
+  flagOverride,
+}: RenderOptions): RenderResultWithClient {
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
@@ -31,7 +41,9 @@ export function renderWithProviders({ pathname }: RenderOptions): RenderResultWi
 
   const result = render(
     <QueryClientProvider client={queryClient}>
-      <RouterProvider router={router} />
+      <FeatureFlagsTestProvider override={flagOverride}>
+        <RouterProvider router={router} />
+      </FeatureFlagsTestProvider>
     </QueryClientProvider>,
   );
 
@@ -39,7 +51,7 @@ export function renderWithProviders({ pathname }: RenderOptions): RenderResultWi
 }
 
 // Smaller wrapper for screens that don't need routing context — lets
-// tests render a single screen with just the query provider.
+// tests render a single screen with just the query and flag providers.
 export function withQueryClient(children: ReactNode, client?: QueryClient): RenderResult {
   const queryClient =
     client ??
@@ -48,5 +60,9 @@ export function withQueryClient(children: ReactNode, client?: QueryClient): Rend
         queries: { retry: false, staleTime: 0 },
       },
     });
-  return render(<QueryClientProvider client={queryClient}>{children}</QueryClientProvider>);
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <FeatureFlagsTestProvider>{children}</FeatureFlagsTestProvider>
+    </QueryClientProvider>,
+  );
 }

--- a/src/Hali.Application/FeatureFlags/FeatureFlags.cs
+++ b/src/Hali.Application/FeatureFlags/FeatureFlags.cs
@@ -46,6 +46,54 @@ public static class FeatureFlags
             new() { Environment = "Development", Value = true },
         });
 
+    // ── Phase 2 institution dashboard master gate. When off, the shell
+    // renders a locked-out state regardless of the user's grants — used
+    // to roll back the surface without a redeploy. Defaults off; flipped
+    // on in Development via targeting and flipped on per institution in
+    // Staging/Production as the rollout progresses.
+    public static readonly BooleanFeatureFlag InstitutionWebEnabled = new(
+        name: "institution_web.enabled",
+        description: "Master gate for the institution operations dashboard shell.",
+        owner: "@irvinesunday",
+        kind: FlagKind.Pilot,
+        visibility: FlagVisibility.ClientVisible,
+        isPermanent: false,
+        expectedRetirement: new DateOnly(2026, 12, 31),
+        @default: false,
+        targeting: new List<FlagRule>
+        {
+            new() { Environment = "Development", Value = true },
+        });
+
+    // ── Gates the "Post an update" composer on the cluster detail
+    // screen. Separate from the master gate so a failing mutation can
+    // be disabled without losing read-only dashboard visibility.
+    public static readonly BooleanFeatureFlag InstitutionWebPostUpdateEnabled = new(
+        name: "institution_web.post_update.enabled",
+        description: "Enables the official-update composer on cluster detail (institution dashboard).",
+        owner: "@irvinesunday",
+        kind: FlagKind.KillSwitch,
+        visibility: FlagVisibility.ClientVisible,
+        isPermanent: true,
+        expectedRetirement: null,
+        @default: true,
+        targeting: new List<FlagRule>());
+
+    // ── Gates the restoration-claim CTA on the cluster detail screen.
+    // Separate from the post-update flag because restoration triggers
+    // a backend state transition; a failure mode in the transition
+    // pipeline can be isolated without disabling other update kinds.
+    public static readonly BooleanFeatureFlag InstitutionWebRestorationClaimEnabled = new(
+        name: "institution_web.restoration_claim.enabled",
+        description: "Enables the institution restoration-claim action on cluster detail.",
+        owner: "@irvinesunday",
+        kind: FlagKind.KillSwitch,
+        visibility: FlagVisibility.ClientVisible,
+        isPermanent: true,
+        expectedRetirement: null,
+        @default: true,
+        targeting: new List<FlagRule>());
+
     /// <summary>
     /// Complete catalog. Kept in the same declaration order as the fields
     /// above; enumeration order is stable for consumers.
@@ -54,5 +102,8 @@ public static class FeatureFlags
     {
         WorkersPushDispatcherEnabled,
         MobileHomeConditionBadgeEnabled,
+        InstitutionWebEnabled,
+        InstitutionWebPostUpdateEnabled,
+        InstitutionWebRestorationClaimEnabled,
     };
 }


### PR DESCRIPTION
Closes #205.

## Summary
- **Backend:** adds three client-visible flags to `Hali.Application/FeatureFlags/FeatureFlags.cs` — `institution_web.enabled` (Pilot, default-off except in Development), `institution_web.post_update.enabled` (KillSwitch, default-on), `institution_web.restoration_claim.enabled` (KillSwitch, default-on).
- **Frontend:** new `FeatureFlagsProvider` fetches `GET /v1/feature-flags` once at mount via TanStack Query and exposes a typed `useFeatureFlag(key)` accessor. On error, every flag resolves to false — the master gate then correctly surfaces the "disabled" screen instead of flashing a broken shell.
- `DashboardGate` wraps the router and drives three states via `data-testid="dashboard-gate-status"`: `loading` while the flag query is in flight, `disabled` when `institution_web.enabled` is off, and the children when enabled.
- Per-feature gates applied to the **Post an update** trigger + modal and the restoration-claim CTA. Read-only surfaces (awaiting banner, resolved banner, official-post list) remain visible when the kill switches flip so operators never lose read access during a rollback.

## Tests
- Real-fetch tests for `FeatureFlagsProvider` cover hit, missing-key (default-off), and error → safe-disable.
- Context-override tests for `DashboardGate` cover the three shell states.
- `renderWithProviders` and the screen-specific helpers now wrap children in a `FeatureFlagsTestProvider` (all flags on by default, per-key overrides optional). New assertions verify both CTAs hide when their kill switches are off.
- All 56 institution-web vitest tests pass; \`dotnet build\` clean; \`npx tsc --noEmit\` and \`npx eslint . --max-warnings=0\` clean.

## Rollout
- Start with `institution_web.enabled = true` only for the Development environment (as shipped) plus opt-in pilot tenants via a later targeting rule.
- Kill switches default-on: if the Post-Update or Restoration-Claim surfaces misbehave in production, flipping the corresponding flag disables the CTA within one cache window without a redeploy.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint . --max-warnings=0` clean
- [x] `npx vitest run` — 56 tests passing
- [x] `dotnet build` clean (0 errors, pre-existing warnings only)
- [x] `dotnet test tests/Hali.Tests.Unit --filter FeatureFlag` — 16 passing
- [ ] CI green
- [ ] Manual smoke: dashboard renders for `institution_web.enabled=true`, blank for `false`, loading state visible during in-flight fetch

🤖 Generated with [Claude Code](https://claude.com/claude-code)