### PR TITLE
feat(hali-web): Phase C — /how-it-works page

### DIFF
--- a/apps/hali-web/app/how-it-works/page.tsx
+++ b/apps/hali-web/app/how-it-works/page.tsx
@@ -1,2 +1,30 @@
-export const metadata = { title: 'How Hali works — The civic feedback loop' }
-export default function HowItWorksPage() { return <main /> }
+import HowItWorksHero from '@/components/how-it-works/HowItWorksHero'
+import ExpandedCivicLoop from '@/components/how-it-works/ExpandedCivicLoop'
+import ParticipationDetail from '@/components/how-it-works/ParticipationDetail'
+import ResolutionExplained from '@/components/how-it-works/ResolutionExplained'
+import HowItWorksCtaSection from '@/components/how-it-works/HowItWorksCtaSection'
+
+export const metadata = {
+  title: 'How Hali works — The civic feedback loop',
+  description:
+    'Understand how citizen signals become visible civic conditions, how institutions respond, and how resolution is confirmed — not declared.',
+  openGraph: {
+    title: 'How Hali works — The civic feedback loop',
+    description:
+      'Understand how citizen signals become visible civic conditions, how institutions respond, and how resolution is confirmed — not declared.',
+    url: 'https://gethali.app/how-it-works',
+    images: [{ url: '/og-image.png', width: 1200, height: 630 }],
+  },
+}
+
+export default function HowItWorksPage() {
+  return (
+    <main>
+      <HowItWorksHero />
+      <ExpandedCivicLoop />
+      <ParticipationDetail />
+      <ResolutionExplained />
+      <HowItWorksCtaSection />
+    </main>
+  )
+}

--- a/apps/hali-web/components/how-it-works/CivicLoopStage.tsx
+++ b/apps/hali-web/components/how-it-works/CivicLoopStage.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import type { ReactNode } from 'react'
+
+export interface CivicLoopStageProps {
+  stageNumber: number
+  title: string
+  icon: ReactNode
+  explanation: string
+  example: string
+  isLast?: boolean
+}
+
+export default function CivicLoopStage({
+  stageNumber,
+  title,
+  icon,
+  explanation,
+  example,
+  isLast = false,
+}: CivicLoopStageProps) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true }}
+      transition={{ duration: 0.5 }}
+      className={`relative py-16 md:py-20 ${
+        isLast ? '' : 'border-b border-hali-border'
+      }`}
+    >
+      <div className="grid md:grid-cols-[30%_70%] gap-8 md:gap-10 items-start">
+        {/* Left — decorative number + icon */}
+        <div className="relative">
+          <span
+            aria-hidden="true"
+            className="absolute -top-6 md:-top-8 -left-2 font-display text-8xl font-bold text-hali-primary opacity-10 leading-none select-none pointer-events-none"
+          >
+            {stageNumber}
+          </span>
+          <div className="relative text-hali-primary w-10 h-10">{icon}</div>
+        </div>
+
+        {/* Right — content */}
+        <div className="max-w-2xl">
+          <h3 className="font-display text-2xl font-bold text-hali-foreground">
+            {title}
+          </h3>
+          <p className="mt-4 text-base leading-relaxed text-hali-foreground">
+            {explanation}
+          </p>
+
+          <div className="mt-4 bg-hali-surface border-l-4 border-hali-primary rounded-r-lg p-4 pl-5">
+            <p className="text-xs font-semibold uppercase tracking-wider text-hali-muted-foreground">
+              In practice
+            </p>
+            <p className="mt-2 text-sm text-hali-foreground italic leading-relaxed">
+              {example}
+            </p>
+          </div>
+        </div>
+      </div>
+    </motion.div>
+  )
+}

