### PR TITLE
feat(hali-web): Phase E — /about, /privacy, /terms

### DIFF
--- a/apps/hali-web/.env.example
+++ b/apps/hali-web/.env.example
@@ -4,6 +4,9 @@ NEXT_PUBLIC_APP_STORE_URL=
 NEXT_PUBLIC_PLAY_STORE_URL=
 NEXT_PUBLIC_SITE_URL=https://gethali.app
 
+# Founder photo URL (optional — omit for placeholder)
+NEXT_PUBLIC_FOUNDER_PHOTO_URL=
+
 # Server-side only (no NEXT_PUBLIC prefix)
 NOTIFY_EMAIL=hello@gethali.app
 INQUIRY_EMAIL=hello@gethali.app

--- a/apps/hali-web/app/about/page.tsx
+++ b/apps/hali-web/app/about/page.tsx
@@ -1,2 +1,30 @@
-export const metadata = { title: 'About Hali — Civic infrastructure for real-world cities' }
-export default function AboutPage() { return <main /> }
+import AboutHero from '@/components/about/AboutHero'
+import MissionStatement from '@/components/about/MissionStatement'
+import PlatformDoctrine from '@/components/about/PlatformDoctrine'
+import FoundingStory from '@/components/about/FoundingStory'
+import AboutCtaSection from '@/components/about/AboutCtaSection'
+
+export const metadata = {
+  title: 'About Hali — Civic infrastructure for real-world cities',
+  description:
+    'Hali turns individual observations into structured, visible civic conditions — and connects that reality to the institutions that can act on it.',
+  openGraph: {
+    title: 'About Hali — Civic infrastructure for real-world cities',
+    description:
+      'Hali turns individual observations into structured, visible civic conditions — and connects that reality to the institutions that can act on it.',
+    url: 'https://gethali.app/about',
+    images: [{ url: '/og-image.png', width: 1200, height: 630 }],
+  },
+}
+
+export default function AboutPage() {
+  return (
+    <main>
+      <AboutHero />
+      <MissionStatement />
+      <PlatformDoctrine />
+      <FoundingStory />
+      <AboutCtaSection />
+    </main>
+  )
+}

--- a/apps/hali-web/app/privacy/page.tsx
+++ b/apps/hali-web/app/privacy/page.tsx
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: 'Privacy Policy | Hali',
+  title: 'Privacy Policy',
 }
 
 export default function PrivacyPage() {

--- a/apps/hali-web/app/privacy/page.tsx
+++ b/apps/hali-web/app/privacy/page.tsx
@@ -1,9 +1,77 @@
-export const metadata = { title: 'Privacy Policy | Hali' }
+export const metadata = {
+  title: 'Privacy Policy | Hali',
+}
+
 export default function PrivacyPage() {
   return (
-    <main className="max-w-3xl mx-auto px-6 py-24">
-      <h1 className="text-3xl font-bold mb-8">Privacy Policy</h1>
-      <p className="text-hali-muted-foreground">This privacy policy is being finalised. Please check back soon.</p>
+    <main className="max-w-3xl mx-auto px-6 py-20">
+      <h1 className="font-display text-3xl font-bold text-hali-foreground mb-4">
+        Privacy Policy
+      </h1>
+      <p className="text-sm text-hali-muted-foreground mb-12">
+        {/* PLACEHOLDER — insert date before launch */}
+        Last updated: April 2026
+      </p>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Overview
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — legal review pending. Replace with final privacy policy copy. */}
+          Hali is committed to protecting your privacy. This policy explains what information we collect, how we use it, and your rights regarding your data. This document is pending legal review and will be updated before public launch.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Information We Collect
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          We collect information you provide directly (such as your phone number or email address for authentication), information about your device, and anonymised civic signal data tied to locations rather than individuals.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          How We Use Your Information
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          Your information is used to operate the Hali service, authenticate your account, send notifications you have opted into, and improve the platform. We do not sell personal data to third parties.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Data Sharing
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          Civic signal data is aggregated and anonymised before any public display. Individual participation is never exposed in public-facing surfaces. We may share anonymised aggregate data with institutions for operational purposes.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Your Rights
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          You have the right to access, correct, or delete your personal data. To exercise these rights, contact us at the address below.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Contact
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — insert contact details before launch */}
+          For privacy-related questions, contact us at privacy@gethali.app
+        </p>
+      </section>
     </main>
   )
 }

