### PR TITLE
feat(hali-web): Phase D — /for-institutions page

### DIFF
--- a/apps/hali-web/app/api/inquiry/route.ts
+++ b/apps/hali-web/app/api/inquiry/route.ts
@@ -12,6 +12,14 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const ALLOWED_CATEGORIES = ['roads', 'water', 'electricity', 'transport', 'other'] as const
 type Category = (typeof ALLOWED_CATEGORIES)[number]
 
+// Server-side upper bounds for free-text fields. Keep modest so a single
+// adversarial request can't bloat the persisted file or the notification email.
+const MAX_NAME = 120
+const MAX_ORGANISATION = 200
+const MAX_ROLE = 120
+const MAX_AREA = 200
+const MAX_MESSAGE = 500
+
 interface InquiryPayload {
   name: string
   organisation: string
@@ -69,12 +77,16 @@ export async function POST(request: NextRequest) {
 
   const isValid =
     name.length >= 2 &&
+    name.length <= MAX_NAME &&
     organisation.length >= 1 &&
+    organisation.length <= MAX_ORGANISATION &&
     role.length >= 1 &&
+    role.length <= MAX_ROLE &&
     emailRaw.length > 0 &&
     emailRaw.length <= MAX_EMAIL_LENGTH &&
     EMAIL_RE.test(emailRaw) &&
     area.length >= 1 &&
+    area.length <= MAX_AREA &&
     isValidCategory
 
   if (!isValid) {
@@ -88,7 +100,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: 'Invalid submission' }, { status: 400 })
     }
     const trimmed = messageRaw.trim()
