### PR TITLE
feat(#254): institution auth — magic link + TOTP + session + CSRF

### DIFF
--- a/02_openapi.yaml
+++ b/02_openapi.yaml
@@ -200,6 +200,11 @@ paths:
           content:
             application/json:
               schema: { $ref: '#/components/schemas/ErrorResponse' }
+        '429':
+          description: Rate limit exceeded — max 3 requests per email per 15 minutes (auth.magic_link_rate_limited)
+          content:
+            application/json:
+              schema: { $ref: '#/components/schemas/ErrorResponse' }
 
   /v1/auth/institution/magic-link/verify:
     post:
@@ -1866,6 +1871,7 @@ components:
         - auth.institution_session_idle_timeout
         - auth.institution_session_invalid
         - auth.magic_link_invalid
+        - auth.magic_link_rate_limited
         - auth.otp_invalid
         - auth.otp_rate_limited
         - auth.refresh_token_invalid

--- a/src/Hali.Api/Controllers/InstitutionAuthController.cs
+++ b/src/Hali.Api/Controllers/InstitutionAuthController.cs
@@ -59,6 +59,9 @@ public sealed class InstitutionAuthController : ControllerBase
 
     [HttpPost("magic-link/request")]
     [AllowAnonymous]
+    [ProducesResponseType(typeof(MagicLinkRequestResponseDto), StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
     public async Task<ActionResult<MagicLinkRequestResponseDto>> RequestMagicLink(
         [FromBody] MagicLinkRequestDto dto, CancellationToken ct)
     {
@@ -67,7 +70,8 @@ public sealed class InstitutionAuthController : ControllerBase
             throw ValidationFromModelState();
         }
 
-        MagicLinkIssued issued = await _magicLink.IssueAsync(dto.Email, ct);
+        string? callerIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        MagicLinkIssued issued = await _magicLink.IssueAsync(dto.Email, callerIp, ct);
 
         // Deliberate UX: the response body never indicates whether the
         // email was registered. Response shape is identical for known

--- a/src/Hali.Api/Controllers/InstitutionAuthController.cs
+++ b/src/Hali.Api/Controllers/InstitutionAuthController.cs
@@ -70,7 +70,12 @@ public sealed class InstitutionAuthController : ControllerBase
             throw ValidationFromModelState();
         }
 
-        string? callerIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        // Strip IPv6 zone/scope suffix (e.g. "fe80::1%12") before storing;
+        // the column is varchar(45) which matches the longest bare IPv6 address
+        // but not a zone-suffixed one, and zone ids are host-local, not useful for audit.
+        string? rawIp = HttpContext.Connection.RemoteIpAddress?.ToString();
+        int zoneSep = rawIp?.IndexOf('%') ?? -1;
+        string? callerIp = zoneSep >= 0 ? rawIp![..zoneSep] : rawIp;
         MagicLinkIssued issued = await _magicLink.IssueAsync(dto.Email, callerIp, ct);
 
         // Deliberate UX: the response body never indicates whether the

--- a/src/Hali.Api/Program.cs
+++ b/src/Hali.Api/Program.cs
@@ -169,6 +169,10 @@ builder.Services.AddScoped<IInstitutionAcknowledgeService, InstitutionAcknowledg
 builder.Services.AddScoped<ITotpService, TotpService>();
 builder.Services.AddScoped<IMagicLinkService, MagicLinkService>();
 builder.Services.AddScoped<IInstitutionSessionService, InstitutionSessionService>();
+// Audit hook for institution auth events (#251). No-op until the full audit
+// infrastructure is merged — replace this binding with the real implementation.
+builder.Services.AddScoped<Hali.Application.Auth.IAuthAuditService,
+    Hali.Infrastructure.Auth.NoOpAuthAuditService>();
 // Phase 2 institution-admin routes (#196).
 builder.Services.AddScoped<Hali.Application.InstitutionAdmin.IInstitutionAdminService,
     Hali.Application.InstitutionAdmin.InstitutionAdminService>();

--- a/src/Hali.Application/Auth/IAuthAuditService.cs
+++ b/src/Hali.Application/Auth/IAuthAuditService.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Hali.Application.Auth;
+
+/// <summary>
+/// Writes structured audit events for institution auth actions.
+/// Hook point for #251 (audit trail) — a no-op implementation is used until
+/// the full audit infrastructure is merged.
+/// </summary>
+public interface IAuthAuditService
+{
+    /// <summary>
+    /// Records an auth audit event. Implementations must never throw — a
+    /// failed audit write must not surface to the caller.
+    /// </summary>
+    Task LogAsync(string eventType, string? ipAddress, CancellationToken ct = default);
+}
+
+/// <summary>
+/// Canonical event type constants used with <see cref="IAuthAuditService"/>.
+/// </summary>
+public static class AuthAuditEvents
+{
+    public const string MagicLinkRequested = "institution.auth.magic_link_requested";
+    public const string MagicLinkVerifiedSuccess = "institution.auth.magic_link_verified.success";
+    public const string MagicLinkVerifiedFailure = "institution.auth.magic_link_verified.failure";
+    public const string TotpVerifiedSuccess = "institution.auth.totp_verified.success";
+    public const string TotpVerifiedFailure = "institution.auth.totp_verified.failure";
+    public const string SessionCreated = "institution.auth.session_created";
+    public const string SessionExpired = "institution.auth.session_expired";
+    public const string SessionRotated = "institution.auth.session_rotated";
+    public const string Logout = "institution.auth.logout";
+    public const string MagicLinkRateLimitHit = "institution.auth.rate_limit_hit";
+}

--- a/src/Hali.Application/Auth/IMagicLinkService.cs
+++ b/src/Hali.Application/Auth/IMagicLinkService.cs
@@ -18,9 +18,11 @@ public interface IMagicLinkService
     /// logged. When the email has no registered account, the row is
     /// still created (with AccountId = null) — the verify flow will
     /// either reject (institution users must pre-exist) or create an
-    /// account depending on policy.
+    /// account depending on policy. Rate-limited: max 3 requests per
+    /// email per 15 minutes; throws <see cref="Hali.Application.Errors.RateLimitException"/>
+    /// on excess. The calling IP is stored for audit purposes only.
     /// </summary>
-    Task<MagicLinkIssued> IssueAsync(string email, CancellationToken ct);
+    Task<MagicLinkIssued> IssueAsync(string email, string? ipAddress, CancellationToken ct);
 
     /// <summary>
     /// Atomically consumes a plaintext token and returns the matched row

--- a/src/Hali.Application/Auth/MagicLinkService.cs
+++ b/src/Hali.Application/Auth/MagicLinkService.cs
@@ -3,6 +3,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Hali.Application.Errors;
 using Hali.Domain.Entities.Auth;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -12,10 +13,15 @@ namespace Hali.Application.Auth;
 public sealed class MagicLinkService : IMagicLinkService
 {
     private const int TokenByteLength = 32; // 256 bits
+    // Max 3 magic link requests per email per 15-minute window.
+    private const int MagicLinkRateMaxRequests = 3;
+    private const int MagicLinkRateWindowMinutes = 15;
 
     private readonly IInstitutionAuthRepository _repo;
     private readonly IAuthRepository _authRepo;
     private readonly IInstitutionEmailSender _emailSender;
+    private readonly IRateLimiter _rateLimiter;
+    private readonly IAuthAuditService _audit;
     private readonly AuthOptions _authOpts;
     private readonly InstitutionAuthOptions _opts;
     private readonly ILogger<MagicLinkService> _logger;
@@ -24,6 +30,8 @@ public sealed class MagicLinkService : IMagicLinkService
         IInstitutionAuthRepository repo,
         IAuthRepository authRepo,
         IInstitutionEmailSender emailSender,
+        IRateLimiter rateLimiter,
+        IAuthAuditService audit,
         IOptions<AuthOptions> authOptions,
         IOptions<InstitutionAuthOptions> options,
         ILogger<MagicLinkService> logger)
@@ -31,15 +39,36 @@ public sealed class MagicLinkService : IMagicLinkService
         _repo = repo;
         _authRepo = authRepo;
         _emailSender = emailSender;
+        _rateLimiter = rateLimiter;
+        _audit = audit;
         _authOpts = authOptions.Value;
         _opts = options.Value;
         _logger = logger;
     }
 
-    public async Task<MagicLinkIssued> IssueAsync(string email, CancellationToken ct)
+    public async Task<MagicLinkIssued> IssueAsync(string email, string? ipAddress, CancellationToken ct)
     {
         string normalised = Normalise(email);
         DateTime now = DateTime.UtcNow;
+
+        // Rate limit: 3 requests per email per 15 minutes.
+        // Key uses the normalised email so case variants don't bypass the limit.
+        string rateLimitKey = $"ml_issue:{normalised}";
+        bool allowed = await _rateLimiter.IsAllowedAsync(
+            rateLimitKey,
+            MagicLinkRateMaxRequests,
+            TimeSpan.FromMinutes(MagicLinkRateWindowMinutes),
+            ct);
+
+        if (!allowed)
+        {
+            await _audit.LogAsync(AuthAuditEvents.MagicLinkRateLimitHit, ipAddress, ct);
+            _logger.LogWarning("institution_auth.magic_link.rate_limited");
+            throw new RateLimitException(
+                code: ErrorCodes.AuthMagicLinkRateLimited,
+                message: "Too many magic link requests. Please wait before trying again.");
+        }
+
         DateTime expiresAt = now.AddMinutes(_opts.MagicLinkTtlMinutes);
 
         string plaintext = GenerateTokenBase64Url();
@@ -59,6 +88,7 @@ public sealed class MagicLinkService : IMagicLinkService
             AccountId = account?.Id,
             ExpiresAt = expiresAt,
             CreatedAt = now,
+            IpAddress = ipAddress,
         };
         await _repo.SaveMagicLinkAsync(token, ct);
 
@@ -73,6 +103,7 @@ public sealed class MagicLinkService : IMagicLinkService
         // per-request correlation id that CorrelationIdMiddleware already
         // tags on every log entry.
         await _emailSender.SendMagicLinkAsync(normalised, url, expiresAt, ct);
+        await _audit.LogAsync(AuthAuditEvents.MagicLinkRequested, ipAddress, ct);
         _logger.LogInformation(
             "institution_auth.magic_link.issued expires_at={ExpiresAt}",
             expiresAt);

--- a/src/Hali.Application/Auth/MagicLinkService.cs
+++ b/src/Hali.Application/Auth/MagicLinkService.cs
@@ -53,7 +53,7 @@ public sealed class MagicLinkService : IMagicLinkService
 
         // Rate limit: 3 requests per email per 15 minutes.
         // Key uses the normalised email so case variants don't bypass the limit.
-        string rateLimitKey = $"ml_issue:{normalised}";
+        string rateLimitKey = $"ratelimit:magic_link_issue:{normalised}";
         bool allowed = await _rateLimiter.IsAllowedAsync(
             rateLimitKey,
             MagicLinkRateMaxRequests,

--- a/src/Hali.Application/Errors/ErrorCodes.cs
+++ b/src/Hali.Application/Errors/ErrorCodes.cs
@@ -49,6 +49,7 @@ public static class ErrorCodes
     public const string AuthCsrfMissing = "auth.csrf_missing";
     public const string AuthCsrfMismatch = "auth.csrf_mismatch";
     public const string AuthMagicLinkInvalid = "auth.magic_link_invalid";
+    public const string AuthMagicLinkRateLimited = "auth.magic_link_rate_limited";
     public const string AuthTotpAlreadyEnrolled = "auth.totp_already_enrolled";
     public const string AuthTotpNotEnrolled = "auth.totp_not_enrolled";
     public const string AuthTotpInvalidCode = "auth.totp_invalid_code";

--- a/src/Hali.Domain/Entities/Auth/MagicLinkToken.cs
+++ b/src/Hali.Domain/Entities/Auth/MagicLinkToken.cs
@@ -35,4 +35,11 @@ public class MagicLinkToken
     public DateTime? ConsumedAt { get; set; }
 
     public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// IP address of the client that requested the magic link. Stored for
+    /// audit purposes — helps correlate suspicious link-request patterns
+    /// without exposing plaintext tokens in logs.
+    /// </summary>
+    public string? IpAddress { get; set; }
 }

--- a/src/Hali.Infrastructure/Auth/NoOpAuthAuditService.cs
+++ b/src/Hali.Infrastructure/Auth/NoOpAuthAuditService.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Auth;
+
+namespace Hali.Infrastructure.Auth;
+
+/// <summary>
+/// No-op audit service used until #251 (institution auth audit trail) is merged.
+/// All writes are silently discarded. Hook point is preserved — replacing this
+/// with a real implementation requires only a DI rebind.
+/// </summary>
+public sealed class NoOpAuthAuditService : IAuthAuditService
+{
+    public Task LogAsync(string eventType, string? ipAddress, CancellationToken ct = default)
+        => Task.CompletedTask;
+}

--- a/src/Hali.Infrastructure/Data/Auth/AuthDbContext.cs
+++ b/src/Hali.Infrastructure/Data/Auth/AuthDbContext.cs
@@ -166,6 +166,7 @@ public class AuthDbContext : DbContext
 			e.Property((MagicLinkToken x) => x.ExpiresAt).HasColumnName("expires_at");
 			e.Property((MagicLinkToken x) => x.ConsumedAt).HasColumnName("consumed_at");
 			e.Property((MagicLinkToken x) => x.CreatedAt).HasColumnName("created_at");
+			e.Property((MagicLinkToken x) => x.IpAddress).HasColumnName("ip_address").HasMaxLength(45);
 			e.HasIndex((MagicLinkToken x) => x.TokenHash).IsUnique().HasDatabaseName("uq_magic_link_tokens_hash");
 			e.HasIndex((MagicLinkToken x) => x.DestinationEmail).HasDatabaseName("ix_magic_link_tokens_email");
 			e.HasIndex((MagicLinkToken x) => x.ExpiresAt).HasDatabaseName("ix_magic_link_tokens_expires");

--- a/src/Hali.Infrastructure/Data/Auth/Migrations/20260419135445_AddIpAddressToMagicLinkTokens.Designer.cs
+++ b/src/Hali.Infrastructure/Data/Auth/Migrations/20260419135445_AddIpAddressToMagicLinkTokens.Designer.cs
@@ -4,6 +4,7 @@ using Hali.Domain.Enums;
 using Hali.Infrastructure.Data.Auth;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -12,9 +13,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Hali.Infrastructure.Data.Auth.Migrations
 {
     [DbContext(typeof(AuthDbContext))]
-    partial class AuthDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260419135445_AddIpAddressToMagicLinkTokens")]
+    partial class AddIpAddressToMagicLinkTokens
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Hali.Infrastructure/Data/Auth/Migrations/20260419135445_AddIpAddressToMagicLinkTokens.cs
+++ b/src/Hali.Infrastructure/Data/Auth/Migrations/20260419135445_AddIpAddressToMagicLinkTokens.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Hali.Infrastructure.Data.Auth.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIpAddressToMagicLinkTokens : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ip_address",
+                table: "magic_link_tokens",
+                type: "character varying(45)",
+                maxLength: 45,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ip_address",
+                table: "magic_link_tokens");
+        }
+    }
+}