--- a/apps/hali-web/app/terms/page.tsx
+++ b/apps/hali-web/app/terms/page.tsx
@@ -1,9 +1,67 @@
-export const metadata = { title: 'Terms of Use | Hali' }
+export const metadata = {
+  title: 'Terms of Use | Hali',
+}
+
 export default function TermsPage() {
   return (
-    <main className="max-w-3xl mx-auto px-6 py-24">
-      <h1 className="text-3xl font-bold mb-8">Terms of Use</h1>
-      <p className="text-hali-muted-foreground">Terms of use are being finalised. Please check back soon.</p>
+    <main className="max-w-3xl mx-auto px-6 py-20">
+      <h1 className="font-display text-3xl font-bold text-hali-foreground mb-4">
+        Terms of Use
+      </h1>
+      <p className="text-sm text-hali-muted-foreground mb-12">
+        {/* PLACEHOLDER — insert date before launch */}
+        Last updated: April 2026
+      </p>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Overview
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — legal review pending. Replace with final terms copy. */}
+          These terms govern your use of the Hali platform. By using Hali, you agree to these terms. This document is pending legal review and will be updated before public launch.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Use of Service
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          Hali is a civic information platform. You may use it to report civic conditions, participate in existing signals, and receive information about your area. You agree not to submit false, misleading, or abusive content.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Prohibited Uses
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          You may not use Hali to submit coordinated false signals, harass other users, circumvent platform integrity systems, or use the platform for commercial purposes without authorisation.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Disclaimers
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — to be completed by legal review */}
+          Hali aggregates and displays civic signals as reported. We do not verify the accuracy of individual reports and are not liable for actions taken based on platform information.
+        </p>
+      </section>
+
+      <section>
+        <h2 className="text-xl font-semibold text-hali-foreground mt-10 mb-4">
+          Contact
+        </h2>
+        <p className="text-base text-hali-foreground leading-relaxed">
+          {/* PLACEHOLDER — insert contact details before launch */}
+          For terms-related questions, contact us at legal@gethali.app
+        </p>
+      </section>
     </main>
   )
 }