-    if (trimmed.length > 500) {
+    if (trimmed.length > MAX_MESSAGE) {
       return NextResponse.json({ success: false, error: 'Invalid submission' }, { status: 400 })
     }
     message = trimmed || undefined

--- a/apps/hali-web/app/api/inquiry/route.ts
+++ b/apps/hali-web/app/api/inquiry/route.ts
@@ -1,0 +1,155 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { promises as fs } from 'node:fs'
+import path from 'node:path'
+
+export const runtime = 'nodejs'
+
+// RFC 5321 caps a full email at 254 chars; reject longer inputs before the
+// regex runs so an adversarial string can't trigger polynomial backtracking.
+const MAX_EMAIL_LENGTH = 254
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const ALLOWED_CATEGORIES = ['roads', 'water', 'electricity', 'transport', 'other'] as const
+type Category = (typeof ALLOWED_CATEGORIES)[number]
+
+interface InquiryPayload {
+  name: string
+  organisation: string
+  role: string
+  email: string
+  area: string
+  category: Category
+  message?: string
+}
+
+async function persistInquiry(payload: InquiryPayload & { at: string }) {
+  // Append to data/inquiries.json — create-if-missing, preserves prior inquiries.
+  const dataDir = path.resolve(process.cwd(), 'data')
+  const file = path.join(dataDir, 'inquiries.json')
+  await fs.mkdir(dataDir, { recursive: true })
+  let existing: Array<InquiryPayload & { at: string }> = []
+  try {
+    const raw = await fs.readFile(file, 'utf8')
+    const parsed = JSON.parse(raw)
+    if (!Array.isArray(parsed)) {
+      // File exists but has an unexpected shape. Refuse to overwrite — this
+      // likely means something else wrote to the file; surfacing the error
+      // is safer than silently replacing prior data.
+      throw new Error('inquiries.json is not an array')
+    }
+    existing = parsed
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException | null)?.code
+    // Only treat "file does not exist yet" as empty state. Any other failure
+    // (corruption, permission, I/O) re-throws so we don't clobber prior data.
+    if (code !== 'ENOENT') throw err
+  }
+  existing.push(payload)
+  await fs.writeFile(file, JSON.stringify(existing, null, 2), 'utf8')
+}
+
+export async function POST(request: NextRequest) {
+  let raw: Record<string, unknown>
+  try {
+    raw = await request.json()
+  } catch {
+    return NextResponse.json({ success: false, error: 'Invalid request' }, { status: 400 })
+  }
+
+  // Validate and sanitise required fields
+  const name = typeof raw.name === 'string' ? raw.name.trim() : ''
+  const organisation = typeof raw.organisation === 'string' ? raw.organisation.trim() : ''
+  const role = typeof raw.role === 'string' ? raw.role.trim() : ''
+  const emailRaw = typeof raw.email === 'string' ? raw.email.trim().toLowerCase() : ''
+  const area = typeof raw.area === 'string' ? raw.area.trim() : ''
+  const category = typeof raw.category === 'string' ? raw.category.trim() : ''
+  const messageRaw = raw.message !== undefined ? raw.message : undefined
+
+  const isValidCategory = (ALLOWED_CATEGORIES as readonly string[]).includes(category)
+
+  const isValid =
+    name.length >= 2 &&
+    organisation.length >= 1 &&
+    role.length >= 1 &&
+    emailRaw.length > 0 &&
+    emailRaw.length <= MAX_EMAIL_LENGTH &&
+    EMAIL_RE.test(emailRaw) &&
+    area.length >= 1 &&
+    isValidCategory
+
+  if (!isValid) {
+    return NextResponse.json({ success: false, error: 'Invalid submission' }, { status: 400 })
+  }
+
+  // Validate optional message field
+  let message: string | undefined
+  if (messageRaw !== undefined) {
+    if (typeof messageRaw !== 'string') {
+      return NextResponse.json({ success: false, error: 'Invalid submission' }, { status: 400 })
+    }
+    const trimmed = messageRaw.trim()
+    if (trimmed.length > 500) {
+      return NextResponse.json({ success: false, error: 'Invalid submission' }, { status: 400 })
+    }
+    message = trimmed || undefined
+  }
+
+  const payload: InquiryPayload & { at: string } = {
+    name,
+    organisation,
+    role,
+    email: emailRaw,
+    area,
+    category: category as Category,
+    ...(message !== undefined ? { message } : {}),
+    at: new Date().toISOString(),
+  }
+
+  try {
+    await persistInquiry(payload)
+  } catch (err) {
+    // Persistence is the primary contract — fail closed if we can't save.
+    console.error('[inquiry] persistence failed', err)
+    return NextResponse.json({ success: false, error: 'Storage unavailable' }, { status: 500 })
+  }
+
+  const resendApiKey = process.env.RESEND_API_KEY
+  const inquiryEmail = process.env.INQUIRY_EMAIL
+  if (resendApiKey && inquiryEmail) {
+    try {
+      const emailText = [
+        `Name: ${name}`,
+        `Organisation: ${organisation}`,
+        `Role: ${role}`,
+        `Email: ${emailRaw}`,
+        `Area: ${area}`,
+        `Category: ${category}`,
+        `Message: ${message ?? 'None'}`,
+      ].join('\n')
+
+      const res = await fetch('https://api.resend.com/emails', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${resendApiKey}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          from: 'Hali <noreply@gethali.app>',
+          to: [inquiryEmail],
+          subject: `New pilot inquiry — ${organisation} (${category})`,
+          text: emailText,
+        }),
+      })
+      if (!res.ok) {
+        // fetch only throws on network errors; surface 4xx/5xx explicitly.
+        const body = await res.text().catch(() => '')
+        console.warn('[inquiry] resend delivery non-2xx', res.status, body.slice(0, 500))
+      }
+    } catch (err) {
+      // Email delivery is best-effort; inquiry is already persisted.
+      console.warn('[inquiry] resend delivery failed', err)
+    }
+  }
+
+  return NextResponse.json({ success: true })
+}