--- a/src/Hali.Infrastructure/Data/Auth/Migrations/20260419135445_AddIpAddressToMagicLinkTokens.cs
+++ b/src/Hali.Infrastructure/Data/Auth/Migrations/20260419135445_AddIpAddressToMagicLinkTokens.cs
@@ -10,20 +10,21 @@ namespace Hali.Infrastructure.Data.Auth.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.AddColumn<string>(
-                name: "ip_address",
-                table: "magic_link_tokens",
-                type: "character varying(45)",
-                maxLength: 45,
-                nullable: true);
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE magic_link_tokens
+                ADD COLUMN IF NOT EXISTS ip_address character varying(45);
+                """);
         }
 
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
-            migrationBuilder.DropColumn(
-                name: "ip_address",
-                table: "magic_link_tokens");
+            migrationBuilder.Sql(
+                """
+                ALTER TABLE magic_link_tokens
+                DROP COLUMN IF EXISTS ip_address;
+                """);
         }
     }
 }

--- a/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
+++ b/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
@@ -111,7 +111,7 @@ public static class InstitutionAuthHelper
         using (var scope = factory.Services.CreateScope())
         {
             var magic = scope.ServiceProvider.GetRequiredService<IMagicLinkService>();
-            MagicLinkIssued issued = await magic.IssueAsync(email, ct);
+            MagicLinkIssued issued = await magic.IssueAsync(email, null, ct);
             plaintextToken = issued.PlaintextToken;
 
             // Defensive re-bind: ensure the magic-link row points at the

--- a/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
+++ b/tests/Hali.Tests.Integration/Helpers/InstitutionAuthHelper.cs
@@ -5,6 +5,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Security.Claims;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
@@ -107,24 +108,28 @@ public static class InstitutionAuthHelper
 
         string email = await GetAccountEmailAsync(factory, accountId, ct);
 
+        // Write the token row directly to avoid hitting the real Redis rate
+        // limiter — test seeding must not exhaust the 3-per-15-min bucket.
         string plaintextToken;
-        using (var scope = factory.Services.CreateScope())
         {
-            var magic = scope.ServiceProvider.GetRequiredService<IMagicLinkService>();
-            MagicLinkIssued issued = await magic.IssueAsync(email, null, ct);
-            plaintextToken = issued.PlaintextToken;
+            byte[] raw = RandomNumberGenerator.GetBytes(32);
+            plaintextToken = Convert.ToBase64String(raw);
+            byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(plaintextToken));
+            string tokenHash = Convert.ToHexString(hashBytes).ToLowerInvariant();
 
-            // Defensive re-bind: ensure the magic-link row points at the
-            // account we just created. MagicLinkService.IssueAsync does
-            // this via the email→account join, but the test wants a
-            // deterministic tie — mirrors the pattern in
-            // InstitutionAdminIntegrationTests.LogInAdminWithStepUpAsync.
             await using var conn = new NpgsqlConnection(Infrastructure.TestConstants.ConnectionString);
             await conn.OpenAsync(ct);
             await using var cmd = new NpgsqlCommand(
-                "UPDATE magic_link_tokens SET account_id = @aid WHERE token_hash = @hash", conn);
+                """
+                INSERT INTO magic_link_tokens (id, destination_email, token_hash, account_id, expires_at, created_at)
+                VALUES (@id, @email, @hash, @aid, @exp, @now)
+                """, conn);
+            cmd.Parameters.AddWithValue("id", Guid.NewGuid());
+            cmd.Parameters.AddWithValue("email", email);
+            cmd.Parameters.AddWithValue("hash", tokenHash);
             cmd.Parameters.AddWithValue("aid", accountId);
-            cmd.Parameters.AddWithValue("hash", magic.HashToken(plaintextToken));
+            cmd.Parameters.AddWithValue("exp", DateTime.UtcNow.AddMinutes(15));
+            cmd.Parameters.AddWithValue("now", DateTime.UtcNow);
             await cmd.ExecuteNonQueryAsync(ct);
         }
 

--- a/tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.cs
+++ b/tests/Hali.Tests.Integration/Infrastructure/HaliWebApplicationFactory.cs
@@ -322,6 +322,8 @@ CREATE TABLE IF NOT EXISTS magic_link_tokens (
 )");
         await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_magic_link_tokens_email ON magic_link_tokens(destination_email)");
         await ExecAsync(conn, "CREATE INDEX IF NOT EXISTS ix_magic_link_tokens_expires ON magic_link_tokens(expires_at)");
+        // #254: ip_address column added to magic_link_tokens for audit trail.
+        await ExecAsync(conn, "ALTER TABLE magic_link_tokens ADD COLUMN IF NOT EXISTS ip_address varchar(45) NULL");
 
         // Data Protection key ring (#243) — mirrors the EF migration.
         // Same schema-bootstrap convention as every other table in this

--- a/tests/Hali.Tests.Integration/InstitutionAuth/InstitutionAuthIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/InstitutionAuth/InstitutionAuthIntegrationTests.cs
@@ -362,22 +362,29 @@ public sealed class InstitutionAuthIntegrationTests : IntegrationTestBase
         return account;
     }
 
-    private async Task<string> SeedMagicLinkAsync(Account account, DateTime expiresAt)
+    private static async Task<string> SeedMagicLinkAsync(Account account, DateTime expiresAt)
     {
-        using var scope = Factory.Services.CreateScope();
-        var service = scope.ServiceProvider.GetRequiredService<IMagicLinkService>();
-        MagicLinkIssued issued = await service.IssueAsync(account.Email!, null, default);
-        // Capture the expiresAt override via direct DB update (the
-        // service uses the configured TTL; the test wants to simulate
-        // an already-expired token without waiting 15 minutes).
+        // Write the token row directly to avoid hitting the real Redis rate limiter.
+        byte[] raw = RandomNumberGenerator.GetBytes(32);
+        string plaintext = Convert.ToBase64String(raw);
+        byte[] hashBytes = SHA256.HashData(Encoding.UTF8.GetBytes(plaintext));
+        string tokenHash = Convert.ToHexString(hashBytes).ToLowerInvariant();
+
         await using var conn = new NpgsqlConnection(TestConstants.ConnectionString);
         await conn.OpenAsync();
         await using var cmd = new NpgsqlCommand(
-            "UPDATE magic_link_tokens SET expires_at = @exp WHERE token_hash = @hash", conn);
+            """
+            INSERT INTO magic_link_tokens (id, destination_email, token_hash, account_id, expires_at, created_at)
+            VALUES (@id, @email, @hash, @aid, @exp, @now)
+            """, conn);
+        cmd.Parameters.AddWithValue("id", Guid.NewGuid());
+        cmd.Parameters.AddWithValue("email", account.Email!);
+        cmd.Parameters.AddWithValue("hash", tokenHash);
+        cmd.Parameters.AddWithValue("aid", account.Id);
         cmd.Parameters.AddWithValue("exp", expiresAt);
-        cmd.Parameters.AddWithValue("hash", service.HashToken(issued.PlaintextToken));
+        cmd.Parameters.AddWithValue("now", DateTime.UtcNow);
         await cmd.ExecuteNonQueryAsync();
-        return issued.PlaintextToken;
+        return plaintext;
     }
 
     private async Task<Guid> GetInstitutionAccountIdAsync()

--- a/tests/Hali.Tests.Integration/InstitutionAuth/InstitutionAuthIntegrationTests.cs
+++ b/tests/Hali.Tests.Integration/InstitutionAuth/InstitutionAuthIntegrationTests.cs
@@ -366,7 +366,7 @@ public sealed class InstitutionAuthIntegrationTests : IntegrationTestBase
     {
         using var scope = Factory.Services.CreateScope();
         var service = scope.ServiceProvider.GetRequiredService<IMagicLinkService>();
-        MagicLinkIssued issued = await service.IssueAsync(account.Email!, default);
+        MagicLinkIssued issued = await service.IssueAsync(account.Email!, null, default);
         // Capture the expiresAt override via direct DB update (the
         // service uses the configured TTL; the test wants to simulate
         // an already-expired token without waiting 15 minutes).

--- a/tests/Hali.Tests.Unit/Auth/InstitutionCsrfMiddlewareTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/InstitutionCsrfMiddlewareTests.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Api.Middleware;
+using Hali.Application.Auth;
+using Hali.Application.Errors;
+using Hali.Domain.Entities.Auth;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hali.Tests.Unit.Auth;
+
+/// <summary>
+/// Unit coverage for <see cref="InstitutionCsrfMiddleware"/>:
+/// GET requests are skipped; POST without X-CSRF-Token returns 403;
+/// POST with wrong token returns 403; POST with correct token passes through.
+/// </summary>
+public sealed class InstitutionCsrfMiddlewareTests
+{
+    // -----------------------------------------------------------------------
+    // GET requests are not CSRF-checked
+    // -----------------------------------------------------------------------
+
+    [Theory]
+    [InlineData("GET")]
+    [InlineData("HEAD")]
+    [InlineData("OPTIONS")]
+    public async Task CsrfMiddleware_SafeVerb_SkipsValidation(string method)
+    {
+        bool nextCalled = false;
+        var middleware = new InstitutionCsrfMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        DefaultHttpContext ctx = BuildContext(method, hasSession: false, csrfHeader: null);
+        var sessions = new FakeSessionService(csrfHash: "any");
+
+        await middleware.InvokeAsync(ctx, sessions);
+
+        Assert.True(nextCalled);
+        Assert.NotEqual(StatusCodes.Status403Forbidden, ctx.Response.StatusCode);
+    }
+
+    // -----------------------------------------------------------------------
+    // Requests without a session cookie are not CSRF-checked
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CsrfMiddleware_NoSession_PassesThrough()
+    {
+        bool nextCalled = false;
+        var middleware = new InstitutionCsrfMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        DefaultHttpContext ctx = BuildContext("POST", hasSession: false, csrfHeader: null);
+        var sessions = new FakeSessionService(csrfHash: "any");
+
+        await middleware.InvokeAsync(ctx, sessions);
+
+        Assert.True(nextCalled);
+    }
+
+    // -----------------------------------------------------------------------
+    // POST with session but missing X-CSRF-Token → 403
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CsrfMiddleware_MissingHeader_Returns403WithCsrfMissingCode()
+    {
+        var middleware = new InstitutionCsrfMiddleware(_ => Task.CompletedTask);
+
+        DefaultHttpContext ctx = BuildContext("POST", hasSession: true, csrfHeader: null);
+        var sessions = new FakeSessionService(csrfHash: "expected-hash");
+
+        await middleware.InvokeAsync(ctx, sessions);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, ctx.Response.StatusCode);
+        var body = await ReadBodyAsync(ctx);
+        Assert.Equal(ErrorCodes.AuthCsrfMissing, body.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    // -----------------------------------------------------------------------
+    // POST with session and wrong X-CSRF-Token → 403
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CsrfMiddleware_MismatchedToken_Returns403WithCsrfMismatchCode()
+    {
+        var middleware = new InstitutionCsrfMiddleware(_ => Task.CompletedTask);
+
+        // Session has csrfTokenHash = SHA-256 of "correct-csrf"
+        string correctPlaintext = "correct-csrf";
+        string correctHash = Sha256Hex(correctPlaintext);
+        DefaultHttpContext ctx = BuildContext("POST", hasSession: true, csrfHeader: "wrong-value");
+        StashSession(ctx, csrfTokenHash: correctHash);
+        var sessions = new FakeSessionService(csrfHash: correctHash);
+
+        await middleware.InvokeAsync(ctx, sessions);
+
+        Assert.Equal(StatusCodes.Status403Forbidden, ctx.Response.StatusCode);
+        var body = await ReadBodyAsync(ctx);
+        Assert.Equal(ErrorCodes.AuthCsrfMismatch, body.GetProperty("error").GetProperty("code").GetString());
+    }
+
+    // -----------------------------------------------------------------------
+    // POST with correct X-CSRF-Token → passes through
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CsrfMiddleware_ValidToken_PassesThrough()
+    {
+        bool nextCalled = false;
+        var middleware = new InstitutionCsrfMiddleware(_ =>
+        {
+            nextCalled = true;
+            return Task.CompletedTask;
+        });
+
+        string plaintext = "correct-csrf-value";
+        string hash = Sha256Hex(plaintext);
+        DefaultHttpContext ctx = BuildContext("POST", hasSession: true, csrfHeader: plaintext);
+        StashSession(ctx, csrfTokenHash: hash);
+        // FakeSessionService.HashCsrfToken must return the same hash for the plaintext.
+        var sessions = new FakeSessionService(csrfHash: hash);
+
+        await middleware.InvokeAsync(ctx, sessions);
+
+        Assert.True(nextCalled);
+        Assert.NotEqual(StatusCodes.Status403Forbidden, ctx.Response.StatusCode);
+    }
+
+    // ======================================================================
+    // Helpers
+    // ======================================================================
+
+    private static DefaultHttpContext BuildContext(
+        string method, bool hasSession, string? csrfHeader)
+    {
+        var ctx = new DefaultHttpContext();
+        ctx.Request.Method = method;
+        ctx.Response.Body = new MemoryStream();
+        if (csrfHeader is not null)
+            ctx.Request.Headers["X-CSRF-Token"] = csrfHeader;
+        if (hasSession)
+            StashSession(ctx, csrfTokenHash: "any-hash");
+        return ctx;
+    }
+
+    private static void StashSession(DefaultHttpContext ctx, string csrfTokenHash)
+    {
+        ctx.Items["InstitutionWebSession"] = new WebSession
+        {
+            Id = Guid.NewGuid(),
+            AccountId = Guid.NewGuid(),
+            SessionTokenHash = "session-hash",
+            CsrfTokenHash = csrfTokenHash,
+            CreatedAt = DateTime.UtcNow,
+            LastActivityAt = DateTime.UtcNow,
+            AbsoluteExpiresAt = DateTime.UtcNow.AddHours(12),
+        };
+    }
+
+    private static async Task<JsonElement> ReadBodyAsync(DefaultHttpContext ctx)
+    {
+        ctx.Response.Body.Seek(0, SeekOrigin.Begin);
+        return await JsonSerializer.DeserializeAsync<JsonElement>(ctx.Response.Body);
+    }
+
+    private static string Sha256Hex(string input)
+    {
+        byte[] hash = System.Security.Cryptography.SHA256.HashData(
+            System.Text.Encoding.UTF8.GetBytes(input));
+        return Convert.ToHexString(hash).ToLowerInvariant();
+    }
+
+    // ======================================================================
+    // Fake session service — only HashCsrfToken is used by the middleware
+    // ======================================================================
+
+    private sealed class FakeSessionService : IInstitutionSessionService
+    {
+        private readonly string _storedCsrfHash;
+
+        public FakeSessionService(string csrfHash) => _storedCsrfHash = csrfHash;
+
+        public string HashCsrfToken(string plaintext) => Sha256Hex(plaintext);
+
+        public string HashSessionToken(string plaintext) => Sha256Hex(plaintext);
+
+        public Task<SessionCreated> CreateAsync(Guid accountId, Guid? institutionId, string role, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task<SessionValidation> ValidateAsync(string sessionTokenPlaintext, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task TouchAsync(Guid sessionId, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task RevokeAsync(Guid sessionId, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task MarkStepUpVerifiedAsync(Guid sessionId, CancellationToken ct)
+            => throw new NotImplementedException();
+    }
+}

--- a/tests/Hali.Tests.Unit/Auth/InstitutionSessionServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/InstitutionSessionServiceTests.cs
@@ -1,0 +1,231 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Auth;
+using Hali.Domain.Entities.Auth;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hali.Tests.Unit.Auth;
+
+/// <summary>
+/// Unit coverage for <see cref="InstitutionSessionService"/>: session token
+/// storage (hash not plaintext), idle + absolute timeout enforcement, revoked
+/// session rejection, and the TouchAsync sliding-window update.
+/// </summary>
+public sealed class InstitutionSessionServiceTests
+{
+    // -----------------------------------------------------------------------
+    // CreateAsync — token storage
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task CreateSession_StoresHashNotPlaintext()
+    {
+        var repo = new FakeSessionRepo();
+        var service = BuildService(repo);
+
+        SessionCreated created = await service.CreateAsync(Guid.NewGuid(), null, "institution", default);
+
+        Assert.False(string.IsNullOrEmpty(created.SessionTokenPlaintext));
+        WebSession saved = Assert.Single(repo.SavedSessions);
+        // Plaintext must not be stored verbatim.
+        Assert.NotEqual(created.SessionTokenPlaintext, saved.SessionTokenHash);
+        // Hash must be 64 hex chars (SHA-256).
+        Assert.Equal(64, saved.SessionTokenHash.Length);
+        Assert.Matches("^[0-9a-f]{64}$", saved.SessionTokenHash);
+
+        // CSRF token obeys the same rule.
+        Assert.NotEqual(created.CsrfTokenPlaintext, saved.CsrfTokenHash);
+        Assert.Equal(64, saved.CsrfTokenHash.Length);
+    }
+
+    [Fact]
+    public async Task CreateSession_PlaintextTokenNotReusable()
+    {
+        // Two separate CreateAsync calls must yield distinct plaintexts.
+        var repo = new FakeSessionRepo();
+        var service = BuildService(repo);
+        var id = Guid.NewGuid();
+
+        SessionCreated a = await service.CreateAsync(id, null, "institution", default);
+        SessionCreated b = await service.CreateAsync(id, null, "institution", default);
+
+        Assert.NotEqual(a.SessionTokenPlaintext, b.SessionTokenPlaintext);
+        Assert.NotEqual(a.CsrfTokenPlaintext, b.CsrfTokenPlaintext);
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateAsync — active session
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ValidateSession_ActiveSession_ReturnsOk()
+    {
+        var repo = new FakeSessionRepo();
+        var service = BuildService(repo);
+        SessionCreated created = await service.CreateAsync(Guid.NewGuid(), null, "institution", default);
+
+        SessionValidation result = await service.ValidateAsync(created.SessionTokenPlaintext, default);
+
+        Assert.Equal(SessionValidationResult.Ok, result.Result);
+        Assert.NotNull(result.Session);
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateAsync — session not found / revoked
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ValidateSession_UnknownToken_ReturnsInvalid()
+    {
+        var repo = new FakeSessionRepo();
+        var service = BuildService(repo);
+
+        SessionValidation result = await service.ValidateAsync("not-a-real-token", default);
+
+        Assert.Equal(SessionValidationResult.Invalid, result.Result);
+        Assert.Null(result.Session);
+    }
+
+    [Fact]
+    public async Task ValidateSession_RevokedSession_ReturnsInvalid()
+    {
+        var repo = new FakeSessionRepo();
+        var service = BuildService(repo);
+        SessionCreated created = await service.CreateAsync(Guid.NewGuid(), null, "institution", default);
+        await service.RevokeAsync(created.Session.Id, default);
+
+        // Repo returns null for revoked sessions.
+        SessionValidation result = await service.ValidateAsync(created.SessionTokenPlaintext, default);
+        Assert.Equal(SessionValidationResult.Invalid, result.Result);
+    }
+
+    // -----------------------------------------------------------------------
+    // ValidateAsync — timeout enforcement
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task ValidateSession_IdleTimeout_ReturnsIdleTimeout()
+    {
+        var repo = new FakeSessionRepo();
+        // Idle threshold is 30 min — put last_activity 31 min in the past.
+        repo.LastActivityOverride = DateTime.UtcNow.AddMinutes(-31);
+        var service = BuildService(repo, idleMinutes: 30, absoluteHours: 12);
+        SessionCreated created = await service.CreateAsync(Guid.NewGuid(), null, "institution", default);
+
+        SessionValidation result = await service.ValidateAsync(created.SessionTokenPlaintext, default);
+        Assert.Equal(SessionValidationResult.IdleTimeout, result.Result);
+    }
+
+    [Fact]
+    public async Task HardExpiry_EnforcedRegardlessOfActivity()
+    {
+        // Even a "recent" last_activity cannot save a session past its
+        // absolute_expires_at.
+        var repo = new FakeSessionRepo();
+        repo.AbsoluteExpiresAtOverride = DateTime.UtcNow.AddHours(-1); // expired 1 h ago
+        repo.LastActivityOverride = DateTime.UtcNow.AddSeconds(-5);   // active very recently
+        var service = BuildService(repo, idleMinutes: 30, absoluteHours: 12);
+        SessionCreated created = await service.CreateAsync(Guid.NewGuid(), null, "institution", default);
+
+        SessionValidation result = await service.ValidateAsync(created.SessionTokenPlaintext, default);
+        Assert.Equal(SessionValidationResult.AbsoluteTimeout, result.Result);
+    }
+
+    // -----------------------------------------------------------------------
+    // TouchAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task TouchSession_UpdatesLastActivityAt()
+    {
+        var repo = new FakeSessionRepo();
+        var service = BuildService(repo);
+        SessionCreated created = await service.CreateAsync(Guid.NewGuid(), null, "institution", default);
+        DateTime before = repo.SavedSessions[0].LastActivityAt;
+
+        await service.TouchAsync(created.Session.Id, default);
+
+        Assert.True(repo.LastTouchedAt >= before);
+    }
+
+    // ======================================================================
+    // Helpers
+    // ======================================================================
+
+    private static InstitutionSessionService BuildService(
+        FakeSessionRepo repo,
+        int idleMinutes = 30,
+        int absoluteHours = 12)
+    {
+        var opts = Options.Create(new InstitutionAuthOptions
+        {
+            SessionIdleMinutes = idleMinutes,
+            SessionAbsoluteHours = absoluteHours,
+        });
+        return new InstitutionSessionService(repo, opts);
+    }
+
+    // ======================================================================
+    // In-process fake
+    // ======================================================================
+
+    private sealed class FakeSessionRepo : IInstitutionAuthRepository
+    {
+        public List<WebSession> SavedSessions { get; } = new();
+        public DateTime? LastActivityOverride { get; set; }
+        public DateTime? AbsoluteExpiresAtOverride { get; set; }
+        public DateTime LastTouchedAt { get; private set; }
+        private readonly HashSet<Guid> _revoked = new();
+
+        public Task SaveWebSessionAsync(WebSession session, CancellationToken ct)
+        {
+            // Apply overrides so tests can manipulate timestamps.
+            if (LastActivityOverride.HasValue)
+                session.LastActivityAt = LastActivityOverride.Value;
+            if (AbsoluteExpiresAtOverride.HasValue)
+                session.AbsoluteExpiresAt = AbsoluteExpiresAtOverride.Value;
+            SavedSessions.Add(session);
+            return Task.CompletedTask;
+        }
+
+        public Task<WebSession?> FindActiveWebSessionAsync(
+            string sessionTokenHash, DateTime now, CancellationToken ct)
+        {
+            foreach (var s in SavedSessions)
+            {
+                if (s.SessionTokenHash == sessionTokenHash && !_revoked.Contains(s.Id))
+                    return Task.FromResult<WebSession?>(s);
+            }
+            return Task.FromResult<WebSession?>(null);
+        }
+
+        public Task TouchWebSessionAsync(Guid sessionId, DateTime lastActivityAt, CancellationToken ct)
+        {
+            LastTouchedAt = lastActivityAt;
+            return Task.CompletedTask;
+        }
+
+        public Task RevokeWebSessionAsync(Guid sessionId, DateTime revokedAt, CancellationToken ct)
+        {
+            _revoked.Add(sessionId);
+            return Task.CompletedTask;
+        }
+
+        public Task MarkStepUpVerifiedAsync(Guid sessionId, DateTime verifiedAt, CancellationToken ct)
+            => Task.CompletedTask;
+
+        // Unused by session tests.
+        public Task SaveMagicLinkAsync(MagicLinkToken token, CancellationToken ct) => throw new NotImplementedException();
+        public Task<MagicLinkToken?> ConsumeMagicLinkAsync(string tokenHash, DateTime now, CancellationToken ct) => throw new NotImplementedException();
+        public Task<TotpSecret?> FindTotpSecretByAccountAsync(Guid accountId, CancellationToken ct) => throw new NotImplementedException();
+        public Task SaveTotpSecretAsync(TotpSecret secret, CancellationToken ct) => throw new NotImplementedException();
+        public Task UpdateTotpSecretAsync(TotpSecret secret, CancellationToken ct) => throw new NotImplementedException();
+        public Task DeleteRecoveryCodesForAccountAsync(Guid accountId, CancellationToken ct) => throw new NotImplementedException();
+        public Task ConfirmTotpSecretAsync(Guid totpSecretId, DateTime confirmedAt, CancellationToken ct) => throw new NotImplementedException();
+        public Task SaveRecoveryCodesAsync(IEnumerable<TotpRecoveryCode> codes, CancellationToken ct) => throw new NotImplementedException();
+        public Task<bool> ConsumeRecoveryCodeAsync(Guid accountId, string codeHash, DateTime usedAt, CancellationToken ct) => throw new NotImplementedException();
+    }
+}

--- a/tests/Hali.Tests.Unit/Auth/MagicLinkServiceTests.cs
+++ b/tests/Hali.Tests.Unit/Auth/MagicLinkServiceTests.cs
@@ -1,0 +1,325 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Hali.Application.Auth;
+using Hali.Application.Errors;
+using Hali.Domain.Entities.Auth;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Hali.Tests.Unit.Auth;
+
+/// <summary>
+/// Unit coverage for <see cref="MagicLinkService"/>: token storage (hash, not
+/// plaintext), rate limiting gate, and unknown-email enumeration resistance.
+/// All dependencies are in-process fakes — no DB or network.
+/// </summary>
+public sealed class MagicLinkServiceTests
+{
+    // -----------------------------------------------------------------------
+    // GenerateMagicLink_StoresHashNotPlaintext
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task GenerateMagicLink_StoresHashNotPlaintext()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var service = BuildService(repo, alwaysAllow: true);
+
+        MagicLinkIssued issued = await service.IssueAsync("user@example.com", "1.2.3.4", default);
+
+        Assert.False(string.IsNullOrEmpty(issued.PlaintextToken));
+        MagicLinkToken saved = Assert.Single(repo.SavedTokens);
+        // The plaintext must never appear in the stored hash column.
+        Assert.NotEqual(issued.PlaintextToken, saved.TokenHash);
+        // Hash must be 64 hex chars (SHA-256).
+        Assert.Equal(64, saved.TokenHash.Length);
+        Assert.Matches("^[0-9a-f]{64}$", saved.TokenHash);
+    }
+
+    [Fact]
+    public async Task GenerateMagicLink_StoresIpAddress()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var service = BuildService(repo, alwaysAllow: true);
+
+        await service.IssueAsync("user@example.com", "192.168.1.1", default);
+
+        Assert.Equal("192.168.1.1", Assert.Single(repo.SavedTokens).IpAddress);
+    }
+
+    // -----------------------------------------------------------------------
+    // VerifyMagicLink tests — delegate to ConsumeAsync
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task VerifyMagicLink_ValidToken_ReturnsMatchedRow()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var service = BuildService(repo, alwaysAllow: true);
+
+        MagicLinkIssued issued = await service.IssueAsync("user@example.com", null, default);
+
+        // ConsumeAsync returns the row when valid + unconsumed.
+        MagicLinkToken? result = await service.ConsumeAsync(issued.PlaintextToken, default);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task VerifyMagicLink_InvalidToken_ReturnsNull()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var service = BuildService(repo, alwaysAllow: true);
+
+        MagicLinkToken? result = await service.ConsumeAsync("bogus-token", default);
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task VerifyMagicLink_AlreadyConsumed_ReturnsNull()
+    {
+        var repo = new FakeMagicLinkRepo { ReturnConsumedToken = true };
+        var service = BuildService(repo, alwaysAllow: true);
+        MagicLinkIssued issued = await service.IssueAsync("user@example.com", null, default);
+
+        // First consume succeeds (repo returns the token).
+        MagicLinkToken? first = await service.ConsumeAsync(issued.PlaintextToken, default);
+        Assert.NotNull(first);
+        // Second consume fails (repo simulates consumed → returns null).
+        MagicLinkToken? second = await service.ConsumeAsync(issued.PlaintextToken, default);
+        Assert.Null(second);
+    }
+
+    [Fact]
+    public async Task VerifyMagicLink_ExpiredToken_ReturnsNull()
+    {
+        var repo = new FakeMagicLinkRepo { ReturnExpiredToken = true };
+        var service = BuildService(repo, alwaysAllow: true);
+        MagicLinkIssued issued = await service.IssueAsync("user@example.com", null, default);
+
+        MagicLinkToken? result = await service.ConsumeAsync(issued.PlaintextToken, default);
+        Assert.Null(result);
+    }
+
+    // -----------------------------------------------------------------------
+    // Rate limiting
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task RequestMagicLink_ExceedsRateLimit_ThrowsRateLimitException()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var service = BuildService(repo, alwaysAllow: false);
+
+        await Assert.ThrowsAsync<RateLimitException>(() =>
+            service.IssueAsync("user@example.com", null, default));
+    }
+
+    [Fact]
+    public async Task RequestMagicLink_UnknownEmail_ResponseIdenticalToSuccess()
+    {
+        // IssueAsync should succeed (not throw) even when the email is not
+        // registered — the caller must receive an identical response shape.
+        var repo = new FakeMagicLinkRepo { KnownEmail = null }; // unknown email
+        var service = BuildService(repo, alwaysAllow: true, knownEmail: null);
+
+        // Must not throw; issued token shape is the same as for a known email.
+        MagicLinkIssued issued = await service.IssueAsync("nobody@example.com", null, default);
+        Assert.False(string.IsNullOrEmpty(issued.PlaintextToken));
+        Assert.True(issued.ExpiresAt > DateTime.UtcNow);
+
+        // The row is still written (with AccountId = null).
+        MagicLinkToken saved = Assert.Single(repo.SavedTokens);
+        Assert.Null(saved.AccountId);
+    }
+
+    // -----------------------------------------------------------------------
+    // HashToken is deterministic and produces a 64-char hex SHA-256
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public void HashToken_IsDeterministicAndProduces64HexChars()
+    {
+        var service = BuildService(new FakeMagicLinkRepo(), alwaysAllow: true);
+        string hash1 = service.HashToken("some-token-value");
+        string hash2 = service.HashToken("some-token-value");
+        Assert.Equal(hash1, hash2);
+        Assert.Equal(64, hash1.Length);
+        Assert.Matches("^[0-9a-f]{64}$", hash1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Audit events are emitted
+    // -----------------------------------------------------------------------
+
+    [Fact]
+    public async Task MagicLinkRequested_EmitsAuditEvent()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var audit = new FakeAuditService();
+        var service = BuildService(repo, alwaysAllow: true, audit: audit);
+
+        await service.IssueAsync("user@example.com", "1.2.3.4", default);
+
+        Assert.Contains(AuthAuditEvents.MagicLinkRequested, audit.LoggedEvents);
+    }
+
+    [Fact]
+    public async Task MagicLinkRateLimitHit_EmitsAuditEvent()
+    {
+        var repo = new FakeMagicLinkRepo();
+        var audit = new FakeAuditService();
+        var service = BuildService(repo, alwaysAllow: false, audit: audit);
+
+        await Assert.ThrowsAsync<RateLimitException>(() =>
+            service.IssueAsync("user@example.com", "1.2.3.4", default));
+
+        Assert.Contains(AuthAuditEvents.MagicLinkRateLimitHit, audit.LoggedEvents);
+    }
+
+    // ======================================================================
+    // Helpers
+    // ======================================================================
+
+    private static MagicLinkService BuildService(
+        FakeMagicLinkRepo repo,
+        bool alwaysAllow,
+        string? knownEmail = "user@example.com",
+        FakeAuditService? audit = null)
+    {
+        var authRepo = new FakeAuthRepo(knownEmail);
+        var emailSender = new FakeEmailSender();
+        var rateLimiter = new FakeRateLimiter(alwaysAllow);
+        var auditSvc = audit ?? new FakeAuditService();
+        var authOpts = Options.Create(new AuthOptions { AppBaseUrl = "https://hali.example.com" });
+        var instOpts = Options.Create(new InstitutionAuthOptions { MagicLinkTtlMinutes = 15 });
+        return new MagicLinkService(
+            repo, authRepo, emailSender, rateLimiter, auditSvc,
+            authOpts, instOpts, NullLogger<MagicLinkService>.Instance);
+    }
+
+    // ======================================================================
+    // In-process fakes
+    // ======================================================================
+
+    private sealed class FakeMagicLinkRepo : IInstitutionAuthRepository
+    {
+        public List<MagicLinkToken> SavedTokens { get; } = new();
+        public bool ReturnConsumedToken { get; set; }
+        public bool ReturnExpiredToken { get; set; }
+        public string? KnownEmail { get; set; } = "user@example.com";
+
+        private bool _consumed;
+
+        public Task SaveMagicLinkAsync(MagicLinkToken token, CancellationToken ct)
+        {
+            SavedTokens.Add(token);
+            return Task.CompletedTask;
+        }
+
+        public Task<MagicLinkToken?> ConsumeMagicLinkAsync(
+            string tokenHash, DateTime now, CancellationToken ct)
+        {
+            if (ReturnExpiredToken) return Task.FromResult<MagicLinkToken?>(null);
+            if (ReturnConsumedToken)
+            {
+                if (_consumed) return Task.FromResult<MagicLinkToken?>(null);
+                _consumed = true;
+                var t = SavedTokens.Find(x => x.TokenHash == tokenHash);
+                return Task.FromResult(t);
+            }
+            var match = SavedTokens.Find(x => x.TokenHash == tokenHash);
+            return Task.FromResult(match);
+        }
+
+        // Unused by these tests — not implemented
+        public Task<TotpSecret?> FindTotpSecretByAccountAsync(Guid accountId, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task SaveTotpSecretAsync(TotpSecret secret, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task UpdateTotpSecretAsync(TotpSecret secret, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task DeleteRecoveryCodesForAccountAsync(Guid accountId, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task ConfirmTotpSecretAsync(Guid totpSecretId, DateTime confirmedAt, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task SaveRecoveryCodesAsync(IEnumerable<TotpRecoveryCode> codes, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task<bool> ConsumeRecoveryCodeAsync(Guid accountId, string codeHash, DateTime usedAt, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task SaveWebSessionAsync(WebSession session, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task<WebSession?> FindActiveWebSessionAsync(string sessionTokenHash, DateTime now, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task TouchWebSessionAsync(Guid sessionId, DateTime lastActivityAt, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task RevokeWebSessionAsync(Guid sessionId, DateTime revokedAt, CancellationToken ct)
+            => throw new NotImplementedException();
+        public Task MarkStepUpVerifiedAsync(Guid sessionId, DateTime verifiedAt, CancellationToken ct)
+            => throw new NotImplementedException();
+    }
+
+    private sealed class FakeAuthRepo : IAuthRepository
+    {
+        private readonly Account? _account;
+
+        public FakeAuthRepo(string? knownEmail)
+        {
+            _account = knownEmail is null ? null : new Account
+            {
+                Id = Guid.NewGuid(),
+                Email = knownEmail,
+                AccountType = Domain.Enums.AccountType.InstitutionUser,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+            };
+        }
+
+        public Task<Account?> FindAccountByEmailAsync(string email, CancellationToken ct)
+            => Task.FromResult(_account?.Email == email ? _account : null);
+
+        public Task<Account?> FindAccountByIdAsync(Guid accountId, CancellationToken ct)
+            => Task.FromResult(_account?.Id == accountId ? _account : null);
+
+        // Remainder not used by these tests.
+        public Task<Account?> FindAccountByPhoneAsync(string phoneE164, CancellationToken ct) => throw new NotImplementedException();
+        public Task<Account> CreateAccountAsync(Account account, CancellationToken ct) => throw new NotImplementedException();
+        public Task SaveOtpChallengeAsync(OtpChallenge challenge, CancellationToken ct) => throw new NotImplementedException();
+        public Task<OtpChallenge?> FindActiveOtpAsync(string destination, DateTime now, CancellationToken ct) => throw new NotImplementedException();
+        public Task ConsumeOtpAsync(OtpChallenge challenge, DateTime consumedAt, CancellationToken ct) => throw new NotImplementedException();
+        public Task<Device> UpsertDeviceAsync(string fingerprintHash, Guid accountId, string? platform, string? appVersion, string? expoPushToken, DateTime now, CancellationToken ct) => throw new NotImplementedException();
+        public Task<RefreshToken?> FindActiveRefreshTokenAsync(string tokenHash, DateTime now, CancellationToken ct) => throw new NotImplementedException();
+        public Task SaveRefreshTokenAsync(RefreshToken token, CancellationToken ct) => throw new NotImplementedException();
+        public Task RevokeRefreshTokenAsync(RefreshToken token, DateTime revokedAt, CancellationToken ct) => throw new NotImplementedException();
+        public Task<Device?> FindDeviceByFingerprintAsync(string fingerprintHash, CancellationToken ct) => throw new NotImplementedException();
+        public Task UpdateExpoPushTokenAsync(Guid deviceId, string expoPushToken, CancellationToken ct) => throw new NotImplementedException();
+        public Task UpdateAccountAsync(Account account, CancellationToken ct) => throw new NotImplementedException();
+        public Task<IReadOnlyList<string>> GetPushTokensByAccountIdsAsync(IEnumerable<Guid> accountIds, CancellationToken ct) => throw new NotImplementedException();
+    }
+
+    private sealed class FakeEmailSender : IInstitutionEmailSender
+    {
+        public Task SendMagicLinkAsync(string destinationEmail, string url, DateTime expiresAt, CancellationToken ct)
+            => Task.CompletedTask;
+    }
+
+    private sealed class FakeRateLimiter : IRateLimiter
+    {
+        private readonly bool _allow;
+        public FakeRateLimiter(bool allow) => _allow = allow;
+        public Task<bool> IsAllowedAsync(string key, int maxRequests, TimeSpan window, CancellationToken ct)
+            => Task.FromResult(_allow);
+    }
+
+    private sealed class FakeAuditService : IAuthAuditService
+    {
+        public List<string> LoggedEvents { get; } = new();
+        public Task LogAsync(string eventType, string? ipAddress, CancellationToken ct = default)
+        {
+            LoggedEvents.Add(eventType);
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `ip_address` column to `magic_link_tokens` for auth audit trail (EF migration + bootstrap in integration test harness)
- Wires rate limiting into `MagicLinkService` (3 requests / email / 15 min via IRateLimiter, throws `RateLimitException(auth.magic_link_rate_limited)`) with 429 response documented in OpenAPI
- Introduces `IAuthAuditService` + `NoOpAuthAuditService` DI hook for audit events (#251 will wire persistence); emits `MagicLinkRequested` and `MagicLinkRateLimitHit`
- Adds 23 unit tests covering `MagicLinkService` (10), `InstitutionSessionService` (8), and `InstitutionCsrfMiddleware` (5) — all in-process fakes, zero DB/network

## Copilot Resolution Table

| Thread | File | Classification | Action |
|---|---|---|---|
| IPv6 zone suffix can overflow varchar(45) | `InstitutionAuthController.cs:74` | Correctness bug | Fixed ffa9306 — strip %scope suffix |
| Migration not idempotent (AddColumn fails if exists) | migration:26 | Robustness | Fixed ffa9306 — use Sql(ADD COLUMN IF NOT EXISTS) |
| Rate-limit key prefix inconsistent | `MagicLinkService.cs:56` | Operational hygiene | Fixed ffa9306 — renamed to ratelimit:magic_link_issue: |

🤖 Generated with [Claude Code](https://claude.com/claude-code)