--- a/apps/hali-web/app/terms/page.tsx
+++ b/apps/hali-web/app/terms/page.tsx
@@ -1,5 +1,5 @@
 export const metadata = {
-  title: 'Terms of Use | Hali',
+  title: 'Terms of Use',
 }
 
 export default function TermsPage() {

--- a/apps/hali-web/components/about/AboutCtaSection.tsx
+++ b/apps/hali-web/components/about/AboutCtaSection.tsx
@@ -1,0 +1,16 @@
+import CtaButton from '@/components/shared/CtaButton'
+
+export default function AboutCtaSection() {
+  return (
+    <section className="bg-hali-background py-20 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <h2 className="font-display text-3xl md:text-4xl text-hali-foreground">
+          See what&apos;s happening in your area
+        </h2>
+        <div className="mt-8 flex justify-center">
+          <CtaButton variant="primary" size="large" />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/about/AboutHero.tsx
+++ b/apps/hali-web/components/about/AboutHero.tsx
@@ -1,0 +1,28 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function AboutHero() {
+  return (
+    <section className="bg-hali-background py-24 md:py-32 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <motion.h1
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5 }}
+          className="font-display text-4xl md:text-5xl font-bold text-hali-foreground leading-[1.1]"
+        >
+          Civic infrastructure for real-world cities
+        </motion.h1>
+        <motion.p
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.12 }}
+          className="text-xl text-hali-muted-foreground mt-6 leading-relaxed"
+        >
+          Hali is built on a simple premise: when people can see what&apos;s happening around them — and see that something is being done about it — cities work better.
+        </motion.p>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/about/FoundingStory.tsx
+++ b/apps/hali-web/components/about/FoundingStory.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import Image from 'next/image'
+import { motion } from 'framer-motion'
+
+export default function FoundingStory() {
+  // If set to an external domain, add it to next.config.mjs images.remotePatterns.
+  const photoSrc = process.env.NEXT_PUBLIC_FOUNDER_PHOTO_URL || null
+
+  return (
+    <section className="bg-hali-background py-16 md:py-20 px-6">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        className="max-w-4xl mx-auto grid md:grid-cols-[40%_60%] gap-10 md:gap-12 items-start"
+      >
+        {/* Photo */}
+        <div className="flex justify-center md:justify-start">
+          {photoSrc ? (
+            <Image
+              src={photoSrc}
+              alt="Founder of Hali"
+              width={192}
+              height={192}
+              className="w-48 h-48 rounded-full object-cover border-2 border-hali-border"
+            />
+          ) : (
+            <div
+              aria-hidden="true"
+              className="w-48 h-48 rounded-full bg-hali-surface border-2 border-hali-border"
+            />
+          )}
+        </div>
+
+        {/* Bio */}
+        <div>
+          {/* PLACEHOLDER — replace before launch */}
+          <h2 className="font-display text-2xl md:text-3xl font-bold text-hali-foreground">
+            [Founder Name]
+          </h2>
+          <p className="mt-2 text-sm text-hali-muted-foreground uppercase tracking-wider font-semibold">
+            Founder, Hali
+          </p>
+          {/* PLACEHOLDER — replace before launch */}
+          <p className="mt-6 text-base md:text-lg text-hali-foreground leading-relaxed">
+            [2–3 sentences. Why this was built, what you saw, why you believed it was worth building. Plain language. No jargon. No LinkedIn summary tone.]
+          </p>
+          {/* PLACEHOLDER — replace before launch */}
+          <p className="mt-4 text-base text-hali-muted-foreground leading-relaxed">
+            [One sentence on background if relevant — keep it human, not résumé.]
+          </p>
+        </div>
+      </motion.div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/about/MissionStatement.tsx
+++ b/apps/hali-web/components/about/MissionStatement.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function MissionStatement() {
+  return (
+    <section className="bg-hali-background py-16 md:py-20 px-6">
+      <motion.div
+        initial={{ opacity: 0, y: 16 }}
+        whileInView={{ opacity: 1, y: 0 }}
+        viewport={{ once: true }}
+        transition={{ duration: 0.5 }}
+        className="max-w-2xl mx-auto"
+      >
+        <h2 className="font-display text-2xl md:text-3xl font-bold text-hali-foreground mb-8">
+          Why Hali exists
+        </h2>
+        <p className="text-base md:text-lg text-hali-foreground leading-relaxed md:leading-loose mb-6">
+          In most cities, when something goes wrong — a road floods, the power goes out, water stops running — there is no reliable way to know whether it&apos;s just you, your street, or your entire area. People turn to WhatsApp groups, call hotlines that go unanswered, or post to social media hoping someone official sees it. The information exists. It&apos;s scattered, unstructured, and invisible to the systems that could act on it.
+        </p>
+        <p className="text-base md:text-lg text-hali-foreground leading-relaxed md:leading-loose">
+          Hali is built to close that gap. It turns individual observations into structured, visible civic conditions — and gives institutions a clear, real-time picture of what is actually happening on the ground. When a problem is visible and confirmed, response follows. When a response arrives, citizens see it. When the condition improves, the people affected say so. That feedback loop is the product.
+        </p>
+      </motion.div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/about/PlatformDoctrine.tsx
+++ b/apps/hali-web/components/about/PlatformDoctrine.tsx
@@ -1,0 +1,64 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+const DOCTRINE = [
+  {
+    headline: 'Neutral by design',
+    body: 'Hali surfaces conditions, not opinions. There are no rankings, no blame attribution, no political interpretation. A pothole is a pothole. A power outage is a power outage. What citizens report and what institutions respond with are both shown — side by side, without editorial interference.',
+  },
+  {
+    headline: 'Dual visibility',
+    body: "Citizen signals and official institutional responses are always visible together. One never replaces or overrides the other. If an institution's response contradicts what citizens are still experiencing, both remain visible. Contradiction is information — Hali does not resolve it for you.",
+  },
+  {
+    headline: 'Resolution belongs to citizens',
+    body: 'A condition is resolved when the people who were affected say it is. Institutional declarations of restoration are treated as proposals, not facts. This is not a technicality — it is the mechanism that makes the system credible to both sides.',
+  },
+]
+
+export default function PlatformDoctrine() {
+  return (
+    <section className="bg-hali-surface py-16 md:py-20 px-6">
+      <div className="max-w-4xl mx-auto">
+        <motion.h2
+          initial={{ opacity: 0, y: 16 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={{ once: true }}
+          transition={{ duration: 0.5 }}
+          className="font-display text-2xl md:text-3xl font-bold text-hali-foreground mb-10"
+        >
+          How Hali is built to behave
+        </motion.h2>
+
+        <div>
+          {DOCTRINE.map((item, i) => (
+            <motion.div
+              key={item.headline}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ duration: 0.5, delay: i * 0.08 }}
+              className={`flex items-start gap-6 py-8 ${
+                i < DOCTRINE.length - 1 ? 'border-b border-hali-border' : ''
+              }`}
+            >
+              <div
+                aria-hidden="true"
+                className="shrink-0 w-1 h-10 bg-hali-primary rounded-full mt-1"
+              />
+              <div>
+                <h3 className="text-xl font-semibold text-hali-foreground">
+                  {item.headline}
+                </h3>
+                <p className="mt-3 text-base text-hali-muted-foreground leading-relaxed">
+                  {item.body}
+                </p>
+              </div>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
Phase E of the Hali website build. Implements /about and replaces /privacy and /terms placeholder shells with structured legal templates.

## Phase
Website Phase E — About + Legal

## What was built
- **AboutHero** — headline + sub-copy
- **MissionStatement** — 2-paragraph prose — why Hali exists
- **PlatformDoctrine** — 3 horizontal doctrine rows: neutral by design, dual visibility, resolution belongs to citizens
- **FoundingStory** — 2-column layout with founder photo slot (placeholder until real photo)
- **AboutCtaSection** — quiet closing CTA
- **/privacy** — structured legal template with section headings and placeholder copy
- **/terms** — structured legal template with section headings and placeholder copy

## Token translation
Spec references `text-hali-text` / `text-hali-muted`. These tokens do not exist in the Phase A Tailwind config — actual tokens are `text-hali-foreground` and `text-hali-muted-foreground`. Translated consistently (same approach as Phase C).

## Placeholder items requiring pre-launch replacement
- `FoundingStory`: all bio copy marked with `PLACEHOLDER` comments
- `FoundingStory`: `NEXT_PUBLIC_FOUNDER_PHOTO_URL` — set in Vercel env when photo is ready (and add the host to `next.config.mjs` `images.remotePatterns` if external)
- `/privacy`: all legal copy marked with `PLACEHOLDER` comments
- `/terms`: all legal copy marked with `PLACEHOLDER` comments
- Last updated dates on both legal pages

## How to test
1. `cd apps/hali-web && pnpm dev`
2. http://localhost:3000/about — verify all 5 sections
3. Verify Mission Statement and Doctrine copy matches spec exactly
4. http://localhost:3000/privacy — verify structured sections render
5. http://localhost:3000/terms — verify structured sections render
6. Verify http://localhost:3000 and /how-it-works still render correctly
7. Verify 375px and 1280px layouts on /about

## Checklist
- [x] `pnpm build` passes
- [x] No TypeScript errors
- [x] `pnpm lint` passes
- [x] No hardcoded hex values
- [x] All copy matches spec — no rewrites
- [x] `PLACEHOLDER` comments present in founding story and legal pages
- [x] `viewport={{ once: true }}` on all scroll-reveal animations (heroes use `animate` on mount, consistent with Phase B)
- [x] Home and /how-it-works unaffected (verified via build)
- [x] No Phase D or Phase F work in this PR

## Copilot Review Resolution
| Thread | Category | Action Taken |
|---|---|---|
| `/privacy/page.tsx` title duplicates `| Hali` due to root `title.template` | VALID AND ALIGNED | Changed to `'Privacy Policy'` in 301cc01 — template now applies once. |
| `/terms/page.tsx` title duplicates `| Hali` due to root `title.template` | VALID AND ALIGNED | Changed to `'Terms of Use'` in 301cc01 — template now applies once. |
| `AboutHero` uses `animate` on mount, not `whileInView` | NOT VALID (code) / minor (description) | Heroes are above-the-fold and use `animate` on mount — consistent with `HeroSection` (Phase B) and `HowItWorksHero` (Phase C). PR checklist item updated below to say "on all scroll-reveal animations." |