--- a/apps/hali-web/app/for-institutions/page.tsx
+++ b/apps/hali-web/app/for-institutions/page.tsx
@@ -1,2 +1,28 @@
-export const metadata = { title: 'For Institutions — Become a Hali pilot partner' }
-export default function ForInstitutionsPage() { return <main /> }
+import ForInstitutionsHero from '@/components/for-institutions/ForInstitutionsHero'
+import WhatInstitutionsSee from '@/components/for-institutions/WhatInstitutionsSee'
+import PilotProcess from '@/components/for-institutions/PilotProcess'
+import PilotInquiryForm from '@/components/for-institutions/PilotInquiryForm'
+
+export const metadata = {
+  title: 'For Institutions — Become a Hali pilot partner',
+  description:
+    'Give your institution a structured view of real conditions on the ground and a direct channel to respond. Become a Hali pilot partner.',
+  openGraph: {
+    title: 'For Institutions — Become a Hali pilot partner',
+    description:
+      'Give your institution a structured view of real conditions on the ground and a direct channel to respond. Become a Hali pilot partner.',
+    url: 'https://gethali.app/for-institutions',
+    images: [{ url: '/og-image.png', width: 1200, height: 630 }],
+  },
+}
+
+export default function ForInstitutionsPage() {
+  return (
+    <main>
+      <ForInstitutionsHero />
+      <WhatInstitutionsSee />
+      <PilotProcess />
+      <PilotInquiryForm />
+    </main>
+  )
+}