--- a/apps/hali-web/components/how-it-works/ExpandedCivicLoop.tsx
+++ b/apps/hali-web/components/how-it-works/ExpandedCivicLoop.tsx
@@ -1,0 +1,69 @@
+import CivicLoopStage from './CivicLoopStage'
+import WaveIcon from '@/components/icons/WaveIcon'
+import PeopleIcon from '@/components/icons/PeopleIcon'
+import BuildingIcon from '@/components/icons/BuildingIcon'
+import CheckIcon from '@/components/icons/CheckIcon'
+
+const STAGES = [
+  {
+    stageNumber: 1,
+    title: 'You report',
+    icon: <WaveIcon className="w-10 h-10" />,
+    explanation:
+      'Type what you see in plain language — no forms, no categories to select. Hali understands what you mean and extracts the location, condition, and civic category from your words. If something is unclear, it asks before assuming.',
+    example:
+      "A resident in Nairobi West types: 'Huge potholes on Lusaka Road near National Oil, very difficult to pass with the rains.' Hali identifies the location, category (roads), condition (difficult), and checks for nearby reports from others who saw the same thing.",
+  },
+  {
+    stageNumber: 2,
+    title: 'Signals cluster',
+    icon: <PeopleIcon className="w-10 h-10" />,
+    explanation:
+      "Your report doesn't stand alone. Hali searches for nearby reports on the same condition and groups them into a single, visible civic reality. The more people report, the stronger and clearer the signal becomes. Clustering means one problem shows up as one thing — not fifty separate noise points.",
+    example:
+      "Three residents near Industrial Area report difficult road conditions within two hours. Hali groups them into one cluster: 'Pothole damage affecting Lusaka Road near CFAO Mobility.' One signal. Confirmed by multiple people. Traceable to a specific place.",
+  },
+  {
+    stageNumber: 3,
+    title: 'Institutions respond',
+    icon: <BuildingIcon className="w-10 h-10" />,
+    explanation:
+      'When a condition is visible and confirmed, institutions — road authorities, utilities, county departments — see it structured and actionable. They post updates that citizens see directly alongside the original signal. Not instead of it. The response and the signal live side by side.',
+    example:
+      "The Kenya National Highways Authority sees the Lusaka Road cluster and posts: 'Teams dispatched to assess road surface damage near CFAO Mobility.' Citizens following the signal see the update immediately. The cluster stays visible until the condition is actually resolved.",
+  },
+  {
+    stageNumber: 4,
+    title: 'Resolution is confirmed',
+    icon: <CheckIcon className="w-10 h-10" />,
+    explanation:
+      'When an institution posts that service is restored, Hali treats that as a proposal — not a fact. It asks the people who were affected: is this actually fixed for you? Resolution happens when enough of them say yes. If they don\u2019t, the signal stays active. This asymmetry is intentional — it protects the credibility of the system.',
+    example:
+      "Kenya Power posts 'Power restored in South B estate.' Hali sends prompts to residents who marked themselves as affected. When enough of them confirm, the cluster resolves. If residents are still reporting no power, it stays active — regardless of what the institution said.",
+  },
+]
+
+export default function ExpandedCivicLoop() {
+  return (
+    <section className="bg-hali-background">
+      <div className="max-w-5xl mx-auto px-6 pt-8">
+        <h2 className="font-display text-3xl md:text-4xl font-bold text-hali-foreground">
+          How the loop works
+        </h2>
+      </div>
+      <div className="max-w-5xl mx-auto px-6">
+        {STAGES.map((stage, i) => (
+          <CivicLoopStage
+            key={stage.stageNumber}
+            stageNumber={stage.stageNumber}
+            title={stage.title}
+            icon={stage.icon}
+            explanation={stage.explanation}
+            example={stage.example}
+            isLast={i === STAGES.length - 1}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/how-it-works/HowItWorksCtaSection.tsx
+++ b/apps/hali-web/components/how-it-works/HowItWorksCtaSection.tsx
@@ -1,0 +1,19 @@
+import CtaButton from '@/components/shared/CtaButton'
+
+export default function HowItWorksCtaSection() {
+  return (
+    <section className="bg-hali-background py-20 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <h2 className="font-display text-3xl md:text-4xl text-hali-foreground">
+          Ready to see what&apos;s happening in your area?
+        </h2>
+        <p className="mt-4 text-lg text-hali-muted-foreground">
+          Open Hali and check what&apos;s active near you right now.
+        </p>
+        <div className="mt-8 flex justify-center">
+          <CtaButton variant="primary" size="large" />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/how-it-works/HowItWorksHero.tsx
+++ b/apps/hali-web/components/how-it-works/HowItWorksHero.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function HowItWorksHero() {
+  return (
+    <section className="bg-hali-background py-24 md:py-32 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <motion.h1
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="font-display text-4xl md:text-5xl text-hali-foreground leading-[1.1]"
+        >
+          The civic feedback loop
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.12 }}
+          className="text-xl text-hali-muted-foreground max-w-2xl mx-auto mt-6 leading-relaxed"
+        >
+          Hali is not a complaint form or a hotline. It&apos;s a system that turns what residents are experiencing into a structured, visible civic reality — and connects that reality to the institutions that can act on it.
+        </motion.p>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/how-it-works/ParticipationDetail.tsx
+++ b/apps/hali-web/components/how-it-works/ParticipationDetail.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function ParticipationDetail() {
+  return (
+    <section className="bg-hali-background py-20 md:py-24">
+      <div className="max-w-5xl mx-auto px-6">
+        <motion.h2
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+          className="font-display text-3xl md:text-4xl font-bold text-hali-foreground"
+        >
+          How participation works
+        </motion.h2>
+
+        <div className="mt-10 grid md:grid-cols-2 gap-6">
+          {/* I'm Affected */}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5 }}
+            className="bg-hali-surface rounded-xl border border-hali-border border-l-4 border-l-hali-primary p-6"
+          >
+            <h3 className="text-lg font-semibold text-hali-foreground">
+              I&apos;m Affected
+            </h3>
+            <p className="mt-3 text-base text-hali-muted-foreground leading-relaxed">
+              You&apos;re directly experiencing the issue. Your participation carries weight in confirming the condition — and in confirming its resolution. When the system asks whether things have improved, your answer matters most.
+            </p>
+          </motion.div>
+
+          {/* I'm Observing */}
+          <motion.div
+            initial={{ opacity: 0, y: 16 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true }}
+            transition={{ duration: 0.5, delay: 0.08 }}
+            className="bg-hali-surface rounded-xl border border-hali-border p-6"
+          >
+            <h3 className="text-lg font-semibold text-hali-foreground">
+              I&apos;m Observing
+            </h3>
+            <p className="mt-3 text-base text-hali-muted-foreground leading-relaxed">
+              You&apos;ve seen or heard about the issue but aren&apos;t directly experiencing it. Your signal adds to the visible picture without claiming direct impact. Both matter. Both count toward the cluster.
+            </p>
+          </motion.div>
+        </div>
+
+        {/* Add Further Context */}
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+          className="mt-8 bg-hali-surface rounded-xl p-6"
+        >
+          <h3 className="text-lg font-semibold text-hali-foreground">
+            Add Further Context
+          </h3>
+          <p className="mt-3 text-base text-hali-muted-foreground leading-relaxed">
+            After marking yourself as affected, you have a short window to add specific detail — &ldquo;water pressure dropped completely around 6am&rdquo; or &ldquo;the road is impassable for motorcycles but cars can still squeeze through.&rdquo; This context helps institutions understand the condition without creating a discussion thread.
+          </p>
+        </motion.div>
+
+        {/* Anonymity statement */}
+        <div className="mt-16 pt-10 border-t border-hali-border">
+          <p className="text-sm text-hali-muted-foreground italic text-center max-w-2xl mx-auto leading-relaxed">
+            &ldquo;Your name is never shown. What&apos;s visible is the pattern — how many people, where, and for how long.&rdquo;
+          </p>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/how-it-works/ResolutionExplained.tsx
+++ b/apps/hali-web/components/how-it-works/ResolutionExplained.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function ResolutionExplained() {
+  return (
+    <section className="bg-hali-background py-16 md:py-24 px-6">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.6 }}
+        className="max-w-2xl mx-auto bg-hali-surface rounded-2xl p-10 md:p-16"
+      >
+        <h2 className="font-display text-3xl font-bold text-hali-foreground">
+          Resolution belongs to the people affected
+        </h2>
+        <div className="mt-8 space-y-6 text-base md:text-lg leading-relaxed text-hali-foreground">
+          <p>
+            Most civic systems declare problems solved when institutions say they&apos;re solved. Hali doesn&apos;t work that way.
+          </p>
+          <p>
+            When a utility or authority posts a restoration notice, Hali reads it as a proposal. It asks the people who were affected — those who reported the issue, who said they were impacted — whether the condition has actually improved for them.
+          </p>
+          <p>
+            Only when enough of them confirm does the cluster resolve. If they don&apos;t confirm — or if new affected reports arrive — the signal stays active, regardless of what the official update says.
+          </p>
+          <p>
+            This asymmetry is structural. It&apos;s not a feature. It&apos;s the foundation of why Hali can be trusted by both sides.
+          </p>
+        </div>
+      </motion.div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/icons/CheckIcon.tsx
+++ b/apps/hali-web/components/icons/CheckIcon.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  className?: string
+}
+
+export default function CheckIcon({ className }: Props) {
+  return (
+    <svg
+      viewBox="0 0 40 40"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="20" cy="20" r="15" />
+      <path d="M13 20.5 L18 25.5 L27 15.5" />
+    </svg>
+  )
+}


### PR DESCRIPTION
## Summary
Phase C of the Hali website build. Implements the complete /how-it-works page.

## Phase
Website Phase C — How It Works

## Sections built
- **HowItWorksHero** — headline, sub-copy, no CTA
- **ExpandedCivicLoop** — 4 stages (You report → Signals cluster → Institutions respond → Resolution confirmed), each with explanation and Nairobi example
- **ParticipationDetail** — I'm Affected / I'm Observing cards, Add Further Context block, anonymity statement
- **ResolutionExplained** — trust differentiator section — prose, no bullets
- **HowItWorksCtaSection** — closing conversion moment

## Infrastructure
- No new API routes
- No new shared components — `CtaButton` imported from Phase B
- `CheckIcon` added to `components/icons/` (did not previously exist)

## Copy fidelity
Copy for all 4 civic loop stages, participation cards, Add Further Context, anonymity statement, and ResolutionExplained paragraphs is used verbatim from the spec.

## Token translation
Spec used `text-hali-text` / `text-hali-muted`. These tokens do not exist in the Phase A Tailwind config — the actual tokens are `text-hali-foreground` (main text) and `text-hali-muted-foreground` (muted text). Translated consistently across all new components.

## How to test
1. `cd apps/hali-web && pnpm dev`
2. Visit http://localhost:3000/how-it-works
3. Scroll through all 5 sections
4. Verify all 4 loop stage copies match the spec exactly
5. Click CTA at bottom — email capture modal opens in prelaunch state
6. Verify 375px and 1280px layouts
7. Confirm http://localhost:3000 (home page) still renders correctly

## Checklist
- [x] `pnpm build` passes — 0 TypeScript errors
- [x] `pnpm lint` passes — 0 warnings
- [x] No hardcoded hex values — all colors via `hali-*` Tailwind classes
- [x] All copy matches spec exactly — no rewrites
- [x] `ResolutionExplained` is prose only — no bullets / decorative elements
- [x] `viewport={{ once: true }}` on all scroll animations
- [x] Home page unaffected
- [x] No Phase E work in this PR

## Copilot Review Resolution
| Thread | Category | Action Taken |
|---|---|---|
| No inline findings — Copilot reviewed all 8 files and generated no comments (summary-only review) | N/A | No threads to resolve. Review state COMMENTED. |