--- a/apps/hali-web/components/for-institutions/ForInstitutionsHero.tsx
+++ b/apps/hali-web/components/for-institutions/ForInstitutionsHero.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+export default function ForInstitutionsHero() {
+  return (
+    <section className="bg-hali-background py-24 md:py-32 px-6">
+      <div className="max-w-3xl mx-auto text-center">
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0 }}
+        >
+          <h1 className="font-display text-4xl md:text-5xl font-bold text-hali-foreground">
+            Real conditions. Structured response.
+          </h1>
+        </motion.div>
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.15 }}
+        >
+          <p className="mt-6 text-xl leading-relaxed text-hali-muted-foreground">
+            Hali gives institutions a structured view of what&apos;s happening on the ground — and a direct, public channel to respond. No more guessing. No more fragmented reports.
+          </p>
+        </motion.div>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/for-institutions/PilotInquiryForm.tsx
+++ b/apps/hali-web/components/for-institutions/PilotInquiryForm.tsx
@@ -86,6 +86,9 @@ export default function PilotInquiryForm() {
     const errors = validate(fields)
     if (Object.keys(errors).length > 0) {
       setFieldErrors(errors)
+      // Clear a stale server-side error banner so the user sees only the
+      // current per-field issues, not a leftover "something went wrong".
+      if (formState === 'error') setFormState('idle')
       return
     }
 
@@ -333,6 +336,7 @@ export default function PilotInquiryForm() {
                 name="message"
                 value={fields.message}
                 onChange={handleChange}
+                maxLength={500}
                 aria-invalid={!!fieldErrors.message}
                 aria-describedby={fieldErrors.message ? 'inq-message-error' : undefined}
                 className={`${inputBase} min-h-[120px] resize-y`}

--- a/apps/hali-web/components/for-institutions/PilotInquiryForm.tsx
+++ b/apps/hali-web/components/for-institutions/PilotInquiryForm.tsx
@@ -1,0 +1,367 @@
+'use client'
+
+import { useState, useRef, useEffect } from 'react'
+
+type FormState = 'idle' | 'loading' | 'success' | 'error'
+
+type Category = 'roads' | 'water' | 'electricity' | 'transport' | 'other'
+
+interface FormFields {
+  name: string
+  organisation: string
+  role: string
+  email: string
+  area: string
+  category: Category | ''
+  message: string
+}
+
+const INITIAL_FIELDS: FormFields = {
+  name: '',
+  organisation: '',
+  role: '',
+  email: '',
+  area: '',
+  category: '',
+  message: '',
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+function validate(fields: FormFields): Partial<Record<keyof FormFields, string>> {
+  const errors: Partial<Record<keyof FormFields, string>> = {}
+
+  if (fields.name.trim().length < 2) {
+    errors.name = 'Please enter your full name.'
+  }
+  if (fields.organisation.trim().length < 1) {
+    errors.organisation = 'Please enter your organisation name.'
+  }
+  if (fields.role.trim().length < 1) {
+    errors.role = 'Please enter your role.'
+  }
+  const email = fields.email.trim().toLowerCase()
+  if (!email || email.length > 254 || !EMAIL_RE.test(email)) {
+    errors.email = 'Please enter a valid email address.'
+  }
+  if (fields.area.trim().length < 1) {
+    errors.area = 'Please enter your area of operation.'
+  }
+  if (!fields.category) {
+    errors.category = 'Please select a category.'
+  }
+  if (fields.message.trim().length > 500) {
+    errors.message = 'Message must be 500 characters or fewer.'
+  }
+
+  return errors
+}
+
+export default function PilotInquiryForm() {
+  const [formState, setFormState] = useState<FormState>('idle')
+  const [fields, setFields] = useState<FormFields>(INITIAL_FIELDS)
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof FormFields, string>>>({})
+  const successHeadingRef = useRef<HTMLHeadingElement>(null)
+
+  useEffect(() => {
+    if (formState === 'success') {
+      successHeadingRef.current?.focus()
+    }
+  }, [formState])
+
+  function handleChange(
+    e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>
+  ) {
+    const { name, value } = e.target
+    setFields((prev) => ({ ...prev, [name]: value }))
+    // Clear the error for the field being edited
+    if (fieldErrors[name as keyof FormFields]) {
+      setFieldErrors((prev) => ({ ...prev, [name]: undefined }))
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault()
+
+    const errors = validate(fields)
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors)
+      return
+    }
+
+    setFormState('loading')
+
+    try {
+      const body: Record<string, string> = {
+        name: fields.name.trim(),
+        organisation: fields.organisation.trim(),
+        role: fields.role.trim(),
+        email: fields.email.trim().toLowerCase(),
+        area: fields.area.trim(),
+        category: fields.category as Category,
+      }
+      if (fields.message.trim()) {
+        body.message = fields.message.trim()
+      }
+
+      const res = await fetch('/api/inquiry', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      })
+
+      const data = (await res.json()) as { success: boolean }
+      if (res.ok && data.success) {
+        setFormState('success')
+      } else {
+        setFormState('error')
+      }
+    } catch {
+      setFormState('error')
+    }
+  }
+
+  const inputBase =
+    'w-full rounded-lg border border-hali-border bg-hali-surface px-4 py-2.5 text-hali-foreground placeholder:text-hali-muted-foreground focus:outline-none focus:ring-2 focus:ring-hali-primary focus:border-hali-primary transition-colors'
+
+  if (formState === 'success') {
+    return (
+      <section className="bg-hali-muted py-20 md:py-28 px-6">
+        <div className="max-w-2xl mx-auto bg-hali-card rounded-2xl border border-hali-border p-8 md:p-10 flex flex-col items-center text-center gap-4">
+          <svg
+            width={48}
+            height={48}
+            viewBox="0 0 48 48"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-hali-primary"
+            aria-hidden="true"
+          >
+            <circle cx="24" cy="24" r="20" />
+            <polyline points="16 24 22 30 32 18" />
+          </svg>
+          <h2
+            ref={successHeadingRef}
+            tabIndex={-1}
+            className="font-display text-3xl md:text-4xl text-hali-foreground focus:outline-none"
+          >
+            Thank you
+          </h2>
+          <p className="text-hali-muted-foreground">
+            We&apos;ve received your inquiry. We&apos;ll be in touch within 48 hours.
+          </p>
+        </div>
+      </section>
+    )
+  }
+
+  return (
+    <section className="bg-hali-muted py-20 md:py-28 px-6">
+      <div className="max-w-2xl mx-auto bg-hali-card rounded-2xl border border-hali-border p-8 md:p-10">
+        <h2 className="font-display text-3xl md:text-4xl text-hali-foreground text-center">
+          Become a pilot partner
+        </h2>
+        <p className="mt-3 text-center text-hali-muted-foreground max-w-xl mx-auto">
+          Tell us about your organisation. We&apos;ll reach out within 48 hours.
+        </p>
+
+        <form onSubmit={handleSubmit} noValidate className="mt-8">
+          <div className="grid gap-5">
+            {/* Name */}
+            <div>
+              <label htmlFor="inq-name" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Name<span aria-hidden="true" className="text-hali-muted-foreground"> *</span>
+              </label>
+              <input
+                id="inq-name"
+                name="name"
+                type="text"
+                autoComplete="name"
+                value={fields.name}
+                onChange={handleChange}
+                aria-required="true"
+                aria-invalid={!!fieldErrors.name}
+                aria-describedby={fieldErrors.name ? 'inq-name-error' : undefined}
+                className={inputBase}
+                placeholder="Your full name"
+              />
+              {fieldErrors.name && (
+                <p id="inq-name-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.name}
+                </p>
+              )}
+            </div>
+
+            {/* Organisation */}
+            <div>
+              <label htmlFor="inq-organisation" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Organisation<span aria-hidden="true" className="text-hali-muted-foreground"> *</span>
+              </label>
+              <input
+                id="inq-organisation"
+                name="organisation"
+                type="text"
+                autoComplete="organization"
+                value={fields.organisation}
+                onChange={handleChange}
+                aria-required="true"
+                aria-invalid={!!fieldErrors.organisation}
+                aria-describedby={fieldErrors.organisation ? 'inq-organisation-error' : undefined}
+                className={inputBase}
+                placeholder="Your organisation name"
+              />
+              {fieldErrors.organisation && (
+                <p id="inq-organisation-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.organisation}
+                </p>
+              )}
+            </div>
+
+            {/* Role */}
+            <div>
+              <label htmlFor="inq-role" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Role<span aria-hidden="true" className="text-hali-muted-foreground"> *</span>
+              </label>
+              <input
+                id="inq-role"
+                name="role"
+                type="text"
+                autoComplete="organization-title"
+                value={fields.role}
+                onChange={handleChange}
+                aria-required="true"
+                aria-invalid={!!fieldErrors.role}
+                aria-describedby={fieldErrors.role ? 'inq-role-error' : undefined}
+                className={inputBase}
+                placeholder="Your job title or role"
+              />
+              {fieldErrors.role && (
+                <p id="inq-role-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.role}
+                </p>
+              )}
+            </div>
+
+            {/* Email */}
+            <div>
+              <label htmlFor="inq-email" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Email<span aria-hidden="true" className="text-hali-muted-foreground"> *</span>
+              </label>
+              <input
+                id="inq-email"
+                name="email"
+                type="email"
+                autoComplete="email"
+                value={fields.email}
+                onChange={handleChange}
+                aria-required="true"
+                aria-invalid={!!fieldErrors.email}
+                aria-describedby={fieldErrors.email ? 'inq-email-error' : undefined}
+                className={inputBase}
+                placeholder="you@organisation.com"
+              />
+              {fieldErrors.email && (
+                <p id="inq-email-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.email}
+                </p>
+              )}
+            </div>
+
+            {/* Area */}
+            <div>
+              <label htmlFor="inq-area" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Area of operation<span aria-hidden="true" className="text-hali-muted-foreground"> *</span>
+              </label>
+              <input
+                id="inq-area"
+                name="area"
+                type="text"
+                value={fields.area}
+                onChange={handleChange}
+                aria-required="true"
+                aria-invalid={!!fieldErrors.area}
+                aria-describedby={fieldErrors.area ? 'inq-area-error' : undefined}
+                className={inputBase}
+                placeholder="e.g. Nairobi Central, Lagos Island"
+              />
+              {fieldErrors.area && (
+                <p id="inq-area-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.area}
+                </p>
+              )}
+            </div>
+
+            {/* Category */}
+            <div>
+              <label htmlFor="inq-category" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Primary civic category<span aria-hidden="true" className="text-hali-muted-foreground"> *</span>
+              </label>
+              <select
+                id="inq-category"
+                name="category"
+                value={fields.category}
+                onChange={handleChange}
+                aria-required="true"
+                aria-invalid={!!fieldErrors.category}
+                aria-describedby={fieldErrors.category ? 'inq-category-error' : undefined}
+                className={inputBase}
+              >
+                <option value="" disabled>Select a category</option>
+                <option value="roads">Roads</option>
+                <option value="water">Water</option>
+                <option value="electricity">Electricity</option>
+                <option value="transport">Transport</option>
+                <option value="other">Other</option>
+              </select>
+              {fieldErrors.category && (
+                <p id="inq-category-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.category}
+                </p>
+              )}
+            </div>
+
+            {/* Message */}
+            <div>
+              <label htmlFor="inq-message" className="block text-sm font-medium text-hali-foreground mb-1.5">
+                Anything else you&apos;d like us to know
+              </label>
+              <textarea
+                id="inq-message"
+                name="message"
+                value={fields.message}
+                onChange={handleChange}
+                aria-invalid={!!fieldErrors.message}
+                aria-describedby={fieldErrors.message ? 'inq-message-error' : undefined}
+                className={`${inputBase} min-h-[120px] resize-y`}
+                placeholder="Optional — share any context about your use case, existing systems, or questions."
+              />
+              <p className="mt-1 text-xs text-hali-muted-foreground">{fields.message.length}/500</p>
+              {fieldErrors.message && (
+                <p id="inq-message-error" className="mt-1.5 text-sm text-hali-destructive">
+                  {fieldErrors.message}
+                </p>
+              )}
+            </div>
+          </div>
+
+          {formState === 'error' && (
+            <div className="mt-5 rounded-lg border border-hali-destructive/40 bg-hali-destructive/5 px-4 py-3 text-sm text-hali-destructive">
+              Something went wrong. Please try again, or email us directly at hello@gethali.app
+            </div>
+          )}
+
+          <button
+            type="submit"
+            disabled={formState === 'loading'}
+            className="mt-6 w-full inline-flex items-center justify-center rounded-full font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 text-base px-7 py-3.5 bg-hali-primary text-hali-primary-foreground hover:opacity-90 focus-visible:ring-hali-primary disabled:opacity-60 disabled:cursor-not-allowed"
+          >
+            {formState === 'loading' ? 'Submitting\u2026' : 'Submit Pilot Inquiry'}
+          </button>
+        </form>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/for-institutions/PilotProcess.tsx
+++ b/apps/hali-web/components/for-institutions/PilotProcess.tsx
@@ -1,0 +1,53 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+const STEPS = [
+  {
+    n: 1,
+    title: 'Submit an inquiry',
+    body: 'Fill in the form below. Tell us your organisation, your area of operation, and which civic categories matter most to you.',
+  },
+  {
+    n: 2,
+    title: 'Scoping call',
+    body: "We'll reach out within 48 hours to understand your jurisdiction, your existing workflows, and how Hali fits into them.",
+  },
+  {
+    n: 3,
+    title: 'Pilot onboarding',
+    body: "We configure Hali for your jurisdiction and categories, connect you to the institution dashboard, and brief your team. You're live within days.",
+  },
+]
+
+export default function PilotProcess() {
+  return (
+    <section className="bg-hali-background py-20 md:py-28 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="font-display text-3xl md:text-4xl text-hali-foreground text-center">
+          How pilot partnership works
+        </h2>
+        <div className="mt-12 grid gap-10 md:grid-cols-3 md:gap-8">
+          {STEPS.map((step, i) => (
+            <motion.div
+              key={step.n}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="md:border-r md:border-dashed md:border-hali-border md:pr-8 md:last:border-r-0 md:last:pr-0"
+            >
+              <span className="font-display text-5xl text-hali-primary/15 leading-none block">
+                {step.n}
+              </span>
+              <h3 className="mt-3 font-display text-xl text-hali-foreground">{step.title}</h3>
+              <p className="mt-2 text-base leading-relaxed text-hali-muted-foreground">
+                {step.body}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/hali-web/components/for-institutions/WhatInstitutionsSee.tsx
+++ b/apps/hali-web/components/for-institutions/WhatInstitutionsSee.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+import { motion } from 'framer-motion'
+
+const CARDS: { headline: string; body: React.ReactNode }[] = [
+  {
+    headline: 'Real-time cluster visibility',
+    body: (
+      <>
+        See what citizens are reporting within your jurisdiction — structured by category, location,
+        and severity of confirmation. No noise. No duplicates. One clear picture of what&apos;s
+        happening on the ground.
+      </>
+    ),
+  },
+  {
+    headline: 'Structured response workflow',
+    body: (
+      <>
+        Post live updates, scheduled disruptions, and restoration notices directly against active
+        citizen signals. Your response sits alongside the signal — visible to everyone, traceable to
+        you.
+      </>
+    ),
+  },
+  {
+    headline: 'Loop Closure Rate',
+    body: (
+      <>
+        The metric that matters. What percentage of reported civic conditions in your jurisdiction
+        actually got resolved? Hali tracks it. Institutions that respond close more loops. That
+        record is public.
+      </>
+    ),
+  },
+]
+
+export default function WhatInstitutionsSee() {
+  return (
+    <section className="bg-hali-muted py-20 md:py-28 px-6">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="font-display text-3xl md:text-4xl text-hali-foreground text-center">
+          What institutions see
+        </h2>
+        <div className="mt-12 grid gap-6 md:grid-cols-3 md:gap-8">
+          {CARDS.map((card, i) => (
+            <motion.div
+              key={card.headline}
+              initial={{ opacity: 0, y: 16 }}
+              whileInView={{ opacity: 1, y: 0 }}
+              viewport={{ once: true }}
+              transition={{ delay: i * 0.1 }}
+              className="bg-hali-card rounded-xl border border-hali-border p-6 transition-shadow hover:shadow-md"
+            >
+              <h3 className="text-lg font-semibold text-hali-foreground">{card.headline}</h3>
+              <p className="mt-3 text-base leading-relaxed text-hali-muted-foreground">
+                {card.body}
+              </p>
+            </motion.div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
Phase D of the Hali website build. Implements the complete /for-institutions page
including the pilot inquiry form and /api/inquiry route handler.

## Phase
Website Phase D — For Institutions

## What was built
- `ForInstitutionsHero`: headline + sub-copy with staggered fade-up
- `WhatInstitutionsSee`: 3-column value point grid (cluster visibility, response workflow, Loop Closure Rate)
- `PilotProcess`: 3-step process section with dashed desktop connectors
- `PilotInquiryForm`: 7-field form with validation, loading, success, error states, a11y wiring
- `/api/inquiry`: route handler — validation, persistence, best-effort Resend delivery

## API route behavior
- Persistence: `apps/hali-web/data/inquiries.json` (same pattern as `/api/notify/signups.json`; gitignored via existing `data/*.json` rule)
- Email delivery: Resend (best-effort, only if `RESEND_API_KEY` and `INQUIRY_EMAIL` set — both already listed in `.env.example`; no duplication added)
- Valid submission: `{ success: true }`
- Invalid submission: `{ success: false, error: 'Invalid submission' }` (generic — does not leak which field failed)
- Persistence failure: `{ success: false, error: 'Storage unavailable' }` with status 500 (fail-closed)

## Token translations applied
- `text-hali-text` (spec logical name) → `text-hali-foreground` (actual Tailwind class)
- `text-hali-muted` (for body text) → `text-hali-muted-foreground`

## Component note (deviation from spec)
The spec implied wrapping the form submit in `<CtaButton variant="primary" size="large" />`.
`CtaButton` owns its own click behavior (opens an email capture modal prelaunch,
renders store links when live), so it cannot act as a form submit button. The form
uses an inline-styled `<button type="submit">` that matches primary CtaButton styling:

```
inline-flex items-center justify-center rounded-full font-medium transition-all
focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2
text-base px-7 py-3.5 bg-hali-primary text-hali-primary-foreground
hover:opacity-90 focus-visible:ring-hali-primary
disabled:opacity-60 disabled:cursor-not-allowed
```

## Accessibility
- Every input has an associated `<label htmlFor>`
- Required fields: `aria-required="true"` + visible `*` indicator (muted color, not red)
- Field errors: `aria-invalid` + `aria-describedby` pointing to inline error `<p>`
- On success, focus moves to the "Thank you" heading (`tabIndex={-1}` + ref + effect)
- Character counter on the optional message textarea

## Verified locally (pre-push)
- `pnpm --filter @hali/hali-web lint` — 0 warnings, 0 errors
- `pnpm --filter @hali/hali-web build` — 0 errors, `/for-institutions` bundle 3.75 kB (was 146 B skeleton)
- `POST /api/inquiry` valid body → `{"success":true}` · persisted to `data/inquiries.json`
- `POST /api/inquiry` invalid body → `{"success":false,"error":"Invalid submission"}`
- `GET /for-institutions` → HTTP 200

## How to test
1. `cd apps/hali-web && pnpm dev`
2. Visit http://localhost:3000/for-institutions
3. Verify all 4 sections render and animate
4. Submit the form with valid data → success state appears
5. Submit with empty required fields → per-field validation errors appear
6. Verify `/`, `/how-it-works`, `/about`, `/privacy`, `/terms` still render

## Checklist
- [x] `pnpm build` passes, zero TypeScript errors
- [x] `pnpm lint` passes, zero warnings
- [x] All copy matches the Phase D brief exactly
- [x] Form validates all required fields client-side before POST
- [x] `/api/inquiry` returns `success: true` on valid submission
- [x] `/api/inquiry` returns `success: false` on invalid submission
- [x] Inquiry data persisted to `data/inquiries.json` (not console-only)
- [x] No hardcoded hex or oklch values — all colors via `hali-*` Tailwind classes
- [x] Responsive at 375px / 768px / 1280px (built and verified)
- [x] All prior pages unaffected
- [x] No Phase F work in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Copilot Review Resolution
| Thread | Category | Action Taken |
|---|---|---|
| textarea missing `maxLength` to pre-cap input | VALID AND ALIGNED | Added `maxLength={500}` (commit 388a638) |
| stale `formState='error'` persists across re-validation | VALID AND ALIGNED | `handleSubmit` now resets `formState` to `'idle'` when returning early from client-side validation (commit 388a638) |
| no server-side max-length on name/org/role/area | VALID AND ALIGNED | Added caps: name 120, organisation 200, role 120, area 200, message 500 (commit 388a638) |
| `process.cwd()/data/*.json` fails on Vercel serverless | DEFERRED | Same pattern as existing `/api/notify`; cross-cutting refactor tracked in #274 (Phase F) |
| read-modify-write race in `persistInquiry` | DEFERRED | Same concern applies to `/api/notify`; eliminated alongside the persistence-layer swap in #274 |

All 5 threads replied to and resolved. Pre-merge `pnpm lint` and `pnpm build` re-run after fixes — both clean.
